### PR TITLE
refactor: 信頼度計算を ConfidenceInput 型で受ける形に変更 (#61)

### DIFF
--- a/src/lib/confidence.ts
+++ b/src/lib/confidence.ts
@@ -1,4 +1,4 @@
-import type { ConfidenceLabel, Garment } from "@/types";
+import type { ConfidenceLabel, GarmentStatus } from "@/types";
 import {
   CONFIDENCE_THRESHOLD,
   GARMENT_STATUS,
@@ -6,11 +6,22 @@ import {
   ORPHAN_CHECKOUT_THRESHOLD_DAYS,
 } from "@/lib/constants";
 
-export const getConfidence = (g: Garment): number =>
-  g.status === GARMENT_STATUS.STORED
+export type ConfidenceInput = {
+  readonly lastScannedAt: number;
+  readonly confidenceDecayDays: number;
+  readonly status: GarmentStatus;
+  readonly lastLocationVisitedAt?: number;
+  readonly locationStabilityScore?: number;
+};
+
+export const getConfidence = (input: ConfidenceInput): number =>
+  input.status === GARMENT_STATUS.STORED
     ? Math.max(
         0,
-        1 - (Date.now() - g.lastScannedAt) / MS_PER_DAY / g.confidenceDecayDays,
+        1 -
+          (Date.now() - input.lastScannedAt) /
+            MS_PER_DAY /
+            input.confidenceDecayDays,
       )
     : 0;
 
@@ -21,10 +32,12 @@ export const getConfidenceLabel = (c: number): ConfidenceLabel =>
       ? "uncertain"
       : "unknown";
 
-export const getItemsNeedingReview = (
-  garments: readonly Garment[],
+export const getItemsNeedingReview = <
+  T extends ConfidenceInput & { readonly locationId: string | undefined },
+>(
+  garments: readonly T[],
   locationId: string,
-): readonly Garment[] =>
+): readonly T[] =>
   garments.filter(
     (g) =>
       g.locationId === locationId &&
@@ -35,10 +48,15 @@ export const getItemsNeedingReview = (
 export const getElapsedDays = (lastScannedAt: number): number =>
   Math.floor((Date.now() - lastScannedAt) / MS_PER_DAY);
 
-export const getOrphanedCheckouts = (
-  garments: readonly Garment[],
+export const getOrphanedCheckouts = <
+  T extends {
+    readonly status: GarmentStatus;
+    readonly checkedOutAt: number | undefined;
+  },
+>(
+  garments: readonly T[],
   thresholdDays: number = ORPHAN_CHECKOUT_THRESHOLD_DAYS,
-): readonly Garment[] =>
+): readonly T[] =>
   garments.filter(
     (g) =>
       g.status === GARMENT_STATUS.CHECKED_OUT &&


### PR DESCRIPTION
## Summary

- Phase 0 の土台整備として `getConfidence` の入力を `Garment` から専用の `ConfidenceInput` 型に分離
- `getItemsNeedingReview` / `getOrphanedCheckouts` もジェネリクスで入力要素型を保存するリファクタ
- Phase 1 で追加される場所情報（`lastLocationVisitedAt` / `locationStabilityScore`）を optional で予約

## 変更

`src/lib/confidence.ts` のみ。`Garment` は構造的に `ConfidenceInput` を満たすため、全呼び出し元・テストは変更なしで動作。

## 受け入れ条件

- [x] `ConfidenceInput` 型が定義されている
- [x] 既存の全呼び出し元が新インターフェースに移行済み（構造的部分型で吸収）
- [x] 既存ユニットテストが変更なしで通る（15 ケース pass）
- [x] `getItemsNeedingReview`, `getOrphanedCheckouts` も同様にリファクタ

## Test plan

- [x] `pnpm test src/lib/confidence.test.ts` — 15 tests pass
- [x] `pnpm test` — 564 tests / 57 files pass
- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm lint` — 0 warnings / 0 errors
- [x] `pnpm i18n:check` — pass

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)