### PR TITLE
feat: dev環境起動失敗の再発防止策

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,20 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
+  build-workers:
+    name: Build Workers
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build:workers
+
   format-check:
     name: Format Check
     runs-on: ubuntu-latest

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,7 @@
 name = "doll-wardrobe-api"
 main = "workers/src/index.ts"
 compatibility_date = "2025-01-01"
+tsconfig = "tsconfig.workers.json"
 
 [[d1_databases]]
 binding = "DB"
@@ -25,9 +26,6 @@ max_batch_size = 10
 
 [triggers]
 crons = ["0 9 * * 1"]
-
-[alias]
-"@shared/lib/constants" = "./src/lib/constants.ts"
 
 [vars]
 TRUSTED_ORIGINS = "http://localhost:3000"


### PR DESCRIPTION
## 概要

PR #70 で修正された `pnpm dev` / `pnpm dev:workers` の起動失敗を再発防止するための対策。

## 変更内容

### 1. wrangler.toml: `tsconfig` キー追加 + `[alias]` 削除
- wrangler が `tsconfig.workers.json` のパスエイリアスを自動参照するように設定
- `@shared/lib/*` に新しいファイルが追加されても同期漏れが発生しない根本対策

### 2. CI に `build-workers` ジョブ追加
- PR時に `wrangler deploy --dry-run` でWorkers バンドルエラーを検出
- エイリアス未定義・インポートエラー・バンドルエラーを事前に検出可能に

## 検証済み

- `pnpm build:workers` 成功
- `pnpm precheck` 全項目パス

🤖 Generated with Claude Code