### PR TITLE
feat: 服・ドール一覧にクライアント側ペジネーションを追加

### DIFF
--- a/src/app/dolls/page.test.tsx
+++ b/src/app/dolls/page.test.tsx
@@ -386,4 +386,137 @@ describe("DollsPage", () => {
 
     expect(screen.getByText(/スタジオ桜/)).toBeInTheDocument();
   });
+
+  describe("ページネーション", () => {
+    const createDolls = (count: number) => {
+      Array.from({ length: count }, (_, idx) => {
+        const i = idx + 1;
+        return testDb.doll.create({
+          id: `d-${i}`,
+          name: `ドール-${String(i).padStart(2, "0")}`,
+          createdAt: FIXED_NOW - (count - i) * MS_PER_DAY,
+        });
+      });
+    };
+
+    const clickNextPage = async (user: ReturnType<typeof userEvent.setup>) => {
+      const buttons = screen.getAllByLabelText("次のページ");
+      const button = buttons[0];
+      expect(button).toBeDefined();
+      if (button === undefined) return;
+      await user.click(button);
+    };
+
+    it("アイテム数がページサイズを超えるとページネーションが表示される", async () => {
+      createDolls(25);
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<DollsPage />);
+
+      expect(
+        screen.getByRole("navigation", { name: "ページネーション" }),
+      ).toBeInTheDocument();
+      expect(screen.getAllByLabelText("次のページ").length).toBeGreaterThan(0);
+    });
+
+    it("アイテム数がページサイズ以下のときナビゲーションボタンが非表示", async () => {
+      createDolls(5);
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<DollsPage />);
+
+      expect(screen.getByText("1-5 / 5件")).toBeInTheDocument();
+      expect(screen.getByLabelText("表示件数")).toBeInTheDocument();
+      expect(screen.queryByLabelText("次のページ")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("前のページ")).not.toBeInTheDocument();
+    });
+
+    it("1ページ目にはページサイズ分のアイテムのみ表示される", async () => {
+      createDolls(25);
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<DollsPage />);
+
+      const displayed = screen.getAllByText(/^ドール-\d+$/);
+      expect(displayed).toHaveLength(20);
+      expect(screen.getByText("ドール-25")).toBeInTheDocument();
+      expect(screen.queryByText("ドール-05")).not.toBeInTheDocument();
+    });
+
+    it("次のページに遷移すると残りのアイテムが表示される", async () => {
+      createDolls(25);
+      await seedDbFromTestDb();
+      const user = userEvent.setup();
+
+      await renderWithProviders(<DollsPage />);
+
+      await clickNextPage(user);
+
+      const displayed = screen.getAllByText(/^ドール-\d+$/);
+      expect(displayed).toHaveLength(5);
+      expect(screen.getByText("ドール-05")).toBeInTheDocument();
+      expect(screen.queryByText("ドール-25")).not.toBeInTheDocument();
+    });
+
+    it("件数表示がページ遷移に応じて更新される", async () => {
+      createDolls(25);
+      await seedDbFromTestDb();
+      const user = userEvent.setup();
+
+      await renderWithProviders(<DollsPage />);
+
+      expect(screen.getByText("1-20 / 25件")).toBeInTheDocument();
+
+      await clickNextPage(user);
+
+      expect(screen.getByText("21-25 / 25件")).toBeInTheDocument();
+    });
+
+    it("表示件数を変更すると全アイテムが1ページに収まる", async () => {
+      createDolls(25);
+      await seedDbFromTestDb();
+      const user = userEvent.setup();
+
+      await renderWithProviders(<DollsPage />);
+
+      await user.selectOptions(screen.getByLabelText("表示件数"), "50");
+
+      const displayed = screen.getAllByText(/^ドール-\d+$/);
+      expect(displayed).toHaveLength(25);
+      expect(screen.queryByLabelText("次のページ")).not.toBeInTheDocument();
+    });
+
+    it("フィルター適用でページが1にリセットされる", async () => {
+      createDolls(25);
+      await seedDbFromTestDb();
+      const user = userEvent.setup();
+
+      await renderWithProviders(<DollsPage />);
+
+      await clickNextPage(user);
+      expect(screen.getByText("21-25 / 25件")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /^SD \(/ }));
+
+      expect(screen.getByText("1-20 / 25件")).toBeInTheDocument();
+    });
+
+    it("検索でページが1にリセットされる", async () => {
+      createDolls(25);
+      await seedDbFromTestDb();
+      const user = userEvent.setup();
+
+      await renderWithProviders(<DollsPage />);
+
+      await clickNextPage(user);
+      expect(screen.getByText("21-25 / 25件")).toBeInTheDocument();
+
+      await user.type(
+        screen.getByPlaceholderText("名前やカスタマイザーで検索..."),
+        "ドール",
+      );
+
+      expect(screen.getByText("1-20 / 25件")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/app/dolls/page.tsx
+++ b/src/app/dolls/page.tsx
@@ -17,6 +17,8 @@ import type { Doll, DollSize } from "@/types";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import DollGrid from "@/components/doll/DollGrid";
 import DollList from "@/components/doll/DollList";
+import Pagination from "@/components/ui/Pagination";
+import usePagination from "@/hooks/usePagination";
 import ChipGroup from "@/components/ui/ChipGroup";
 import EmptyState from "@/components/ui/EmptyState";
 import FAB from "@/components/ui/FAB";
@@ -181,6 +183,13 @@ const DollListContent = () => {
     return [...filtered].sort(DOLL_COMPARATORS[sortOption]);
   }, [dolls, searchQuery, activeSize, customizerFilter, sortOption]);
 
+  const {
+    paginatedItems: paginatedDolls,
+    onChangePage,
+    onChangePageSize,
+    ...paginationData
+  } = usePagination({ items: filteredDolls });
+
   if (allDolls.length === 0) {
     return (
       <EmptyState
@@ -260,10 +269,19 @@ const DollListContent = () => {
         <p className="py-12 text-center text-sm text-text-tertiary">
           <Trans>一致するドールが見つかりません</Trans>
         </p>
-      ) : viewMode === "grid" ? (
-        <DollGrid dolls={filteredDolls} />
       ) : (
-        <DollList dolls={filteredDolls} />
+        <>
+          {viewMode === "grid" ? (
+            <DollGrid dolls={paginatedDolls} />
+          ) : (
+            <DollList dolls={paginatedDolls} />
+          )}
+          <Pagination
+            pagination={paginationData}
+            onChangePage={onChangePage}
+            onChangePageSize={onChangePageSize}
+          />
+        </>
       )}
     </div>
   );

--- a/src/app/garments/page-pagination.test.tsx
+++ b/src/app/garments/page-pagination.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MS_PER_DAY } from "@/lib/constants";
+import { testDb, FIXED_NOW } from "@/test/mocks/db";
+import { seedDbFromTestDb } from "@/test/helpers/seedDb";
+import { renderWithProviders } from "@/test/testUtils";
+import GarmentsPage from "./page";
+
+const mockRouter = vi.hoisted(() => ({
+  push: vi.fn(),
+  back: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    readonly href: string;
+    readonly children: React.ReactNode;
+  } & Record<string, unknown>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("GarmentsPage ページネーション", () => {
+  beforeEach(() => {
+    vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createGarments = (count: number) => {
+    Array.from({ length: count }, (_, idx) => {
+      const i = idx + 1;
+      return testDb.garment.create({
+        id: `g-${i}`,
+        name: `服-${String(i).padStart(2, "0")}`,
+        createdAt: FIXED_NOW - (count - i) * MS_PER_DAY,
+      });
+    });
+  };
+
+  const clickNextPage = async (user: ReturnType<typeof userEvent.setup>) => {
+    const buttons = screen.getAllByLabelText("次のページ");
+    const button = buttons[0];
+    expect(button).toBeDefined();
+    if (button === undefined) return;
+    await user.click(button);
+  };
+
+  it("アイテム数がページサイズを超えるとページネーションが表示される", async () => {
+    createGarments(25);
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    expect(
+      screen.getByRole("navigation", { name: "ページネーション" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByLabelText("次のページ").length).toBeGreaterThan(0);
+  });
+
+  it("アイテム数がページサイズ以下のときナビゲーションボタンが非表示", async () => {
+    createGarments(5);
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    expect(screen.getByText("1-5 / 5件")).toBeInTheDocument();
+    expect(screen.getByLabelText("表示件数")).toBeInTheDocument();
+    expect(screen.queryByLabelText("次のページ")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("前のページ")).not.toBeInTheDocument();
+  });
+
+  it("1ページ目にはページサイズ分のアイテムのみ表示される", async () => {
+    createGarments(25);
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    const displayed = screen.getAllByText(/^服-\d+$/);
+    expect(displayed).toHaveLength(20);
+    expect(screen.getByText("服-25")).toBeInTheDocument();
+    expect(screen.queryByText("服-05")).not.toBeInTheDocument();
+  });
+
+  it("次のページに遷移すると残りのアイテムが表示される", async () => {
+    createGarments(25);
+    await seedDbFromTestDb();
+    const user = userEvent.setup();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    await clickNextPage(user);
+
+    const displayed = screen.getAllByText(/^服-\d+$/);
+    expect(displayed).toHaveLength(5);
+    expect(screen.getByText("服-05")).toBeInTheDocument();
+    expect(screen.queryByText("服-25")).not.toBeInTheDocument();
+  });
+
+  it("件数表示がページ遷移に応じて更新される", async () => {
+    createGarments(25);
+    await seedDbFromTestDb();
+    const user = userEvent.setup();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    expect(screen.getByText("1-20 / 25件")).toBeInTheDocument();
+
+    await clickNextPage(user);
+
+    expect(screen.getByText("21-25 / 25件")).toBeInTheDocument();
+  });
+
+  it("表示件数を変更すると全アイテムが1ページに収まる", async () => {
+    createGarments(25);
+    await seedDbFromTestDb();
+    const user = userEvent.setup();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    await user.selectOptions(screen.getByLabelText("表示件数"), "50");
+
+    const displayed = screen.getAllByText(/^服-\d+$/);
+    expect(displayed).toHaveLength(25);
+    expect(screen.queryByLabelText("次のページ")).not.toBeInTheDocument();
+  });
+
+  it("フィルター適用でページが1にリセットされる", async () => {
+    createGarments(25);
+    await seedDbFromTestDb();
+    const user = userEvent.setup();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    await clickNextPage(user);
+    expect(screen.getByText("21-25 / 25件")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "ドレス" }));
+
+    expect(screen.getByText("1-20 / 25件")).toBeInTheDocument();
+  });
+
+  it("検索でページが1にリセットされる", async () => {
+    createGarments(25);
+    await seedDbFromTestDb();
+    const user = userEvent.setup();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    await clickNextPage(user);
+    expect(screen.getByText("21-25 / 25件")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("名前やタグで検索..."), "服");
+
+    expect(screen.getByText("1-20 / 25件")).toBeInTheDocument();
+  });
+});

--- a/src/app/garments/page.tsx
+++ b/src/app/garments/page.tsx
@@ -30,6 +30,8 @@ import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import DollCombobox from "@/components/garment/DollCombobox";
 import GarmentGrid from "@/components/garment/GarmentGrid";
 import GarmentList from "@/components/garment/GarmentList";
+import Pagination from "@/components/ui/Pagination";
+import usePagination from "@/hooks/usePagination";
 import ChipGroup from "@/components/ui/ChipGroup";
 import EmptyState from "@/components/ui/EmptyState";
 import FAB from "@/components/ui/FAB";
@@ -241,6 +243,13 @@ const GarmentListContent = () => {
     selectedDoll,
   ]);
 
+  const {
+    paginatedItems: paginatedGarments,
+    onChangePage,
+    onChangePageSize,
+    ...paginationData
+  } = usePagination({ items: filteredGarments });
+
   if (allGarments.length === 0) {
     return (
       <EmptyState
@@ -321,10 +330,19 @@ const GarmentListContent = () => {
         <p className="py-12 text-center text-sm text-text-tertiary">
           <Trans>一致する服が見つかりません</Trans>
         </p>
-      ) : viewMode === "grid" ? (
-        <GarmentGrid garments={filteredGarments} />
       ) : (
-        <GarmentList garments={filteredGarments} />
+        <>
+          {viewMode === "grid" ? (
+            <GarmentGrid garments={paginatedGarments} />
+          ) : (
+            <GarmentList garments={paginatedGarments} />
+          )}
+          <Pagination
+            pagination={paginationData}
+            onChangePage={onChangePage}
+            onChangePageSize={onChangePageSize}
+          />
+        </>
       )}
     </div>
   );

--- a/src/components/ui/Pagination.test.tsx
+++ b/src/components/ui/Pagination.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { I18nTestWrapper } from "@/test/i18nWrapper";
+import Pagination from "./Pagination";
+
+const defaultProps = {
+  pagination: {
+    currentPage: 1,
+    totalPages: 5,
+    pageSize: 20 as const,
+    totalCount: 100,
+  },
+  onChangePage: vi.fn(),
+  onChangePageSize: vi.fn(),
+};
+
+const renderPagination = (
+  overrides: Partial<typeof defaultProps> & {
+    pagination?: Partial<(typeof defaultProps)["pagination"]>;
+  } = {},
+) => {
+  const { pagination: paginationOverrides, ...restOverrides } = overrides;
+  const props = {
+    ...defaultProps,
+    ...restOverrides,
+    pagination: { ...defaultProps.pagination, ...paginationOverrides },
+  };
+  return render(<Pagination {...props} />, {
+    wrapper: I18nTestWrapper,
+  });
+};
+
+describe("Pagination", () => {
+  it("件数表示が正しい", () => {
+    renderPagination();
+
+    expect(screen.getByText("1-20 / 100件")).toBeInTheDocument();
+  });
+
+  it("2ページ目の件数表示が正しい", () => {
+    renderPagination({
+      pagination: { currentPage: 2 },
+    });
+
+    expect(screen.getByText("21-40 / 100件")).toBeInTheDocument();
+  });
+
+  it("ページ番号ボタンがデスクトップで表示される", () => {
+    renderPagination();
+
+    const nav = screen.getByRole("navigation");
+    expect(nav).toBeInTheDocument();
+  });
+
+  it("1ページ目で前へボタンがdisabledになる", () => {
+    renderPagination({ pagination: { currentPage: 1 } });
+
+    screen.getAllByLabelText("前のページ").forEach((btn) => {
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  it("最終ページで次へボタンがdisabledになる", () => {
+    renderPagination({
+      pagination: { currentPage: 5 },
+    });
+
+    screen.getAllByLabelText("次のページ").forEach((btn) => {
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  it("次へボタンクリックでonChangePageが呼ばれる", async () => {
+    const onChangePage = vi.fn();
+    renderPagination({ onChangePage });
+    const user = userEvent.setup();
+
+    const nextButtons = screen.getAllByLabelText("次のページ");
+    const firstNextButton = nextButtons[0];
+    expect(firstNextButton).toBeDefined();
+    if (firstNextButton === undefined) return;
+    await user.click(firstNextButton);
+
+    expect(onChangePage).toHaveBeenCalledWith(2);
+  });
+
+  it("ページサイズ変更でonChangePageSizeが呼ばれる", async () => {
+    const onChangePageSize = vi.fn();
+    renderPagination({ onChangePageSize });
+    const user = userEvent.setup();
+
+    const select = screen.getByLabelText("表示件数");
+    await user.selectOptions(select, "50");
+
+    expect(onChangePageSize).toHaveBeenCalledWith(50);
+  });
+
+  it("totalPages===1のときページ番号ボタンが非表示", () => {
+    renderPagination({
+      pagination: { totalPages: 1, totalCount: 10 },
+    });
+
+    expect(screen.queryByText("前へ")).not.toBeInTheDocument();
+    expect(screen.queryByText("次へ")).not.toBeInTheDocument();
+    expect(screen.getByText("1-10 / 10件")).toBeInTheDocument();
+  });
+
+  it("現在のページにaria-current=pageが付与される", () => {
+    renderPagination({ pagination: { currentPage: 3 } });
+
+    const pageButton = screen.getByRole("button", { name: "3" });
+    expect(pageButton).toHaveAttribute("aria-current", "page");
+  });
+
+  it("多ページ時に省略記号が表示される", () => {
+    renderPagination({
+      pagination: { currentPage: 5, totalPages: 10, totalCount: 200 },
+    });
+
+    const ellipses = screen.getAllByText("...");
+    expect(ellipses.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/ui/Pagination.test.tsx
+++ b/src/components/ui/Pagination.test.tsx
@@ -16,7 +16,7 @@ const defaultProps = {
 };
 
 const renderPagination = (
-  overrides: Partial<typeof defaultProps> & {
+  overrides: Omit<Partial<typeof defaultProps>, "pagination"> & {
     pagination?: Partial<(typeof defaultProps)["pagination"]>;
   } = {},
 ) => {

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import clsx from "clsx";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import { PAGE_SIZES } from "@/lib/constants";
+import type { PageSize } from "@/lib/constants";
+
+const ELLIPSIS = "ellipsis" as const;
+type PageItem = number | typeof ELLIPSIS;
+
+const MAX_VISIBLE_PAGES = 7;
+const EDGE_THRESHOLD = 4;
+const INNER_PAGE_COUNT = MAX_VISIBLE_PAGES - 2;
+
+const getVisiblePages = ({
+  currentPage,
+  totalPages,
+}: {
+  readonly currentPage: number;
+  readonly totalPages: number;
+}): readonly PageItem[] => {
+  if (totalPages <= MAX_VISIBLE_PAGES) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  if (currentPage <= EDGE_THRESHOLD) {
+    return [
+      ...Array.from({ length: INNER_PAGE_COUNT }, (_, i) => i + 1),
+      ELLIPSIS,
+      totalPages,
+    ];
+  }
+
+  if (currentPage >= totalPages - EDGE_THRESHOLD + 1) {
+    return [
+      1,
+      ELLIPSIS,
+      ...Array.from(
+        { length: INNER_PAGE_COUNT },
+        (_, i) => totalPages - INNER_PAGE_COUNT + 1 + i,
+      ),
+    ];
+  }
+
+  return [
+    1,
+    ELLIPSIS,
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    ELLIPSIS,
+    totalPages,
+  ];
+};
+
+export type PaginationData = {
+  readonly currentPage: number;
+  readonly totalPages: number;
+  readonly pageSize: PageSize;
+  readonly totalCount: number;
+};
+
+type Props = {
+  readonly pagination: PaginationData;
+  readonly onChangePage: (page: number) => void;
+  readonly onChangePageSize: (size: PageSize) => void;
+};
+
+const isPageSize = (value: number): value is PageSize =>
+  (PAGE_SIZES as readonly number[]).includes(value);
+
+const Pagination = ({ pagination, onChangePage, onChangePageSize }: Props) => {
+  const { currentPage, totalPages, pageSize, totalCount } = pagination;
+  const { i18n } = useLingui();
+
+  const visiblePages = getVisiblePages({ currentPage, totalPages });
+  const isFirstPage = currentPage === 1;
+  const isLastPage = currentPage === totalPages;
+  const displayStart = (currentPage - 1) * pageSize + 1;
+  const displayEnd = Math.min(currentPage * pageSize, totalCount);
+
+  return (
+    <nav
+      aria-label={i18n._(t`ページネーション`)}
+      className="flex flex-col gap-3"
+    >
+      {totalPages > 1 && (
+        <>
+          <div className="flex items-center justify-center gap-2 lg:hidden">
+            <button
+              type="button"
+              onClick={() => onChangePage(currentPage - 1)}
+              disabled={isFirstPage}
+              aria-label={i18n._(t`前のページ`)}
+              className={clsx(
+                "inline-flex size-9 items-center justify-center rounded-lg transition-colors",
+                isFirstPage
+                  ? "pointer-events-none opacity-50"
+                  : "text-text-secondary hover:bg-primary-50",
+              )}
+            >
+              <ChevronLeft className="size-4" />
+            </button>
+            <span className="text-sm text-text-secondary">
+              {currentPage} / {totalPages}
+            </span>
+            <button
+              type="button"
+              onClick={() => onChangePage(currentPage + 1)}
+              disabled={isLastPage}
+              aria-label={i18n._(t`次のページ`)}
+              className={clsx(
+                "inline-flex size-9 items-center justify-center rounded-lg transition-colors",
+                isLastPage
+                  ? "pointer-events-none opacity-50"
+                  : "text-text-secondary hover:bg-primary-50",
+              )}
+            >
+              <ChevronRight className="size-4" />
+            </button>
+          </div>
+
+          <div className="hidden items-center justify-center gap-1 lg:flex">
+            <button
+              type="button"
+              onClick={() => onChangePage(currentPage - 1)}
+              disabled={isFirstPage}
+              aria-label={i18n._(t`前のページ`)}
+              className={clsx(
+                "inline-flex h-8 items-center gap-1 rounded-lg px-2 text-xs font-medium transition-colors",
+                isFirstPage
+                  ? "pointer-events-none opacity-50"
+                  : "text-text-secondary hover:bg-primary-50",
+              )}
+            >
+              <ChevronLeft className="size-3.5" />
+              <Trans>前へ</Trans>
+            </button>
+
+            {visiblePages.map((item, i) =>
+              item === ELLIPSIS ? (
+                <span
+                  key={`ellipsis-${i}`}
+                  className="inline-flex size-8 items-center justify-center text-xs text-text-tertiary"
+                  aria-hidden="true"
+                >
+                  ...
+                </span>
+              ) : (
+                <button
+                  key={item}
+                  type="button"
+                  onClick={() => onChangePage(item)}
+                  aria-current={item === currentPage ? "page" : undefined}
+                  className={clsx(
+                    "inline-flex size-8 items-center justify-center rounded-lg text-xs font-medium transition-colors",
+                    item === currentPage
+                      ? "bg-primary-500 text-text-inverse"
+                      : "border border-border-default bg-surface-overlay text-text-secondary hover:bg-primary-50",
+                  )}
+                >
+                  {item}
+                </button>
+              ),
+            )}
+
+            <button
+              type="button"
+              onClick={() => onChangePage(currentPage + 1)}
+              disabled={isLastPage}
+              aria-label={i18n._(t`次のページ`)}
+              className={clsx(
+                "inline-flex h-8 items-center gap-1 rounded-lg px-2 text-xs font-medium transition-colors",
+                isLastPage
+                  ? "pointer-events-none opacity-50"
+                  : "text-text-secondary hover:bg-primary-50",
+              )}
+            >
+              <Trans>次へ</Trans>
+              <ChevronRight className="size-3.5" />
+            </button>
+          </div>
+        </>
+      )}
+
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-text-tertiary">
+          <Trans>
+            {displayStart}-{displayEnd} / {totalCount}件
+          </Trans>
+        </p>
+        <select
+          value={pageSize}
+          onChange={(e) => {
+            const parsed = Number(e.target.value);
+            if (isPageSize(parsed)) {
+              onChangePageSize(parsed);
+            }
+          }}
+          aria-label={i18n._(t`表示件数`)}
+          className="h-8 rounded-lg border border-border-default bg-surface-overlay px-2 text-xs text-text-secondary focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100"
+        >
+          {PAGE_SIZES.map((size) => (
+            <option key={size} value={size}>
+              {i18n._(t`${size}件表示`)}
+            </option>
+          ))}
+        </select>
+      </div>
+    </nav>
+  );
+};
+
+export default Pagination;

--- a/src/hooks/usePagination.test.ts
+++ b/src/hooks/usePagination.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import usePagination from "./usePagination";
+
+const createItems = (count: number): readonly number[] =>
+  Array.from({ length: count }, (_, i) => i + 1);
+
+describe("usePagination", () => {
+  it("20件以下で1ページに収まる", () => {
+    const items = createItems(15);
+    const { result } = renderHook(() => usePagination({ items }));
+
+    expect(result.current.currentPage).toBe(1);
+    expect(result.current.totalPages).toBe(1);
+    expect(result.current.totalCount).toBe(15);
+    expect(result.current.paginatedItems).toEqual(items);
+  });
+
+  it("50件でpageSize=20の場合、totalPages=3", () => {
+    const items = createItems(50);
+    const { result } = renderHook(() => usePagination({ items }));
+
+    expect(result.current.totalPages).toBe(3);
+    expect(result.current.paginatedItems).toEqual(createItems(20));
+  });
+
+  it("onChangePageでページ遷移できる", () => {
+    const items = createItems(50);
+    const { result } = renderHook(() => usePagination({ items }));
+
+    act(() => {
+      result.current.onChangePage(2);
+    });
+
+    expect(result.current.currentPage).toBe(2);
+    expect(result.current.paginatedItems).toEqual(
+      Array.from({ length: 20 }, (_, i) => i + 21),
+    );
+  });
+
+  it("最終ページでは残りのアイテムのみ返す", () => {
+    const items = createItems(50);
+    const { result } = renderHook(() => usePagination({ items }));
+
+    act(() => {
+      result.current.onChangePage(3);
+    });
+
+    expect(result.current.currentPage).toBe(3);
+    expect(result.current.paginatedItems).toEqual(
+      Array.from({ length: 10 }, (_, i) => i + 41),
+    );
+  });
+
+  it("onChangePageSizeでページが1にリセットされる", () => {
+    const items = createItems(100);
+    const { result } = renderHook(() => usePagination({ items }));
+
+    act(() => {
+      result.current.onChangePage(3);
+    });
+    expect(result.current.currentPage).toBe(3);
+
+    act(() => {
+      result.current.onChangePageSize(50);
+    });
+
+    expect(result.current.currentPage).toBe(1);
+    expect(result.current.pageSize).toBe(50);
+    expect(result.current.totalPages).toBe(2);
+    expect(result.current.paginatedItems).toHaveLength(50);
+  });
+
+  it("items が0件のとき totalPages=1、paginatedItems=[]", () => {
+    const items: readonly number[] = [];
+    const { result } = renderHook(() => usePagination({ items }));
+
+    expect(result.current.totalPages).toBe(1);
+    expect(result.current.totalCount).toBe(0);
+    expect(result.current.paginatedItems).toEqual([]);
+  });
+
+  it("範囲外のページ番号はクランプされる（下限）", () => {
+    const items = createItems(50);
+    const { result } = renderHook(() => usePagination({ items }));
+
+    act(() => {
+      result.current.onChangePage(0);
+    });
+
+    expect(result.current.currentPage).toBe(1);
+  });
+
+  it("範囲外のページ番号はクランプされる（上限）", () => {
+    const items = createItems(50);
+    const { result } = renderHook(() => usePagination({ items }));
+
+    act(() => {
+      result.current.onChangePage(100);
+    });
+
+    expect(result.current.currentPage).toBe(3);
+  });
+
+  it("件数が同じでも配列参照が変わればページ1にリセットされる", () => {
+    const itemsA = createItems(60);
+    const itemsB = createItems(60);
+    const { result, rerender } = renderHook(
+      ({ items }) => usePagination({ items }),
+      { initialProps: { items: itemsA } },
+    );
+
+    act(() => {
+      result.current.onChangePage(3);
+    });
+    expect(result.current.currentPage).toBe(3);
+
+    rerender({ items: itemsB });
+
+    expect(result.current.currentPage).toBe(1);
+  });
+
+  it("items.lengthが減ったときページが1にリセットされる", () => {
+    const initialItems = createItems(100);
+    const { result, rerender } = renderHook(
+      ({ items }) => usePagination({ items }),
+      { initialProps: { items: initialItems } },
+    );
+
+    act(() => {
+      result.current.onChangePage(5);
+    });
+    expect(result.current.currentPage).toBe(5);
+
+    rerender({ items: createItems(10) });
+
+    expect(result.current.currentPage).toBe(1);
+    expect(result.current.totalPages).toBe(1);
+  });
+
+  it("initialPageSizeで初期ページサイズを設定できる", () => {
+    const items = createItems(200);
+    const { result } = renderHook(() =>
+      usePagination({ items, initialPageSize: 50 }),
+    );
+
+    expect(result.current.pageSize).toBe(50);
+    expect(result.current.totalPages).toBe(4);
+    expect(result.current.paginatedItems).toHaveLength(50);
+  });
+});

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useMemo, useRef } from "react";
+import { DEFAULT_PAGE_SIZE } from "@/lib/constants";
+import type { PageSize } from "@/lib/constants";
+
+type UsePaginationArgs<T> = {
+  readonly items: readonly T[];
+  readonly initialPageSize?: PageSize;
+};
+
+type PaginationData<T> = {
+  readonly paginatedItems: readonly T[];
+  readonly currentPage: number;
+  readonly totalPages: number;
+  readonly pageSize: PageSize;
+  readonly totalCount: number;
+};
+
+type PaginationActions = {
+  readonly onChangePage: (page: number) => void;
+  readonly onChangePageSize: (size: PageSize) => void;
+};
+
+type UsePaginationResult<T> = PaginationData<T> & PaginationActions;
+
+const usePagination = <T>({
+  items,
+  initialPageSize = DEFAULT_PAGE_SIZE,
+}: UsePaginationArgs<T>): UsePaginationResult<T> => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState<PageSize>(initialPageSize);
+  const prevItemsRef = useRef(items);
+
+  const { length: totalCount } = items;
+
+  if (prevItemsRef.current !== items) {
+    prevItemsRef.current = items;
+    setCurrentPage(1);
+  }
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const safePage = Math.min(currentPage, totalPages);
+
+  const startIndex = (safePage - 1) * pageSize;
+  const endIndex = Math.min(startIndex + pageSize, totalCount);
+
+  const paginatedItems = useMemo(
+    () => items.slice(startIndex, endIndex),
+    [items, startIndex, endIndex],
+  );
+
+  const onChangePage = (page: number) => {
+    setCurrentPage(Math.max(1, Math.min(page, totalPages)));
+  };
+
+  const onChangePageSize = (size: PageSize) => {
+    setPageSize(size);
+    setCurrentPage(1);
+  };
+
+  return {
+    paginatedItems,
+    currentPage: safePage,
+    totalPages,
+    pageSize,
+    totalCount,
+    onChangePage,
+    onChangePageSize,
+  };
+};
+
+export default usePagination;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -217,3 +217,7 @@ export type ColorName =
   | "pink"
   | "orange"
   | "cyan";
+
+export const PAGE_SIZES = [20, 50, 100] as const;
+export type PageSize = (typeof PAGE_SIZES)[number];
+export const DEFAULT_PAGE_SIZE: PageSize = 20;

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -83,6 +83,14 @@ msgstr "{0} garments scanned"
 msgid "{0}行 x {1}列"
 msgstr "{0} rows x {1} cols"
 
+#: src/components/ui/Pagination.tsx
+msgid "{displayStart}-{displayEnd} / {totalCount}件"
+msgstr "{displayStart}-{displayEnd} / {totalCount} items"
+
+#: src/components/ui/Pagination.tsx
+#~ msgid "{displayStart}-{endIndex} / {totalCount}件"
+#~ msgstr "{displayStart}-{endIndex} / {totalCount} items"
+
 #: src/components/scan/OrphanCheckoutDialog.tsx
 msgid "{elapsedDays}日前から取り出し中"
 msgstr "Checked out {elapsedDays} days ago"
@@ -95,6 +103,10 @@ msgstr "{errorCount} errors"
 #: src/components/location/StorageCaseCard.tsx
 msgid "{needsReviewCount}着 要確認"
 msgstr "{needsReviewCount} items need review"
+
+#: src/components/ui/Pagination.tsx
+msgid "{size}件表示"
+msgstr "Show {size}"
 
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件 有効"
@@ -607,6 +619,10 @@ msgstr "Brand/Maker"
 msgid "プレビュー"
 msgstr "Preview"
 
+#: src/components/ui/Pagination.tsx
+msgid "ページネーション"
+msgstr "Pagination"
+
 #: src/app/nfc-write/page.tsx
 #: src/app/print/page.tsx
 msgid "ページの読み込みに失敗しました"
@@ -848,11 +864,17 @@ msgstr "Columns"
 msgid "削除"
 msgstr "Delete"
 
+#: src/components/ui/Pagination.tsx
+#: src/components/ui/Pagination.tsx
+msgid "前のページ"
+msgstr "Previous page"
+
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 msgid "前の値を適用"
 msgstr "Apply previous values"
 
 #: src/components/garment/bulk/BulkMetadataForm.tsx
+#: src/components/ui/Pagination.tsx
 msgid "前へ"
 msgstr "Back"
 
@@ -1072,9 +1094,15 @@ msgstr "Unassigned"
 msgid "未配置にする"
 msgstr "Unassign"
 
+#: src/components/ui/Pagination.tsx
+#: src/components/ui/Pagination.tsx
+msgid "次のページ"
+msgstr "Next page"
+
 #: src/app/nfc-write/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/bulk/CaptureCamera.tsx
+#: src/components/ui/Pagination.tsx
 msgid "次へ"
 msgstr "Next"
 
@@ -1177,6 +1205,10 @@ msgstr "Enter notes freely..."
 msgid "色"
 msgstr "Colors"
 
+#: src/components/garment/GarmentForm.tsx
+msgid "色を分析中..."
+msgstr "Analyzing colors..."
+
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "行"
 msgstr "Row"
@@ -1192,6 +1224,10 @@ msgstr "Add costume cases to manage garment storage"
 #: src/app/dolls/page.tsx
 #~ msgid "表示するドールがありません"
 #~ msgstr "No dolls to display"
+
+#: src/components/ui/Pagination.tsx
+msgid "表示件数"
+msgstr "Items per page"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/lib/i18n-labels.ts

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -83,6 +83,14 @@ msgstr "{0}着をスキャンしました"
 msgid "{0}行 x {1}列"
 msgstr "{0}行 x {1}列"
 
+#: src/components/ui/Pagination.tsx
+msgid "{displayStart}-{displayEnd} / {totalCount}件"
+msgstr "{displayStart}-{displayEnd} / {totalCount}件"
+
+#: src/components/ui/Pagination.tsx
+#~ msgid "{displayStart}-{endIndex} / {totalCount}件"
+#~ msgstr "{displayStart}-{endIndex} / {totalCount}件"
+
 #: src/components/scan/OrphanCheckoutDialog.tsx
 msgid "{elapsedDays}日前から取り出し中"
 msgstr "{elapsedDays}日前から取り出し中"
@@ -95,6 +103,10 @@ msgstr "{errorCount}件 エラー"
 #: src/components/location/StorageCaseCard.tsx
 msgid "{needsReviewCount}着 要確認"
 msgstr "{needsReviewCount}着 要確認"
+
+#: src/components/ui/Pagination.tsx
+msgid "{size}件表示"
+msgstr "{size}件表示"
 
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件 有効"
@@ -607,6 +619,10 @@ msgstr "ブランド/メーカー"
 msgid "プレビュー"
 msgstr "プレビュー"
 
+#: src/components/ui/Pagination.tsx
+msgid "ページネーション"
+msgstr "ページネーション"
+
 #: src/app/nfc-write/page.tsx
 #: src/app/print/page.tsx
 msgid "ページの読み込みに失敗しました"
@@ -848,11 +864,17 @@ msgstr "列数"
 msgid "削除"
 msgstr "削除"
 
+#: src/components/ui/Pagination.tsx
+#: src/components/ui/Pagination.tsx
+msgid "前のページ"
+msgstr "前のページ"
+
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 msgid "前の値を適用"
 msgstr "前の値を適用"
 
 #: src/components/garment/bulk/BulkMetadataForm.tsx
+#: src/components/ui/Pagination.tsx
 msgid "前へ"
 msgstr "前へ"
 
@@ -1072,9 +1094,15 @@ msgstr "未配置"
 msgid "未配置にする"
 msgstr "未配置にする"
 
+#: src/components/ui/Pagination.tsx
+#: src/components/ui/Pagination.tsx
+msgid "次のページ"
+msgstr "次のページ"
+
 #: src/app/nfc-write/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/bulk/CaptureCamera.tsx
+#: src/components/ui/Pagination.tsx
 msgid "次へ"
 msgstr "次へ"
 
@@ -1177,6 +1205,10 @@ msgstr "自由にメモを入力..."
 msgid "色"
 msgstr "色"
 
+#: src/components/garment/GarmentForm.tsx
+msgid "色を分析中..."
+msgstr "色を分析中..."
+
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "行"
 msgstr "行"
@@ -1192,6 +1224,10 @@ msgstr "衣装ケースを追加して、服の収納場所を管理しましょ
 #: src/app/dolls/page.tsx
 #~ msgid "表示するドールがありません"
 #~ msgstr "表示するドールがありません"
+
+#: src/components/ui/Pagination.tsx
+msgid "表示件数"
+msgstr "表示件数"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/lib/i18n-labels.ts

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -83,6 +83,14 @@ msgstr "{0}벌 스캔 완료"
 msgid "{0}行 x {1}列"
 msgstr "{0}행 x {1}열"
 
+#: src/components/ui/Pagination.tsx
+msgid "{displayStart}-{displayEnd} / {totalCount}件"
+msgstr "{displayStart}-{displayEnd} / {totalCount}건"
+
+#: src/components/ui/Pagination.tsx
+#~ msgid "{displayStart}-{endIndex} / {totalCount}件"
+#~ msgstr "{displayStart}-{endIndex} / {totalCount}건"
+
 #: src/components/scan/OrphanCheckoutDialog.tsx
 msgid "{elapsedDays}日前から取り出し中"
 msgstr "{elapsedDays}일 전부터 꺼낸 상태"
@@ -95,6 +103,10 @@ msgstr "{errorCount}건 오류"
 #: src/components/location/StorageCaseCard.tsx
 msgid "{needsReviewCount}着 要確認"
 msgstr "{needsReviewCount}벌 확인 필요"
+
+#: src/components/ui/Pagination.tsx
+msgid "{size}件表示"
+msgstr "{size}건 표시"
 
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件 有効"
@@ -607,6 +619,10 @@ msgstr "브랜드/메이커"
 msgid "プレビュー"
 msgstr "미리보기"
 
+#: src/components/ui/Pagination.tsx
+msgid "ページネーション"
+msgstr "페이지네이션"
+
 #: src/app/nfc-write/page.tsx
 #: src/app/print/page.tsx
 msgid "ページの読み込みに失敗しました"
@@ -848,11 +864,17 @@ msgstr "열 수"
 msgid "削除"
 msgstr "삭제"
 
+#: src/components/ui/Pagination.tsx
+#: src/components/ui/Pagination.tsx
+msgid "前のページ"
+msgstr "이전 페이지"
+
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 msgid "前の値を適用"
 msgstr "이전 값 적용"
 
 #: src/components/garment/bulk/BulkMetadataForm.tsx
+#: src/components/ui/Pagination.tsx
 msgid "前へ"
 msgstr "이전"
 
@@ -1072,9 +1094,15 @@ msgstr "미배치"
 msgid "未配置にする"
 msgstr "미배치로 설정"
 
+#: src/components/ui/Pagination.tsx
+#: src/components/ui/Pagination.tsx
+msgid "次のページ"
+msgstr "다음 페이지"
+
 #: src/app/nfc-write/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/bulk/CaptureCamera.tsx
+#: src/components/ui/Pagination.tsx
 msgid "次へ"
 msgstr "다음"
 
@@ -1177,6 +1205,10 @@ msgstr "자유롭게 메모를 입력..."
 msgid "色"
 msgstr "색상"
 
+#: src/components/garment/GarmentForm.tsx
+msgid "色を分析中..."
+msgstr "색상 분석 중..."
+
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "行"
 msgstr "행"
@@ -1192,6 +1224,10 @@ msgstr "의상 케이스를 추가하여 옷의 수납 장소를 관리하세요
 #: src/app/dolls/page.tsx
 #~ msgid "表示するドールがありません"
 #~ msgstr "표시할 인형이 없습니다"
+
+#: src/components/ui/Pagination.tsx
+msgid "表示件数"
+msgstr "표시 건수"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/lib/i18n-labels.ts

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -83,6 +83,14 @@ msgstr "已扫描{0}件"
 msgid "{0}行 x {1}列"
 msgstr "{0}行 x {1}列"
 
+#: src/components/ui/Pagination.tsx
+msgid "{displayStart}-{displayEnd} / {totalCount}件"
+msgstr "{displayStart}-{displayEnd} / 共{totalCount}项"
+
+#: src/components/ui/Pagination.tsx
+#~ msgid "{displayStart}-{endIndex} / {totalCount}件"
+#~ msgstr "{displayStart}-{endIndex} / 共{totalCount}项"
+
 #: src/components/scan/OrphanCheckoutDialog.tsx
 msgid "{elapsedDays}日前から取り出し中"
 msgstr "{elapsedDays}天前取出"
@@ -95,6 +103,10 @@ msgstr "{errorCount}项错误"
 #: src/components/location/StorageCaseCard.tsx
 msgid "{needsReviewCount}着 要確認"
 msgstr "{needsReviewCount}件 待确认"
+
+#: src/components/ui/Pagination.tsx
+msgid "{size}件表示"
+msgstr "显示{size}项"
 
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件 有効"
@@ -607,6 +619,10 @@ msgstr "品牌/厂商"
 msgid "プレビュー"
 msgstr "预览"
 
+#: src/components/ui/Pagination.tsx
+msgid "ページネーション"
+msgstr "分页"
+
 #: src/app/nfc-write/page.tsx
 #: src/app/print/page.tsx
 msgid "ページの読み込みに失敗しました"
@@ -848,11 +864,17 @@ msgstr "列数"
 msgid "削除"
 msgstr "删除"
 
+#: src/components/ui/Pagination.tsx
+#: src/components/ui/Pagination.tsx
+msgid "前のページ"
+msgstr "上一页"
+
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 msgid "前の値を適用"
 msgstr "应用上一个值"
 
 #: src/components/garment/bulk/BulkMetadataForm.tsx
+#: src/components/ui/Pagination.tsx
 msgid "前へ"
 msgstr "上一步"
 
@@ -1072,9 +1094,15 @@ msgstr "未分配"
 msgid "未配置にする"
 msgstr "取消分配"
 
+#: src/components/ui/Pagination.tsx
+#: src/components/ui/Pagination.tsx
+msgid "次のページ"
+msgstr "下一页"
+
 #: src/app/nfc-write/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/bulk/CaptureCamera.tsx
+#: src/components/ui/Pagination.tsx
 msgid "次へ"
 msgstr "下一步"
 
@@ -1177,6 +1205,10 @@ msgstr "自由输入备注..."
 msgid "色"
 msgstr "颜色"
 
+#: src/components/garment/GarmentForm.tsx
+msgid "色を分析中..."
+msgstr "正在分析颜色..."
+
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "行"
 msgstr "行"
@@ -1192,6 +1224,10 @@ msgstr "添加收纳箱来管理衣服的存放位置"
 #: src/app/dolls/page.tsx
 #~ msgid "表示するドールがありません"
 #~ msgstr "没有可显示的娃娃"
+
+#: src/components/ui/Pagination.tsx
+msgid "表示件数"
+msgstr "每页显示数"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/lib/i18n-labels.ts


### PR DESCRIPTION
## Summary

- 服一覧 (`/garments`) とドール一覧 (`/dolls`) に**クライアント側ペジネーション**を追加（デフォルト20件/ページ、20/50/100から選択可能）
- 汎用 `usePagination` hook を新規作成し、フィルタ変更・ページサイズ変更時にページ1へ自動リセット
- レスポンシブ対応の `Pagination` UIコンポーネントを新規作成（モバイル: コンパクト表示、デスクトップ: ページ番号+省略記号）
- en/ko/zh の翻訳を追加
- hook ユニットテスト（11件）+ UIインテグレーションテスト（10件）を追加

## Test plan

- [ ] `pnpm precheck` 通過確認済み
- [ ] 服一覧・ドール一覧でページ遷移が正しく動作すること
- [ ] フィルタ変更時にページが1にリセットされること
- [ ] ページサイズ変更（20/50/100）が正しく動作すること
- [ ] モバイル表示でコンパクトなペジネーションが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)