### PR TITLE
Add packageManager field to enforce pnpm usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "doll-wardrobe",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.28.2",
   "type": "module",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
Added `packageManager: "pnpm@10.28.2"` to package.json to enforce pnpm through Corepack. This prevents developers from accidentally using npm or yarn and ensures consistent tooling across the team.

## Test plan
- Verify pnpm install works correctly
- Verify typecheck passes
- Confirm lock file remains valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)