### PR TITLE
refactor: DRY原則に従いフロント・バックエンドの重複コードを整理

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -162,6 +162,13 @@ export default tseslint.config(
     },
   },
   {
+    files: ["src/lib/generateLabel.ts"],
+    rules: {
+      "functional/no-conditional-statements": "off",
+      "functional/no-throw-statements": "off",
+    },
+  },
+  {
     files: ["src/lib/image/**/*.ts"],
     rules: {
       "functional/no-expression-statements": "off",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -24,6 +24,8 @@ export const CONFIDENCE_THRESHOLD = Object.freeze({
   UNCERTAIN: 0.3,
 });
 
+export const CONFIDENCE_DECAY_MIN = 1;
+export const CONFIDENCE_DECAY_MAX = 365;
 export const DEFAULT_CONFIDENCE_DECAY_DAYS = 30;
 export const SEASONAL_CONFIDENCE_DECAY_DAYS = 90;
 
@@ -55,6 +57,7 @@ export type StorageCaseType =
 
 export const STORAGE_CASE_TYPES: readonly StorageCaseType[] = ["grid", "unit"];
 
+export const GARMENT_NAME_MAX_LENGTH = 100;
 export const CASE_NAME_MAX_LENGTH = 100;
 export const CASE_DESCRIPTION_MAX_LENGTH = 200;
 export const LOCATION_CUSTOM_NAME_MAX_LENGTH = 50;
@@ -63,6 +66,7 @@ export const GARMENT_DESCRIPTION_MAX_LENGTH = 500;
 export const GARMENT_SET_CONTENTS_MAX_LENGTH = 500;
 export const DOLL_NAME_MAX_LENGTH = 100;
 export const DOLL_MEMO_MAX_LENGTH = 500;
+export const MAX_LABEL_LENGTH = 20;
 export const GRID_SIZE_MIN = 1;
 export const GRID_SIZE_MAX = 20;
 

--- a/src/lib/generateLabel.test.ts
+++ b/src/lib/generateLabel.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { generateLabel } from "./generateLabel";
+
+describe("generateLabel", () => {
+  it("row=0, col=0 のとき A-1 を返す", () => {
+    expect(generateLabel({ row: 0, col: 0 })).toBe("A-1");
+  });
+
+  it("row=0, col=2 のとき A-3 を返す", () => {
+    expect(generateLabel({ row: 0, col: 2 })).toBe("A-3");
+  });
+
+  it("row=1, col=0 のとき B-1 を返す", () => {
+    expect(generateLabel({ row: 1, col: 0 })).toBe("B-1");
+  });
+
+  it("row=2, col=4 のとき C-5 を返す", () => {
+    expect(generateLabel({ row: 2, col: 4 })).toBe("C-5");
+  });
+
+  it("row=25, col=0 のとき Z-1 を返す", () => {
+    expect(generateLabel({ row: 25, col: 0 })).toBe("Z-1");
+  });
+
+  it("row=26 のとき例外をスローする", () => {
+    expect(() => generateLabel({ row: 26, col: 0 })).toThrow();
+  });
+});

--- a/src/lib/generateLabel.ts
+++ b/src/lib/generateLabel.ts
@@ -8,10 +8,8 @@ export const generateLabel = ({
   readonly row: number;
   readonly col: number;
 }): string => {
-  /* eslint-disable functional/no-conditional-statements, functional/no-throw-statements -- row boundary validation shared with workers */
   if (row >= MAX_LABEL_ROWS) {
     throw new Error(`row must be less than ${MAX_LABEL_ROWS}, got ${row}`);
   }
-  /* eslint-enable functional/no-conditional-statements, functional/no-throw-statements */
   return `${String.fromCharCode(ASCII_UPPER_A + row)}-${col + 1}`;
 };

--- a/src/lib/generateLabel.ts
+++ b/src/lib/generateLabel.ts
@@ -1,4 +1,5 @@
 const ASCII_UPPER_A = 65;
+const MAX_LABEL_ROWS = 26;
 
 export const generateLabel = ({
   row,
@@ -6,4 +7,11 @@ export const generateLabel = ({
 }: {
   readonly row: number;
   readonly col: number;
-}): string => `${String.fromCharCode(ASCII_UPPER_A + row)}-${col + 1}`;
+}): string => {
+  /* eslint-disable functional/no-conditional-statements, functional/no-throw-statements -- row boundary validation shared with workers */
+  if (row >= MAX_LABEL_ROWS) {
+    throw new Error(`row must be less than ${MAX_LABEL_ROWS}, got ${row}`);
+  }
+  /* eslint-enable functional/no-conditional-statements, functional/no-throw-statements */
+  return `${String.fromCharCode(ASCII_UPPER_A + row)}-${col + 1}`;
+};

--- a/src/stores/createEntityAtoms.ts
+++ b/src/stores/createEntityAtoms.ts
@@ -1,0 +1,93 @@
+import type Dexie from "dexie";
+import { atom } from "jotai";
+import type { Atom, WritableAtom } from "jotai";
+import { getDb } from "@/lib/db/dexie";
+
+type SyncActionTypes = {
+  readonly create: string;
+  readonly update: string;
+  readonly delete: string;
+};
+
+type EntityAtoms<T> = {
+  readonly dataAtom: Atom<Promise<T[]>>;
+  readonly refreshAtom: WritableAtom<undefined, [], void>;
+  readonly addAtom: WritableAtom<undefined, [T], Promise<void>>;
+  readonly updateAtom: WritableAtom<undefined, [T], Promise<void>>;
+  readonly deleteAtom: WritableAtom<undefined, [string], Promise<void>>;
+};
+
+export const createEntityAtoms = <T>(
+  getTable: () => Dexie.Table<T, string>,
+  syncActionTypes: SyncActionTypes,
+): EntityAtoms<T> => {
+  const refreshTriggerAtom = atom(0);
+
+  const dataAtom = atom(async (get) =>
+    typeof indexedDB === "undefined"
+      ? ([] satisfies T[] as T[])
+      : (get(refreshTriggerAtom), await getTable().toArray()),
+  );
+
+  const refreshAtom = atom(undefined, (_get, set) => {
+    set(refreshTriggerAtom, (prev) => prev + 1);
+  });
+
+  const addAtom = atom(undefined, async (_get, set, item: T) => {
+    await getTable().add(item);
+    await getDb().syncQueue.add({
+      type: syncActionTypes.create,
+      payload: item,
+      createdAt: Date.now(),
+    });
+    set(refreshAtom);
+  });
+
+  const updateAtom = atom(undefined, async (_get, set, item: T) => {
+    await getTable().put(item);
+    await getDb().syncQueue.add({
+      type: syncActionTypes.update,
+      payload: item,
+      createdAt: Date.now(),
+    });
+    set(refreshAtom);
+  });
+
+  const deleteAtom = atom(undefined, async (_get, set, id: string) => {
+    await getTable().delete(id);
+    await getDb().syncQueue.add({
+      type: syncActionTypes.delete,
+      payload: { id },
+      createdAt: Date.now(),
+    });
+    set(refreshAtom);
+  });
+
+  return { dataAtom, refreshAtom, addAtom, updateAtom, deleteAtom };
+};
+
+export const createRestoreAtom = (
+  getTable: () => Dexie.Table<
+    {
+      readonly id: string;
+      readonly archivedAt: number | undefined;
+      readonly updatedAt: number;
+    },
+    string
+  >,
+  refreshAtom: WritableAtom<undefined, [], void>,
+  syncUpdateType: string,
+) =>
+  atom(undefined, async (_get, set, id: string) => {
+    const now = Date.now();
+    await getTable().update(id, { archivedAt: undefined, updatedAt: now });
+    const updated = await getTable().get(id);
+    await (updated === undefined
+      ? Promise.resolve()
+      : getDb().syncQueue.add({
+          type: syncUpdateType,
+          payload: updated,
+          createdAt: now,
+        }));
+    set(refreshAtom);
+  });

--- a/src/stores/createEntityAtoms.ts
+++ b/src/stores/createEntityAtoms.ts
@@ -66,15 +66,14 @@ export const createEntityAtoms = <T>(
   return { dataAtom, refreshAtom, addAtom, updateAtom, deleteAtom };
 };
 
+type Restorable = {
+  readonly id: string;
+  readonly archivedAt: number | undefined;
+  readonly updatedAt: number;
+};
+
 export const createRestoreAtom = (
-  getTable: () => Dexie.Table<
-    {
-      readonly id: string;
-      readonly archivedAt: number | undefined;
-      readonly updatedAt: number;
-    },
-    string
-  >,
+  getTable: () => Dexie.Table<Restorable, string>,
   refreshAtom: WritableAtom<undefined, [], void>,
   syncUpdateType: string,
 ) =>

--- a/src/stores/dollAtoms.ts
+++ b/src/stores/dollAtoms.ts
@@ -2,64 +2,32 @@ import { atom } from "jotai";
 import { getDb } from "@/lib/db/dexie";
 import { SYNC_ACTION_TYPE } from "@/lib/constants";
 import type { Doll } from "@/types";
+import { createEntityAtoms, createRestoreAtom } from "./createEntityAtoms";
 
-const dollsRefreshTriggerAtom = atom(0);
-
-export const dollsAtom = atom(async (get) =>
-  typeof indexedDB === "undefined"
-    ? ([] satisfies Doll[])
-    : (get(dollsRefreshTriggerAtom), await getDb().dolls.toArray()),
-);
-
-export const refreshDollsAtom = atom(undefined, (_get, set) => {
-  set(dollsRefreshTriggerAtom, (prev) => prev + 1);
+const {
+  dataAtom: dollsAtom,
+  refreshAtom: refreshDollsAtom,
+  addAtom: addDollAtom,
+  updateAtom: updateDollAtom,
+  deleteAtom: deleteDollAtom,
+} = createEntityAtoms<Doll>(() => getDb().dolls, {
+  create: SYNC_ACTION_TYPE.DOLL_CREATE,
+  update: SYNC_ACTION_TYPE.DOLL_UPDATE,
+  delete: SYNC_ACTION_TYPE.DOLL_DELETE,
 });
 
-export const addDollAtom = atom(undefined, async (_get, set, doll: Doll) => {
-  await getDb().dolls.add(doll);
-  await getDb().syncQueue.add({
-    type: SYNC_ACTION_TYPE.DOLL_CREATE,
-    payload: doll,
-    createdAt: Date.now(),
-  });
-  set(refreshDollsAtom);
-});
+export {
+  dollsAtom,
+  refreshDollsAtom,
+  addDollAtom,
+  updateDollAtom,
+  deleteDollAtom,
+};
 
-export const updateDollAtom = atom(undefined, async (_get, set, doll: Doll) => {
-  await getDb().dolls.put(doll);
-  await getDb().syncQueue.add({
-    type: SYNC_ACTION_TYPE.DOLL_UPDATE,
-    payload: doll,
-    createdAt: Date.now(),
-  });
-  set(refreshDollsAtom);
-});
-
-export const deleteDollAtom = atom(undefined, async (_get, set, id: string) => {
-  await getDb().dolls.delete(id);
-  await getDb().syncQueue.add({
-    type: SYNC_ACTION_TYPE.DOLL_DELETE,
-    payload: { id },
-    createdAt: Date.now(),
-  });
-  set(refreshDollsAtom);
-});
-
-export const restoreDollAtom = atom(
-  undefined,
-  async (_get, set, id: string) => {
-    const now = Date.now();
-    await getDb().dolls.update(id, { archivedAt: undefined, updatedAt: now });
-    const updated = await getDb().dolls.get(id);
-    await (updated === undefined
-      ? Promise.resolve()
-      : getDb().syncQueue.add({
-          type: SYNC_ACTION_TYPE.DOLL_UPDATE,
-          payload: updated,
-          createdAt: now,
-        }));
-    set(refreshDollsAtom);
-  },
+export const restoreDollAtom = createRestoreAtom(
+  () => getDb().dolls,
+  refreshDollsAtom,
+  SYNC_ACTION_TYPE.DOLL_UPDATE,
 );
 
 export const selectedDollIdAtom = atom<string | undefined>(undefined);

--- a/src/stores/garmentAtoms.ts
+++ b/src/stores/garmentAtoms.ts
@@ -2,81 +2,37 @@ import { atom } from "jotai";
 import { getDb } from "@/lib/db/dexie";
 import { GARMENT_STATUS, SYNC_ACTION_TYPE } from "@/lib/constants";
 import type { Garment, ScanConfirmation } from "@/types";
+import { createEntityAtoms, createRestoreAtom } from "./createEntityAtoms";
 
-const garmentsRefreshTriggerAtom = atom(0);
-
-export const garmentsAtom = atom(async (get) =>
-  typeof indexedDB === "undefined"
-    ? ([] satisfies Garment[])
-    : (get(garmentsRefreshTriggerAtom), await getDb().garments.toArray()),
-);
-
-export const refreshGarmentsAtom = atom(undefined, (_get, set) => {
-  set(garmentsRefreshTriggerAtom, (prev) => prev + 1);
+const {
+  dataAtom: garmentsAtom,
+  refreshAtom: refreshGarmentsAtom,
+  addAtom: addGarmentAtom,
+  updateAtom: updateGarmentAtom,
+  deleteAtom: deleteGarmentAtom,
+} = createEntityAtoms<Garment>(() => getDb().garments, {
+  create: SYNC_ACTION_TYPE.GARMENT_CREATE,
+  update: SYNC_ACTION_TYPE.GARMENT_UPDATE,
+  delete: SYNC_ACTION_TYPE.GARMENT_DELETE,
 });
+
+export {
+  garmentsAtom,
+  refreshGarmentsAtom,
+  addGarmentAtom,
+  updateGarmentAtom,
+  deleteGarmentAtom,
+};
 
 export const activeGarmentsAtom = atom(async (get) => {
   const garments = await get(garmentsAtom);
   return garments.filter((g) => g.archivedAt === undefined);
 });
 
-export const addGarmentAtom = atom(
-  undefined,
-  async (_get, set, garment: Garment) => {
-    await getDb().garments.add(garment);
-    await getDb().syncQueue.add({
-      type: SYNC_ACTION_TYPE.GARMENT_CREATE,
-      payload: garment,
-      createdAt: Date.now(),
-    });
-    set(refreshGarmentsAtom);
-  },
-);
-
-export const updateGarmentAtom = atom(
-  undefined,
-  async (_get, set, garment: Garment) => {
-    await getDb().garments.put(garment);
-    await getDb().syncQueue.add({
-      type: SYNC_ACTION_TYPE.GARMENT_UPDATE,
-      payload: garment,
-      createdAt: Date.now(),
-    });
-    set(refreshGarmentsAtom);
-  },
-);
-
-export const deleteGarmentAtom = atom(
-  undefined,
-  async (_get, set, id: string) => {
-    await getDb().garments.delete(id);
-    await getDb().syncQueue.add({
-      type: SYNC_ACTION_TYPE.GARMENT_DELETE,
-      payload: { id },
-      createdAt: Date.now(),
-    });
-    set(refreshGarmentsAtom);
-  },
-);
-
-export const restoreGarmentAtom = atom(
-  undefined,
-  async (_get, set, id: string) => {
-    const now = Date.now();
-    await getDb().garments.update(id, {
-      archivedAt: undefined,
-      updatedAt: now,
-    });
-    const updated = await getDb().garments.get(id);
-    await (updated === undefined
-      ? Promise.resolve()
-      : getDb().syncQueue.add({
-          type: SYNC_ACTION_TYPE.GARMENT_UPDATE,
-          payload: updated,
-          createdAt: now,
-        }));
-    set(refreshGarmentsAtom);
-  },
+export const restoreGarmentAtom = createRestoreAtom(
+  () => getDb().garments,
+  refreshGarmentsAtom,
+  SYNC_ACTION_TYPE.GARMENT_UPDATE,
 );
 
 export const confirmAllGarmentsAtom = atom(

--- a/tsconfig.workers.json
+++ b/tsconfig.workers.json
@@ -20,7 +20,8 @@
     "workers/**/*.ts",
     "src/types/**/*.ts",
     "src/lib/confidence.ts",
-    "src/lib/constants.ts"
+    "src/lib/constants.ts",
+    "src/lib/generateLabel.ts"
   ],
   "exclude": ["node_modules", "workers/**/*.test.ts", "workers/test/**"]
 }

--- a/workers/src/db/validation.ts
+++ b/workers/src/db/validation.ts
@@ -5,6 +5,19 @@ import {
   DOLL_SIZES,
   GARMENT_STATUSES,
   STORAGE_CASE_TYPES,
+  GARMENT_NAME_MAX_LENGTH,
+  CONFIDENCE_DECAY_MIN,
+  CONFIDENCE_DECAY_MAX,
+  DEFAULT_CONFIDENCE_DECAY_DAYS,
+  CASE_NAME_MAX_LENGTH,
+  DOLL_NAME_MAX_LENGTH,
+  MAX_LABEL_LENGTH,
+  DOLL_MEMO_MAX_LENGTH,
+  GRID_SIZE_MAX,
+  GRID_SIZE_MIN,
+  CASE_DESCRIPTION_MAX_LENGTH,
+  LOCATION_CUSTOM_NAME_MAX_LENGTH,
+  LOCATION_DESCRIPTION_MAX_LENGTH,
 } from "@shared/lib/constants";
 import {
   garments,
@@ -14,19 +27,6 @@ import {
   digests,
   dolls,
 } from "./schema";
-
-const GARMENT_NAME_MAX_LENGTH = 100;
-const CONFIDENCE_DECAY_MIN = 1;
-const CONFIDENCE_DECAY_MAX = 365;
-const DEFAULT_CONFIDENCE_DECAY_DAYS = 30;
-const MAX_NAME_LENGTH = 100;
-const MAX_LABEL_LENGTH = 20;
-const DOLL_MEMO_MAX_LENGTH = 500;
-const MAX_GRID_SIZE = 20;
-const MIN_GRID_SIZE = 1;
-const MAX_CASE_DESCRIPTION_LENGTH = 200;
-const MAX_LOCATION_CUSTOM_NAME_LENGTH = 50;
-const MAX_LOCATION_DESCRIPTION_LENGTH = 200;
 
 const toNonEmptyTuple = <T extends string>(arr: readonly T[]): [T, ...T[]] => {
   const [first, ...rest] = arr;
@@ -67,9 +67,9 @@ export const garmentInsertSchema = createInsertSchema(garments, {
 });
 
 export const storageCaseInsertSchema = createInsertSchema(storageCases, {
-  name: z.string().min(1).max(MAX_NAME_LENGTH),
-  rows: z.number().int().min(MIN_GRID_SIZE).max(MAX_GRID_SIZE),
-  cols: z.number().int().min(MIN_GRID_SIZE).max(MAX_GRID_SIZE),
+  name: z.string().min(1).max(CASE_NAME_MAX_LENGTH),
+  rows: z.number().int().min(GRID_SIZE_MIN).max(GRID_SIZE_MAX),
+  cols: z.number().int().min(GRID_SIZE_MIN).max(GRID_SIZE_MAX),
 });
 
 export const storageLocationInsertSchema = createInsertSchema(
@@ -177,7 +177,7 @@ export const dollSelectSchema = createSelectSchema(dolls, {
 });
 
 export const dollInsertSchema = createInsertSchema(dolls, {
-  name: z.string().min(1).max(MAX_NAME_LENGTH),
+  name: z.string().min(1).max(DOLL_NAME_MAX_LENGTH),
   bodySize: dollSizeSchema,
 });
 
@@ -189,9 +189,9 @@ export const createDollInputSchema = dollInsertSchema
     updatedAt: true,
   })
   .extend({
-    headModel: z.string().max(MAX_NAME_LENGTH).optional(),
-    maker: z.string().max(MAX_NAME_LENGTH).optional(),
-    customizer: z.string().max(MAX_NAME_LENGTH).optional(),
+    headModel: z.string().max(DOLL_NAME_MAX_LENGTH).optional(),
+    maker: z.string().max(DOLL_NAME_MAX_LENGTH).optional(),
+    customizer: z.string().max(DOLL_NAME_MAX_LENGTH).optional(),
     imageUrl: z.url().optional(),
     memo: z.string().max(DOLL_MEMO_MAX_LENGTH).optional(),
   });
@@ -199,11 +199,11 @@ export type CreateDollInput = z.infer<typeof createDollInputSchema>;
 
 export const updateDollInputSchema = z.object({
   id: cuidSchema,
-  name: z.string().min(1).max(MAX_NAME_LENGTH).optional(),
-  headModel: z.string().max(MAX_NAME_LENGTH).optional(),
+  name: z.string().min(1).max(DOLL_NAME_MAX_LENGTH).optional(),
+  headModel: z.string().max(DOLL_NAME_MAX_LENGTH).optional(),
   bodySize: dollSizeSchema.optional(),
-  maker: z.string().max(MAX_NAME_LENGTH).optional(),
-  customizer: z.string().max(MAX_NAME_LENGTH).optional(),
+  maker: z.string().max(DOLL_NAME_MAX_LENGTH).optional(),
+  customizer: z.string().max(DOLL_NAME_MAX_LENGTH).optional(),
   imageUrl: z.url().optional(),
   memo: z.string().max(DOLL_MEMO_MAX_LENGTH).optional(),
 });
@@ -215,21 +215,21 @@ export const listDollsInputSchema = z.object({
 
 const caseDescriptionSchema = z
   .string()
-  .max(MAX_CASE_DESCRIPTION_LENGTH)
+  .max(CASE_DESCRIPTION_MAX_LENGTH)
   .optional()
   .transform((v) => v ?? undefined);
 
 export const createCaseInputSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("grid"),
-    name: z.string().min(1).max(MAX_NAME_LENGTH),
+    name: z.string().min(1).max(CASE_NAME_MAX_LENGTH),
     description: caseDescriptionSchema,
-    rows: z.number().int().min(MIN_GRID_SIZE).max(MAX_GRID_SIZE),
-    cols: z.number().int().min(MIN_GRID_SIZE).max(MAX_GRID_SIZE),
+    rows: z.number().int().min(GRID_SIZE_MIN).max(GRID_SIZE_MAX),
+    cols: z.number().int().min(GRID_SIZE_MIN).max(GRID_SIZE_MAX),
   }),
   z.object({
     type: z.literal("unit"),
-    name: z.string().min(1).max(MAX_NAME_LENGTH),
+    name: z.string().min(1).max(CASE_NAME_MAX_LENGTH),
     description: caseDescriptionSchema,
   }),
 ]);
@@ -237,7 +237,7 @@ export type CreateCaseInput = z.infer<typeof createCaseInputSchema>;
 
 export const updateCaseInputSchema = z.object({
   id: cuidSchema,
-  name: z.string().min(1).max(MAX_NAME_LENGTH),
+  name: z.string().min(1).max(CASE_NAME_MAX_LENGTH),
   description: caseDescriptionSchema,
 });
 
@@ -245,12 +245,12 @@ export const updateLocationInputSchema = z.object({
   id: cuidSchema,
   customName: z
     .string()
-    .max(MAX_LOCATION_CUSTOM_NAME_LENGTH)
+    .max(LOCATION_CUSTOM_NAME_MAX_LENGTH)
     .optional()
     .transform((v) => v ?? undefined),
   description: z
     .string()
-    .max(MAX_LOCATION_DESCRIPTION_LENGTH)
+    .max(LOCATION_DESCRIPTION_MAX_LENGTH)
     .optional()
     .transform((v) => v ?? undefined),
 });

--- a/workers/src/db/validation.ts
+++ b/workers/src/db/validation.ts
@@ -27,14 +27,7 @@ import {
   digests,
   dolls,
 } from "./schema";
-
-const toNonEmptyTuple = <T extends string>(arr: readonly T[]): [T, ...T[]] => {
-  const [first, ...rest] = arr;
-  if (first === undefined) {
-    throw new Error("Array must not be empty");
-  }
-  return [first, ...rest];
-};
+import { toNonEmptyTuple } from "../lib/to-non-empty-tuple";
 
 export const cuidSchema = z.string().min(1);
 export const storageCaseTypeSchema = z.enum(

--- a/workers/src/lib/to-non-empty-tuple.ts
+++ b/workers/src/lib/to-non-empty-tuple.ts
@@ -1,0 +1,9 @@
+export const toNonEmptyTuple = <T extends string>(
+  arr: readonly T[],
+): [T, ...T[]] => {
+  const [first, ...rest] = arr;
+  if (first === undefined) {
+    throw new Error("Array must not be empty");
+  }
+  return [first, ...rest];
+};

--- a/workers/src/repositories/build-set-object.ts
+++ b/workers/src/repositories/build-set-object.ts
@@ -4,7 +4,7 @@ export const buildSetObject = <T extends Record<string, unknown>>({
 }: {
   readonly fields: T;
   readonly keys: ReadonlyArray<keyof T & string>;
-}): Record<string, unknown> => {
+}): Record<string, T[keyof T & string]> => {
   const entries = keys.flatMap((key) => {
     const value = fields[key];
     return value === undefined ? [] : ([[key, value]] as const);

--- a/workers/src/repositories/build-set-object.ts
+++ b/workers/src/repositories/build-set-object.ts
@@ -1,0 +1,13 @@
+export const buildSetObject = <T extends Record<string, unknown>>({
+  fields,
+  keys,
+}: {
+  readonly fields: T;
+  readonly keys: ReadonlyArray<keyof T & string>;
+}): Record<string, unknown> => {
+  const entries = keys.flatMap((key) => {
+    const value = fields[key];
+    return value === undefined ? [] : ([[key, value]] as const);
+  });
+  return Object.fromEntries(entries);
+};

--- a/workers/src/repositories/doll-repository.ts
+++ b/workers/src/repositories/doll-repository.ts
@@ -6,6 +6,7 @@ import type { Logger } from "../lib/logger";
 import type { DrizzleDB } from "../db/client";
 import { dolls } from "../db/schema";
 import { wrapDbError } from "../trpc/lib/d1-helpers";
+import { buildSetObject } from "./build-set-object";
 
 type DollSelectRow = typeof dolls.$inferSelect;
 
@@ -128,18 +129,8 @@ const UPDATABLE_FIELD_KEYS = [
   "memo",
 ] as const;
 
-const buildSetObject = (
-  fields: DollUpdatableFields,
-): Record<string, string> => {
-  const entries = UPDATABLE_FIELD_KEYS.flatMap((key) => {
-    const value = fields[key];
-    if (value === undefined) {
-      return [];
-    }
-    return [[key, value]] as const;
-  });
-  return Object.fromEntries(entries);
-};
+const buildDollSetObject = (fields: DollUpdatableFields) =>
+  buildSetObject({ fields, keys: UPDATABLE_FIELD_KEYS });
 
 export const updateDollFields = async ({
   drizzleDb,
@@ -155,7 +146,7 @@ export const updateDollFields = async ({
   readonly logger: Logger;
 }): Promise<Doll | undefined> => {
   const setObject = {
-    ...buildSetObject(fields),
+    ...buildDollSetObject(fields),
     updatedAt: Date.now(),
   };
 

--- a/workers/src/repositories/garment-repository.ts
+++ b/workers/src/repositories/garment-repository.ts
@@ -15,6 +15,7 @@ import type { Logger } from "../lib/logger";
 import type { DrizzleDB } from "../db/client";
 import { garments } from "../db/schema";
 import { wrapDbError } from "../trpc/lib/d1-helpers";
+import { buildSetObject } from "./build-set-object";
 
 type GarmentSelectRow = typeof garments.$inferSelect;
 
@@ -218,18 +219,8 @@ const UPDATABLE_FIELD_KEYS = [
   "confidenceDecayDays",
 ] as const;
 
-const buildSetObject = (
-  fields: GarmentUpdatableFields,
-): Record<string, string | number | readonly string[]> => {
-  const entries = UPDATABLE_FIELD_KEYS.flatMap((key) => {
-    const value = fields[key];
-    if (value === undefined) {
-      return [];
-    }
-    return [[key, value]] as const;
-  });
-  return Object.fromEntries(entries);
-};
+const buildGarmentSetObject = (fields: GarmentUpdatableFields) =>
+  buildSetObject({ fields, keys: UPDATABLE_FIELD_KEYS });
 
 export const updateGarmentFields = async ({
   drizzleDb,
@@ -245,7 +236,7 @@ export const updateGarmentFields = async ({
   readonly logger: Logger;
 }): Promise<Garment | undefined> => {
   const setObject = {
-    ...buildSetObject(fields),
+    ...buildGarmentSetObject(fields),
     updatedAt: Date.now(),
   };
 

--- a/workers/src/repositories/location-repository.ts
+++ b/workers/src/repositories/location-repository.ts
@@ -3,7 +3,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import type { DrizzleDB } from "../db/client";
 import { garments, storageCases, storageLocations } from "../db/schema";
-import { generateLabel } from "../trpc/lib/d1-helpers";
+import { generateLabel } from "@shared/lib/generateLabel";
 
 const CASE_TYPE_MAP: Record<string, StorageCaseType> = {
   grid: "grid",

--- a/workers/src/services/delete-with-image-cleanup.ts
+++ b/workers/src/services/delete-with-image-cleanup.ts
@@ -1,0 +1,69 @@
+import type { R2Bucket } from "@cloudflare/workers-types";
+import type { Logger } from "../lib/logger";
+import * as imageService from "./image-service";
+import { type ServiceResult, serviceError, serviceOk } from "./types";
+
+type EntityFinders<T> = {
+  readonly findById: () => Promise<T | undefined>;
+  readonly deleteById: () => Promise<number>;
+};
+
+type ImageCleanupContext = {
+  readonly entityName: string;
+  readonly entityId: string;
+  readonly bucket: R2Bucket;
+  readonly r2PublicUrl: string;
+  readonly logger: Logger;
+};
+
+export const deleteEntityWithImageCleanup = async <
+  T extends { readonly imageUrl?: string },
+>({
+  finders,
+  context,
+}: {
+  readonly finders: EntityFinders<T>;
+  readonly context: ImageCleanupContext;
+}): Promise<ServiceResult<{ readonly success: true }>> => {
+  const entity = await finders.findById();
+  if (entity === undefined) {
+    return serviceError(
+      "NOT_FOUND",
+      `${context.entityName} not found: ${context.entityId}`,
+    );
+  }
+
+  const changes = await finders.deleteById();
+  if (changes === 0) {
+    return serviceError(
+      "NOT_FOUND",
+      `${context.entityName} not found: ${context.entityId}`,
+    );
+  }
+
+  if (entity.imageUrl !== undefined) {
+    const r2Key = imageService.extractR2KeyFromUrl({
+      r2PublicUrl: context.r2PublicUrl,
+      imageUrl: entity.imageUrl,
+    });
+    if (r2Key !== undefined) {
+      const deleteResult = await imageService.deleteImage({
+        bucket: context.bucket,
+        key: r2Key,
+        logger: context.logger,
+      });
+      if (!deleteResult.ok) {
+        context.logger.warn(
+          `R2 image cleanup failed after ${context.entityName} deletion`,
+          {
+            [`${context.entityName}Id`]: context.entityId,
+            r2Key,
+            error: deleteResult.error.message,
+          },
+        );
+      }
+    }
+  }
+
+  return serviceOk({ success: true });
+};

--- a/workers/src/services/delete-with-image-cleanup.ts
+++ b/workers/src/services/delete-with-image-cleanup.ts
@@ -8,8 +8,10 @@ type EntityFinders<T> = {
   readonly deleteById: () => Promise<number>;
 };
 
+type DeletableEntityName = "Garment" | "Doll";
+
 type ImageCleanupContext = {
-  readonly entityName: string;
+  readonly entityName: DeletableEntityName;
   readonly entityId: string;
   readonly bucket: R2Bucket;
   readonly r2PublicUrl: string;

--- a/workers/src/services/doll-service.ts
+++ b/workers/src/services/doll-service.ts
@@ -4,7 +4,7 @@ import { createId } from "@paralleldrive/cuid2";
 import type { Logger } from "../lib/logger";
 import type { DrizzleDB } from "../db/client";
 import * as dollRepo from "../repositories/doll-repository";
-import * as imageService from "./image-service";
+import { deleteEntityWithImageCleanup } from "./delete-with-image-cleanup";
 import { type ServiceResult, serviceError, serviceOk } from "./types";
 
 export const listDolls = async ({
@@ -161,47 +161,13 @@ export const deleteDoll = async ({
   readonly bucket: R2Bucket;
   readonly r2PublicUrl: string;
   readonly logger: Logger;
-}): Promise<ServiceResult<{ readonly success: true }>> => {
-  const doll = await dollRepo.findDollById({
-    drizzleDb,
-    id,
-    userId,
-    logger,
+}): Promise<ServiceResult<{ readonly success: true }>> =>
+  await deleteEntityWithImageCleanup({
+    finders: {
+      findById: async () =>
+        await dollRepo.findDollById({ drizzleDb, id, userId, logger }),
+      deleteById: async () =>
+        await dollRepo.deleteDollById({ drizzleDb, id, userId, logger }),
+    },
+    context: { entityName: "Doll", entityId: id, bucket, r2PublicUrl, logger },
   });
-  if (doll === undefined) {
-    return serviceError("NOT_FOUND", `Doll not found: ${id}`);
-  }
-
-  const changes = await dollRepo.deleteDollById({
-    drizzleDb,
-    id,
-    userId,
-    logger,
-  });
-  if (changes === 0) {
-    return serviceError("NOT_FOUND", `Doll not found: ${id}`);
-  }
-
-  if (doll.imageUrl !== undefined) {
-    const r2Key = imageService.extractR2KeyFromUrl({
-      r2PublicUrl,
-      imageUrl: doll.imageUrl,
-    });
-    if (r2Key !== undefined) {
-      const deleteResult = await imageService.deleteImage({
-        bucket,
-        key: r2Key,
-        logger,
-      });
-      if (!deleteResult.ok) {
-        logger.warn("R2 image cleanup failed after doll deletion", {
-          dollId: id,
-          r2Key,
-          error: deleteResult.error.message,
-        });
-      }
-    }
-  }
-
-  return serviceOk({ success: true });
-};

--- a/workers/src/services/garment-service.ts
+++ b/workers/src/services/garment-service.ts
@@ -5,7 +5,7 @@ import { GARMENT_STATUS } from "@shared/lib/constants";
 import type { Logger } from "../lib/logger";
 import type { DrizzleDB } from "../db/client";
 import * as garmentRepo from "../repositories/garment-repository";
-import * as imageService from "./image-service";
+import { deleteEntityWithImageCleanup } from "./delete-with-image-cleanup";
 import { type ServiceResult, serviceError, serviceOk } from "./types";
 
 export const listGarments = async ({
@@ -240,47 +240,19 @@ export const deleteGarment = async ({
   readonly bucket: R2Bucket;
   readonly r2PublicUrl: string;
   readonly logger: Logger;
-}): Promise<ServiceResult<{ readonly success: true }>> => {
-  const garment = await garmentRepo.findGarmentById({
-    drizzleDb,
-    id,
-    userId,
-    logger,
-  });
-  if (garment === undefined) {
-    return serviceError("NOT_FOUND", `Garment not found: ${id}`);
-  }
-
-  const changes = await garmentRepo.deleteGarmentById({
-    drizzleDb,
-    id,
-    userId,
-    logger,
-  });
-  if (changes === 0) {
-    return serviceError("NOT_FOUND", `Garment not found: ${id}`);
-  }
-
-  if (garment.imageUrl !== undefined) {
-    const r2Key = imageService.extractR2KeyFromUrl({
+}): Promise<ServiceResult<{ readonly success: true }>> =>
+  await deleteEntityWithImageCleanup({
+    finders: {
+      findById: async () =>
+        await garmentRepo.findGarmentById({ drizzleDb, id, userId, logger }),
+      deleteById: async () =>
+        await garmentRepo.deleteGarmentById({ drizzleDb, id, userId, logger }),
+    },
+    context: {
+      entityName: "Garment",
+      entityId: id,
+      bucket,
       r2PublicUrl,
-      imageUrl: garment.imageUrl,
-    });
-    if (r2Key !== undefined) {
-      const deleteResult = await imageService.deleteImage({
-        bucket,
-        key: r2Key,
-        logger,
-      });
-      if (!deleteResult.ok) {
-        logger.warn("R2 image cleanup failed after garment deletion", {
-          garmentId: id,
-          r2Key,
-          error: deleteResult.error.message,
-        });
-      }
-    }
-  }
-
-  return serviceOk({ success: true });
-};
+      logger,
+    },
+  });

--- a/workers/src/trpc/lib/d1-helpers.test.ts
+++ b/workers/src/trpc/lib/d1-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { TRPCError } from "@trpc/server";
-import { wrapDbError, generateLabel } from "./d1-helpers";
+import { wrapDbError } from "./d1-helpers";
 import { createLogger } from "../../lib/logger";
 
 const testLogger = createLogger({ minLevel: "error" });
@@ -36,31 +36,5 @@ describe("wrapDbError", () => {
     const result = expect(() => handler(new Error("test")));
 
     result.toThrow(TRPCError);
-  });
-});
-
-describe("generateLabel", () => {
-  it("row=0, col=0 のとき A-1 を返す", () => {
-    expect(generateLabel({ row: 0, col: 0 })).toBe("A-1");
-  });
-
-  it("row=0, col=2 のとき A-3 を返す", () => {
-    expect(generateLabel({ row: 0, col: 2 })).toBe("A-3");
-  });
-
-  it("row=1, col=0 のとき B-1 を返す", () => {
-    expect(generateLabel({ row: 1, col: 0 })).toBe("B-1");
-  });
-
-  it("row=2, col=4 のとき C-5 を返す", () => {
-    expect(generateLabel({ row: 2, col: 4 })).toBe("C-5");
-  });
-
-  it("row=25, col=0 のとき Z-1 を返す", () => {
-    expect(generateLabel({ row: 25, col: 0 })).toBe("Z-1");
-  });
-
-  it("row=26 のとき例外をスローする", () => {
-    expect(() => generateLabel({ row: 26, col: 0 })).toThrow();
   });
 });

--- a/workers/src/trpc/lib/d1-helpers.ts
+++ b/workers/src/trpc/lib/d1-helpers.ts
@@ -27,19 +27,3 @@ export const wrapDbError =
       cause: err,
     });
   };
-
-const ASCII_UPPER_A = 65;
-const MAX_LABEL_ROWS = 26;
-
-export const generateLabel = ({
-  row,
-  col,
-}: {
-  readonly row: number;
-  readonly col: number;
-}): string => {
-  if (row >= MAX_LABEL_ROWS) {
-    throw new Error(`row must be less than ${MAX_LABEL_ROWS}, got ${row}`);
-  }
-  return `${String.fromCharCode(ASCII_UPPER_A + row)}-${col + 1}`;
-};

--- a/workers/src/trpc/lib/schemas.ts
+++ b/workers/src/trpc/lib/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { SYNC_ACTION_TYPE, ORPHAN_RESOLUTION } from "@shared/lib/constants";
 import { cuidSchema } from "../../db/validation";
 
 export {
@@ -48,19 +49,15 @@ export const confirmPartialInputSchema = z.object({
     .min(MIN_CONFIRMATIONS_LENGTH),
 });
 
-const SYNC_ACTION_TYPES = [
-  "garment:create",
-  "garment:update",
-  "garment:delete",
-  "storageCase:create",
-  "storageCase:update",
-  "storageCase:delete",
-  "storageLocation:create",
-  "storageLocation:update",
-  "doll:create",
-  "doll:update",
-  "doll:delete",
-] as const;
+const toNonEmptyTuple = <T extends string>(arr: readonly T[]): [T, ...T[]] => {
+  const [first, ...rest] = arr;
+  if (first === undefined) {
+    throw new Error("Array must not be empty");
+  }
+  return [first, ...rest];
+};
+
+const SYNC_ACTION_TYPES = toNonEmptyTuple(Object.values(SYNC_ACTION_TYPE));
 
 const syncQueueItemSchema = z.object({
   type: z.enum(SYNC_ACTION_TYPES),
@@ -74,7 +71,7 @@ export const syncPushInputSchema = z.object({
   items: z.array(syncQueueItemSchema).min(MIN_SYNC_ITEMS_LENGTH),
 });
 
-const ORPHAN_RESOLUTIONS = ["stored_back", "still_using", "lost"] as const;
+const ORPHAN_RESOLUTIONS = toNonEmptyTuple(Object.values(ORPHAN_RESOLUTION));
 
 export const orphanResolveInputSchema = z
   .object({

--- a/workers/src/trpc/lib/schemas.ts
+++ b/workers/src/trpc/lib/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { SYNC_ACTION_TYPE, ORPHAN_RESOLUTION } from "@shared/lib/constants";
 import { cuidSchema } from "../../db/validation";
+import { toNonEmptyTuple } from "../../lib/to-non-empty-tuple";
 
 export {
   cuidSchema,
@@ -48,14 +49,6 @@ export const confirmPartialInputSchema = z.object({
     )
     .min(MIN_CONFIRMATIONS_LENGTH),
 });
-
-const toNonEmptyTuple = <T extends string>(arr: readonly T[]): [T, ...T[]] => {
-  const [first, ...rest] = arr;
-  if (first === undefined) {
-    throw new Error("Array must not be empty");
-  }
-  return [first, ...rest];
-};
 
 const SYNC_ACTION_TYPES = toNonEmptyTuple(Object.values(SYNC_ACTION_TYPE));
 


### PR DESCRIPTION
## Summary

- **バリデー���ョン定数の統一**: `workers/src/db/validation.ts` のローカル定数12個を `@shared/lib/constants` からの import に置き換え。`schemas.ts` の `SYNC_ACTION_TYPES` / `ORPHAN_RESOLUTIONS` も共有定数から導出
- **`generateLabel()` の統一**: フロント版にバリデーション（`row >= 26` エラー）を追加し、バックエンドの重複実装を削除。テストをフロント側に移動
- **`buildSetObject` の共通化**: garment/doll リポジトリで重複していた関数を `build-set-object.ts` に抽出
- **Delete + Image Cleanup の共通化**: garment/doll サービスの削除+R2画像クリーンアップロジックを `delete-with-image-cleanup.ts` に抽出
- **Jotai CRUD Atom ファクトリ**: garment/doll ストアの重複 CRUD パターンを `createEntityAtoms` ファクトリに集約

## Test plan

- [x] `pnpm precheck:full` パス（型チェック・lint・フォーマット・i18n・全テスト）
- [x] フロントエンドテスト 379件パス
- [x] バックエンドテスト 148件パス
- [x] `generateLabel` テストが新しい場所で正常動作
- [ ] 手動でガーメント/ドールの CRUD 操作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)