### PR TITLE
fix: dev環境の起動失敗を修正

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,7 @@ const nextConfig: NextConfig = {
   },
   turbopack: {
     rules: {
-      "*.{js,jsx,ts,tsx}": {
+      "./src/{app,components,lib}/**/*.{js,jsx,ts,tsx}": {
         loaders: [
           {
             loader: path.resolve(

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -26,6 +26,9 @@ max_batch_size = 10
 [triggers]
 crons = ["0 9 * * 1"]
 
+[alias]
+"@shared/lib/constants" = "./src/lib/constants.ts"
+
 [vars]
 TRUSTED_ORIGINS = "http://localhost:3000"
 ALLOWED_ORIGINS = "http://localhost:3000"


### PR DESCRIPTION
## Summary

dev環境の`pnpm run dev`と`pnpm run dev:workers`の起動失敗を修正。

- **wrangler.toml**: `[alias]`セクション追加で`@shared/lib/constants`パスを解決
- **next.config.ts**: Turbopackローダールール限定（全ファイルから`src/{app,components,lib}`のみに変更）

以前はカスタムローダーが`src/instrumentation.ts`に適用され、InstrumentationEndpointパニックを引き起こしていた。

## Test plan

- [x] `pnpm run dev`正常起動確認
- [x] `pnpm run dev:workers`正常起動確認  
- [x] `pnpm precheck`全項目パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)