### PR TITLE
refactor: PR #27 レビュー対応

### DIFF
--- a/src/app/garments/page.tsx
+++ b/src/app/garments/page.tsx
@@ -41,6 +41,15 @@ const CATEGORY_FILTERS: readonly CategoryFilter[] = [
   })),
 ];
 
+const GARMENT_COMPARATORS = Object.freeze({
+  newest: (a: Garment, b: Garment) => b.createdAt - a.createdAt,
+  oldest: (a: Garment, b: Garment) => a.createdAt - b.createdAt,
+  confidence_asc: (a: Garment, b: Garment) =>
+    getConfidence(a) - getConfidence(b),
+  confidence_desc: (a: Garment, b: Garment) =>
+    getConfidence(b) - getConfidence(a),
+} satisfies Record<SortOptionValue, (a: Garment, b: Garment) => number>);
+
 const GarmentListContent = () => {
   const router = useRouter();
   const garments = useAtomValue(garmentsAtom);
@@ -69,17 +78,7 @@ const GarmentListContent = () => {
       return matchesCategory && matchesSearch && matchesConfidence;
     });
 
-    const comparators: Record<
-      SortOptionValue,
-      (a: Garment, b: Garment) => number
-    > = {
-      newest: (a, b) => b.createdAt - a.createdAt,
-      oldest: (a, b) => a.createdAt - b.createdAt,
-      confidence_asc: (a, b) => getConfidence(a) - getConfidence(b),
-      confidence_desc: (a, b) => getConfidence(b) - getConfidence(a),
-    };
-
-    return [...filtered].sort(comparators[sortOption]);
+    return [...filtered].sort(GARMENT_COMPARATORS[sortOption]);
   }, [garments, searchQuery, activeCategory, confidenceFilter, sortOption]);
 
   if (garments.length === 0) {

--- a/src/components/garment/GarmentCard.tsx
+++ b/src/components/garment/GarmentCard.tsx
@@ -2,9 +2,8 @@ import Link from "next/link";
 import { Shirt } from "lucide-react";
 import clsx from "clsx";
 import type { Garment } from "@/types";
-import { getConfidence, getConfidenceLabel } from "@/lib/confidence";
 import { GARMENT_CATEGORY_LABEL, DOLL_SIZE_LABEL } from "@/lib/constants";
-import ConfidenceBadge from "@/components/confidence/ConfidenceBadge";
+import ConfidenceIndicator from "@/components/confidence/ConfidenceIndicator";
 import Card from "@/components/ui/Card";
 
 type Props = {
@@ -12,8 +11,6 @@ type Props = {
 };
 
 const GarmentCard = ({ garment }: Props) => {
-  const confidence = getConfidence(garment);
-  const label = getConfidenceLabel(confidence);
   const isCheckedOut = garment.status === "checked_out";
 
   return (
@@ -48,7 +45,7 @@ const GarmentCard = ({ garment }: Props) => {
           {DOLL_SIZE_LABEL[garment.dollSize]}
         </p>
         <div className="mt-2">
-          <ConfidenceBadge label={label} />
+          <ConfidenceIndicator garment={garment} compact />
         </div>
       </Card>
     </Link>

--- a/src/components/garment/GarmentList.tsx
+++ b/src/components/garment/GarmentList.tsx
@@ -2,9 +2,8 @@ import Link from "next/link";
 import { Shirt } from "lucide-react";
 import clsx from "clsx";
 import type { Garment } from "@/types";
-import { getConfidence, getConfidenceLabel } from "@/lib/confidence";
 import { GARMENT_CATEGORY_LABEL, DOLL_SIZE_LABEL } from "@/lib/constants";
-import ConfidenceBadge from "@/components/confidence/ConfidenceBadge";
+import ConfidenceIndicator from "@/components/confidence/ConfidenceIndicator";
 
 type Props = {
   readonly garments: readonly Garment[];
@@ -12,48 +11,43 @@ type Props = {
 
 const GarmentList = ({ garments }: Props) => (
   <div className="flex flex-col gap-2">
-    {garments.map((garment, i) => {
-      const confidence = getConfidence(garment);
-      const label = getConfidenceLabel(confidence);
-
-      return (
-        <Link
-          key={garment.id}
-          href={`/garments/${garment.id}`}
-          className="animate-[slide-up_0.3s_ease-out_both]"
-          style={{ animationDelay: `${i * 30}ms` }}
+    {garments.map((garment, i) => (
+      <Link
+        key={garment.id}
+        href={`/garments/${garment.id}`}
+        className="animate-[slide-up_0.3s_ease-out_both]"
+        style={{ animationDelay: `${i * 30}ms` }}
+      >
+        <div
+          className={clsx(
+            "flex items-center gap-3 rounded-xl border border-border-default bg-surface-overlay p-3 shadow-card",
+            "transition-all hover:-translate-y-0.5 hover:shadow-md active:translate-y-0",
+          )}
         >
-          <div
-            className={clsx(
-              "flex items-center gap-3 rounded-xl border border-border-default bg-surface-overlay p-3 shadow-card",
-              "transition-all hover:-translate-y-0.5 hover:shadow-md active:translate-y-0",
+          <div className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-primary-50">
+            {garment.imageUrl !== undefined ? (
+              <img
+                src={garment.imageUrl}
+                alt={garment.name}
+                className="size-full object-cover"
+              />
+            ) : (
+              <Shirt className="size-6 text-primary-200" />
             )}
-          >
-            <div className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-primary-50">
-              {garment.imageUrl !== undefined ? (
-                <img
-                  src={garment.imageUrl}
-                  alt={garment.name}
-                  className="size-full object-cover"
-                />
-              ) : (
-                <Shirt className="size-6 text-primary-200" />
-              )}
-            </div>
-            <div className="flex-1 overflow-hidden">
-              <p className="truncate font-display text-sm font-bold">
-                {garment.name}
-              </p>
-              <p className="text-xs text-text-tertiary">
-                {GARMENT_CATEGORY_LABEL[garment.category]} ・{" "}
-                {DOLL_SIZE_LABEL[garment.dollSize]}
-              </p>
-            </div>
-            <ConfidenceBadge label={label} />
           </div>
-        </Link>
-      );
-    })}
+          <div className="flex-1 overflow-hidden">
+            <p className="truncate font-display text-sm font-bold">
+              {garment.name}
+            </p>
+            <p className="text-xs text-text-tertiary">
+              {GARMENT_CATEGORY_LABEL[garment.category]} ・{" "}
+              {DOLL_SIZE_LABEL[garment.dollSize]}
+            </p>
+          </div>
+          <ConfidenceIndicator garment={garment} compact />
+        </div>
+      </Link>
+    ))}
   </div>
 );
 


### PR DESCRIPTION
## Summary
- GarmentCard/GarmentList の信頼度計算ロジック重複を `<ConfidenceIndicator garment={garment} compact />` に置換
- `comparators` を `GARMENT_COMPARATORS` としてモジュールスコープに移動（`Object.freeze()` + `satisfies Record<...>` 適用）
- Comment #3（createdAt vs updatedAt）は意図的な設計選択としてコメント回答済み

Addresses review comments on #27

## Test plan
- [x] 型チェック（tsc-files）パス
- [x] Lint（oxlint + eslint）パス
- [x] 全テスト（27件）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)