### PR TITLE
feat: Web NFC 型定義 & ケイパビリティ検出 (#56)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,7 @@ export default tseslint.config(
       "sentry.client.config.ts",
       "sentry.server.config.ts",
       "sentry.edge.config.ts",
+      "src/types/**/*.d.ts",
     ],
   },
   js.configs.recommended,

--- a/src/components/scan/NfcCapabilityBadge.test.tsx
+++ b/src/components/scan/NfcCapabilityBadge.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/testUtils";
+import NfcCapabilityBadge from "./NfcCapabilityBadge";
+
+const mockIsNfcSupported = vi.hoisted(() => vi.fn<() => boolean>());
+
+vi.mock("@/lib/nfc/capability", () => ({
+  isNfcSupported: mockIsNfcSupported,
+}));
+
+describe("NfcCapabilityBadge", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("NFC 対応時に「NFC 対応」と表示される", () => {
+    mockIsNfcSupported.mockReturnValue(true);
+    renderWithProviders(<NfcCapabilityBadge />);
+
+    expect(screen.getByText("NFC 対応")).toBeInTheDocument();
+  });
+
+  it("NFC 非対応時に「NFC 非対応」と表示される", () => {
+    mockIsNfcSupported.mockReturnValue(false);
+    renderWithProviders(<NfcCapabilityBadge />);
+
+    expect(screen.getByText("NFC 非対応")).toBeInTheDocument();
+  });
+});

--- a/src/components/scan/NfcCapabilityBadge.tsx
+++ b/src/components/scan/NfcCapabilityBadge.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import { Nfc } from "lucide-react";
+import Badge from "@/components/ui/Badge";
+import { isNfcSupported } from "@/lib/nfc/capability";
+
+const NfcCapabilityBadge = () => {
+  const supported = isNfcSupported();
+
+  return (
+    <Badge variant={supported ? "confirmed" : "default"}>
+      <Nfc className="size-3" />
+      {supported ? <Trans>NFC 対応</Trans> : <Trans>NFC 非対応</Trans>}
+    </Badge>
+  );
+};
+
+export default NfcCapabilityBadge;

--- a/src/lib/nfc/capability.test.ts
+++ b/src/lib/nfc/capability.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { isNfcSupported } from "./capability";
+
+describe("isNfcSupported", () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, "NDEFReader");
+  });
+
+  it("NDEFReader が存在する場合 true を返す", () => {
+    Object.defineProperty(window, "NDEFReader", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    expect(isNfcSupported()).toBe(true);
+  });
+
+  it("NDEFReader が存在しない場合 false を返す", () => {
+    Reflect.deleteProperty(globalThis, "NDEFReader");
+    expect(isNfcSupported()).toBe(false);
+  });
+});

--- a/src/lib/nfc/capability.ts
+++ b/src/lib/nfc/capability.ts
@@ -1,0 +1,2 @@
+export const isNfcSupported = (): boolean =>
+  typeof window !== "undefined" && "NDEFReader" in window;

--- a/src/types/web-nfc.d.ts
+++ b/src/types/web-nfc.d.ts
@@ -1,0 +1,65 @@
+type NDEFRecordInit = {
+  readonly recordType: string;
+  readonly mediaType?: string;
+  readonly id?: string;
+  readonly encoding?: string;
+  readonly lang?: string;
+  readonly data?: string | BufferSource;
+};
+
+type NDEFMessageInit = {
+  readonly records: readonly NDEFRecordInit[];
+};
+
+type NDEFRecord = {
+  readonly recordType: string;
+  readonly mediaType: string;
+  readonly id: string;
+  readonly encoding: string;
+  readonly lang: string;
+  readonly data: DataView | undefined;
+  toRecords(): readonly NDEFRecord[];
+};
+
+type NDEFMessage = {
+  readonly records: readonly NDEFRecord[];
+};
+
+interface NDEFReadingEvent extends Event {
+  readonly serialNumber: string;
+  readonly message: NDEFMessage;
+}
+
+type NDEFScanOptions = {
+  readonly signal?: AbortSignal;
+};
+
+type NDEFWriteOptions = {
+  readonly overwrite?: boolean;
+  readonly signal?: AbortSignal;
+};
+
+type NDEFMessageSource = string | BufferSource | NDEFMessageInit;
+
+declare global {
+  class NDEFReader extends EventTarget {
+    constructor();
+    scan(options?: NDEFScanOptions): Promise<void>;
+    write(
+      message: NDEFMessageSource,
+      options?: NDEFWriteOptions,
+    ): Promise<void>;
+    addEventListener(
+      type: "reading",
+      listener: (event: NDEFReadingEvent) => void,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+      type: "readingerror",
+      listener: (event: Event) => void,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary

- W3C Web NFC 仕様に基づく TypeScript グローバル型定義を追加（`NDEFReader`, `NDEFMessage`, `NDEFRecord`, `NDEFReadingEvent` 等）
- SSR セーフな NFC ケイパビリティ検出ユーティリティ `isNfcSupported()` を実装
- NFC 対応/非対応を表示する `NfcCapabilityBadge` コンポーネントを実装（既存 Badge 再利用、i18n 対応）
- `.d.ts` ファイルを ESLint ignores に追加（functional ルールとの競合回避）

## Test plan

- [x] `isNfcSupported()` のユニットテスト（window.NDEFReader の有無をモック）
- [x] `NfcCapabilityBadge` のレンダリングテスト（対応/非対応の表示切替）
- [x] `pnpm precheck` 全パス（型チェック + ESLint + フォーマット）

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)