### PR TITLE
feat: 場所訪問による暗黙的信頼度回復 (Phase 1 B-1)

### DIFF
--- a/e2e/fixtures/factories.ts
+++ b/e2e/fixtures/factories.ts
@@ -72,6 +72,7 @@ export const createStorageLocation = (
   description: undefined,
   row: 0,
   col: 0,
+  lastVisitedAt: undefined,
   createdAt: FIXED_NOW,
   ...overrides,
 });

--- a/src/app/garments/page.tsx
+++ b/src/app/garments/page.tsx
@@ -10,6 +10,7 @@ import { msg, t } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 import { activeGarmentsAtom, garmentsAtom } from "@/stores/garmentAtoms";
 import { dollsAtom, selectedDollIdAtom } from "@/stores/dollAtoms";
+import { storageLocationsAtom } from "@/stores/locationAtoms";
 import { pendingArchivesAtom } from "@/stores/pendingArchiveAtoms";
 import { canDollWear } from "@/lib/doll-compatibility";
 import { getConfidence, getConfidenceLabel } from "@/lib/confidence";
@@ -53,14 +54,26 @@ const CATEGORY_FILTERS = [
   })),
 ];
 
-const GARMENT_COMPARATORS = Object.freeze({
-  newest: (a: Garment, b: Garment) => b.createdAt - a.createdAt,
-  oldest: (a: Garment, b: Garment) => a.createdAt - b.createdAt,
-  confidence_asc: (a: Garment, b: Garment) =>
-    getConfidence(a) - getConfidence(b),
-  confidence_desc: (a: Garment, b: Garment) =>
-    getConfidence(b) - getConfidence(a),
-} satisfies Record<SortOptionValue, (a: Garment, b: Garment) => number>);
+type GarmentComparator = (a: Garment, b: Garment) => number;
+
+const buildGarmentComparators = (
+  visitedAtById: ReadonlyMap<string, number | undefined>,
+): Record<SortOptionValue, GarmentComparator> => {
+  const confidenceOf = (g: Garment) =>
+    getConfidence({
+      ...g,
+      lastLocationVisitedAt:
+        g.locationId !== undefined
+          ? visitedAtById.get(g.locationId)
+          : undefined,
+    });
+  return {
+    newest: (a, b) => b.createdAt - a.createdAt,
+    oldest: (a, b) => a.createdAt - b.createdAt,
+    confidence_asc: (a, b) => confidenceOf(a) - confidenceOf(b),
+    confidence_desc: (a, b) => confidenceOf(b) - confidenceOf(a),
+  };
+};
 
 type FilterPanelProps = {
   readonly isOpen: boolean;
@@ -143,6 +156,7 @@ const matchesGarmentFilter = ({
   confidenceFilter,
   dollSizeFilter,
   selectedDoll,
+  visitedAtById,
 }: {
   readonly garment: Garment;
   readonly query: string;
@@ -152,15 +166,21 @@ const matchesGarmentFilter = ({
   readonly selectedDoll:
     | { readonly bodySize: Garment["dollSizes"][number] }
     | undefined;
+  readonly visitedAtById: ReadonlyMap<string, number | undefined>;
 }): boolean => {
   const matchesCategory =
     activeCategory === "all" || garment.category === activeCategory;
   const nameMatches = garment.name.toLowerCase().includes(query);
   const tagMatches = garment.tags.some((t) => t.toLowerCase().includes(query));
   const matchesSearch = [query === "", nameMatches, tagMatches].some(Boolean);
+  const lastLocationVisitedAt =
+    garment.locationId !== undefined
+      ? visitedAtById.get(garment.locationId)
+      : undefined;
   const matchesConfidence =
     confidenceFilter === "all" ||
-    getConfidenceLabel(getConfidence(garment)) === confidenceFilter;
+    getConfidenceLabel(getConfidence({ ...garment, lastLocationVisitedAt })) ===
+      confidenceFilter;
   const matchesDollSize =
     dollSizeFilter === "all" || garment.dollSizes.includes(dollSizeFilter);
   const matchesDoll =
@@ -184,8 +204,17 @@ const GarmentListContent = () => {
   const allGarments = useAtomValue(garmentsAtom);
   const activeGarments = useAtomValue(activeGarmentsAtom);
   const dolls = useAtomValue(dollsAtom);
+  const locations = useAtomValue(storageLocationsAtom);
   const pendingArchives = useAtomValue(pendingArchivesAtom);
   const [selectedDollId, setSelectedDollId] = useAtom(selectedDollIdAtom);
+  const visitedAtById = useMemo(
+    () => new Map(locations.map((l) => [l.id, l.lastVisitedAt])),
+    [locations],
+  );
+  const comparators = useMemo(
+    () => buildGarmentComparators(visitedAtById),
+    [visitedAtById],
+  );
 
   const garments = useMemo(() => {
     const pendingGarmentIds = new Set(
@@ -229,10 +258,11 @@ const GarmentListContent = () => {
         confidenceFilter,
         dollSizeFilter,
         selectedDoll,
+        visitedAtById,
       }),
     );
 
-    return [...filtered].sort(GARMENT_COMPARATORS[sortOption]);
+    return [...filtered].sort(comparators[sortOption]);
   }, [
     garments,
     searchQuery,
@@ -241,6 +271,8 @@ const GarmentListContent = () => {
     dollSizeFilter,
     sortOption,
     selectedDoll,
+    visitedAtById,
+    comparators,
   ]);
 
   const {

--- a/src/app/locations/[caseId]/page.tsx
+++ b/src/app/locations/[caseId]/page.tsx
@@ -47,13 +47,22 @@ const CaseDetailContent = () => {
 
   const caseLocations = locations.filter((l) => l.caseId === storageCase.id);
   const locationIds = new Set(caseLocations.map((l) => l.id));
+  const visitedAtById = new Map(
+    caseLocations.map((l) => [l.id, l.lastVisitedAt]),
+  );
   const caseGarments = garments.filter(
     (g) => g.locationId !== undefined && locationIds.has(g.locationId),
   );
   const needsReviewCount = caseGarments.filter(
     (g) =>
       g.status === GARMENT_STATUS.STORED &&
-      getConfidence(g) < CONFIDENCE_THRESHOLD.CONFIRMED,
+      getConfidence({
+        ...g,
+        lastLocationVisitedAt:
+          g.locationId !== undefined
+            ? visitedAtById.get(g.locationId)
+            : undefined,
+      }) < CONFIDENCE_THRESHOLD.CONFIRMED,
   ).length;
 
   const isUnit = storageCase.type === STORAGE_CASE_TYPE.UNIT;

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -127,7 +127,8 @@ const ScanPage = () => {
   const handleReviewConfirmPartial = async (
     confirmations: readonly ScanConfirmation[],
   ) => {
-    await confirmPartial(confirmations);
+    if (activeLocationId === undefined) return;
+    await confirmPartial({ locationId: activeLocationId, confirmations });
     setReviewDialogOpen(false);
   };
 

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -63,7 +63,11 @@ const ScanPage = () => {
           subtitle: i18n._(msg`場所を設定しました`),
         });
 
-        const needsReview = getItemsNeedingReview(garments, locationId);
+        const needsReview = getItemsNeedingReview(
+          garments,
+          locationId,
+          loc?.lastVisitedAt,
+        );
         if (needsReview.length > 0) {
           setReviewDialogOpen(true);
         }
@@ -107,7 +111,11 @@ const ScanPage = () => {
 
   const itemsNeedingReview =
     activeLocationId !== undefined
-      ? getItemsNeedingReview(garments, activeLocationId)
+      ? getItemsNeedingReview(
+          garments,
+          activeLocationId,
+          activeLocation?.lastVisitedAt,
+        )
       : [];
 
   const handleReviewConfirmAll = async () => {
@@ -166,6 +174,7 @@ const ScanPage = () => {
         isOpen={reviewDialogOpen}
         onClose={handleReviewClose}
         itemsNeedingReview={itemsNeedingReview}
+        lastLocationVisitedAt={activeLocation?.lastVisitedAt}
         onConfirmAll={handleReviewConfirmAll}
         onConfirmPartial={handleReviewConfirmPartial}
       />

--- a/src/components/confidence/ConfidenceIndicator.tsx
+++ b/src/components/confidence/ConfidenceIndicator.tsx
@@ -10,11 +10,16 @@ import ConfidenceBar from "@/components/confidence/ConfidenceBar";
 
 type Props = {
   readonly garment: Garment;
+  readonly lastLocationVisitedAt?: number;
   readonly compact?: boolean;
 };
 
-const ConfidenceIndicator = ({ garment, compact = false }: Props) => {
-  const confidence = getConfidence(garment);
+const ConfidenceIndicator = ({
+  garment,
+  lastLocationVisitedAt,
+  compact = false,
+}: Props) => {
+  const confidence = getConfidence({ ...garment, lastLocationVisitedAt });
   const label = getConfidenceLabel(confidence);
   const locale = useAtomValue(localeAtom);
 

--- a/src/components/confidence/ConfidenceStats.tsx
+++ b/src/components/confidence/ConfidenceStats.tsx
@@ -3,9 +3,11 @@
 import { msg } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react";
+import { useAtomValue } from "jotai";
 import Card from "@/components/ui/Card";
 import type { Garment } from "@/types";
 import { getConfidence, getConfidenceLabel } from "@/lib/confidence";
+import { storageLocationsAtom } from "@/stores/locationAtoms";
 
 type Props = {
   readonly garments: readonly Garment[];
@@ -13,10 +15,18 @@ type Props = {
 
 const ConfidenceStats = ({ garments }: Props) => {
   const { i18n } = useLingui();
+  const locations = useAtomValue(storageLocationsAtom);
+  const visitedAtById = new Map(locations.map((l) => [l.id, l.lastVisitedAt]));
   const stored = garments.filter((g) => g.status === "stored");
   const counts = stored.reduce(
     (acc, g) => {
-      const label = getConfidenceLabel(getConfidence(g));
+      const lastLocationVisitedAt =
+        g.locationId !== undefined
+          ? visitedAtById.get(g.locationId)
+          : undefined;
+      const label = getConfidenceLabel(
+        getConfidence({ ...g, lastLocationVisitedAt }),
+      );
       return { ...acc, [label]: acc[label] + 1 };
     },
     { confirmed: 0, uncertain: 0, unknown: 0 },

--- a/src/components/dashboard/RecentItems.tsx
+++ b/src/components/dashboard/RecentItems.tsx
@@ -6,6 +6,7 @@ import { Shirt } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react";
 import { activeGarmentsAtom } from "@/stores/garmentAtoms";
+import { storageLocationsAtom } from "@/stores/locationAtoms";
 import { getConfidence, getConfidenceLabel } from "@/lib/confidence";
 import { GARMENT_CATEGORY_LABEL } from "@/lib/i18n-labels";
 import ConfidenceBadge from "@/components/confidence/ConfidenceBadge";
@@ -15,8 +16,10 @@ const RECENT_COUNT = 8;
 
 const RecentItems = () => {
   const garments = useAtomValue(activeGarmentsAtom);
+  const locations = useAtomValue(storageLocationsAtom);
   const { i18n } = useLingui();
 
+  const visitedAtById = new Map(locations.map((l) => [l.id, l.lastVisitedAt]));
   const recentGarments = [...garments]
     .sort((a, b) => b.lastScannedAt - a.lastScannedAt)
     .slice(0, RECENT_COUNT);
@@ -40,7 +43,14 @@ const RecentItems = () => {
       </div>
       <div className="-mx-4 flex gap-3 overflow-x-auto px-4 pb-2 [scroll-snap-type:x_mandatory] lg:mx-0 lg:grid lg:grid-cols-4 lg:overflow-visible lg:px-0">
         {recentGarments.map((garment) => {
-          const confidence = getConfidence(garment);
+          const lastLocationVisitedAt =
+            garment.locationId !== undefined
+              ? visitedAtById.get(garment.locationId)
+              : undefined;
+          const confidence = getConfidence({
+            ...garment,
+            lastLocationVisitedAt,
+          });
           const label = getConfidenceLabel(confidence);
 
           return (

--- a/src/components/garment/GarmentCard.tsx
+++ b/src/components/garment/GarmentCard.tsx
@@ -5,8 +5,10 @@ import { Shirt } from "lucide-react";
 import clsx from "clsx";
 import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react";
+import { useAtomValue } from "jotai";
 import type { Garment } from "@/types";
 import { GARMENT_CATEGORY_LABEL, DOLL_SIZE_LABEL } from "@/lib/i18n-labels";
+import { storageLocationsAtom } from "@/stores/locationAtoms";
 import ConfidenceIndicator from "@/components/confidence/ConfidenceIndicator";
 import Card from "@/components/ui/Card";
 
@@ -16,6 +18,11 @@ type Props = {
 
 const GarmentCard = ({ garment }: Props) => {
   const { i18n } = useLingui();
+  const locations = useAtomValue(storageLocationsAtom);
+  const lastLocationVisitedAt =
+    garment.locationId !== undefined
+      ? locations.find((l) => l.id === garment.locationId)?.lastVisitedAt
+      : undefined;
   const isCheckedOut = garment.status === "checked_out";
 
   return (
@@ -57,7 +64,11 @@ const GarmentCard = ({ garment }: Props) => {
           </p>
         )}
         <div className="mt-2">
-          <ConfidenceIndicator garment={garment} compact />
+          <ConfidenceIndicator
+            garment={garment}
+            lastLocationVisitedAt={lastLocationVisitedAt}
+            compact
+          />
         </div>
       </Card>
     </Link>

--- a/src/components/garment/GarmentDetail.tsx
+++ b/src/components/garment/GarmentDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { Shirt, Archive, RotateCcw, Trash2, Edit3, QrCode } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
@@ -15,6 +15,7 @@ import {
   GARMENT_STATUS_LABEL,
 } from "@/lib/i18n-labels";
 import { deleteGarmentAtom, restoreGarmentAtom } from "@/stores/garmentAtoms";
+import { storageLocationsAtom } from "@/stores/locationAtoms";
 import { requestArchiveAtom } from "@/stores/pendingArchiveAtoms";
 import ConfidenceIndicator from "@/components/confidence/ConfidenceIndicator";
 import GarmentLocationRow from "@/components/garment/GarmentLocationRow";
@@ -27,12 +28,22 @@ type Props = {
   readonly garment: Garment;
 };
 
+const useLastLocationVisitedAt = (
+  locationId: string | undefined,
+): number | undefined => {
+  const locations = useAtomValue(storageLocationsAtom);
+  return locationId === undefined
+    ? undefined
+    : locations.find((l) => l.id === locationId)?.lastVisitedAt;
+};
+
 const GarmentDetail = ({ garment }: Props) => {
   const { i18n } = useLingui();
   const router = useRouter();
   const deleteGarment = useSetAtom(deleteGarmentAtom);
   const restoreGarment = useSetAtom(restoreGarmentAtom);
   const requestArchive = useSetAtom(requestArchiveAtom);
+  const lastLocationVisitedAt = useLastLocationVisitedAt(garment.locationId);
   const [isArchiveConfirmOpen, setIsArchiveConfirmOpen] = useState(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const isArchived = garment.archivedAt !== undefined;
@@ -84,7 +95,11 @@ const GarmentDetail = ({ garment }: Props) => {
               </p>
             )}
           </div>
-          <ConfidenceIndicator garment={garment} compact />
+          <ConfidenceIndicator
+            garment={garment}
+            lastLocationVisitedAt={lastLocationVisitedAt}
+            compact
+          />
         </div>
 
         <Card>
@@ -105,7 +120,10 @@ const GarmentDetail = ({ garment }: Props) => {
                 {i18n._(GARMENT_STATUS_LABEL[garment.status])}
               </Badge>
             </div>
-            <ConfidenceIndicator garment={garment} />
+            <ConfidenceIndicator
+              garment={garment}
+              lastLocationVisitedAt={lastLocationVisitedAt}
+            />
           </div>
         </Card>
 

--- a/src/components/garment/GarmentList.tsx
+++ b/src/components/garment/GarmentList.tsx
@@ -4,8 +4,10 @@ import Link from "next/link";
 import { Shirt } from "lucide-react";
 import clsx from "clsx";
 import { useLingui } from "@lingui/react";
+import { useAtomValue } from "jotai";
 import type { Garment } from "@/types";
 import { GARMENT_CATEGORY_LABEL, DOLL_SIZE_LABEL } from "@/lib/i18n-labels";
+import { storageLocationsAtom } from "@/stores/locationAtoms";
 import ConfidenceIndicator from "@/components/confidence/ConfidenceIndicator";
 
 type Props = {
@@ -14,6 +16,8 @@ type Props = {
 
 const GarmentList = ({ garments }: Props) => {
   const { i18n } = useLingui();
+  const locations = useAtomValue(storageLocationsAtom);
+  const visitedAtById = new Map(locations.map((l) => [l.id, l.lastVisitedAt]));
 
   return (
     <div className="flex flex-col gap-2">
@@ -53,7 +57,15 @@ const GarmentList = ({ garments }: Props) => {
                 {garment.brand !== undefined && ` ・ ${garment.brand}`}
               </p>
             </div>
-            <ConfidenceIndicator garment={garment} compact />
+            <ConfidenceIndicator
+              garment={garment}
+              lastLocationVisitedAt={
+                garment.locationId !== undefined
+                  ? visitedAtById.get(garment.locationId)
+                  : undefined
+              }
+              compact
+            />
           </div>
         </Link>
       ))}

--- a/src/components/location/StorageCaseCard.tsx
+++ b/src/components/location/StorageCaseCard.tsx
@@ -29,13 +29,20 @@ const StorageCaseCard = ({
   onDelete,
 }: Props) => {
   const locationIds = new Set(locations.map((l) => l.id));
+  const visitedAtById = new Map(locations.map((l) => [l.id, l.lastVisitedAt]));
   const caseGarments = garments.filter(
     (g) => g.locationId !== undefined && locationIds.has(g.locationId),
   );
   const needsReviewCount = caseGarments.filter(
     (g) =>
       g.status === GARMENT_STATUS.STORED &&
-      getConfidence(g) < CONFIDENCE_THRESHOLD.CONFIRMED,
+      getConfidence({
+        ...g,
+        lastLocationVisitedAt:
+          g.locationId !== undefined
+            ? visitedAtById.get(g.locationId)
+            : undefined,
+      }) < CONFIDENCE_THRESHOLD.CONFIRMED,
   ).length;
 
   const isUnit = storageCase.type === STORAGE_CASE_TYPE.UNIT;

--- a/src/components/location/StorageCell.tsx
+++ b/src/components/location/StorageCell.tsx
@@ -13,13 +13,16 @@ type Props = {
 
 const getWorstConfidence = (
   garments: readonly Garment[],
+  lastLocationVisitedAt: number | undefined,
 ): "confirmed" | "uncertain" | "unknown" | "empty" => {
   if (garments.length === 0) return "empty";
 
   const stored = garments.filter((g) => g.status === GARMENT_STATUS.STORED);
   if (stored.length === 0) return "empty";
 
-  const worstConfidence = Math.min(...stored.map((g) => getConfidence(g)));
+  const worstConfidence = Math.min(
+    ...stored.map((g) => getConfidence({ ...g, lastLocationVisitedAt })),
+  );
   return getConfidenceLabel(worstConfidence);
 };
 
@@ -31,7 +34,7 @@ const CELL_BG = {
 } as const;
 
 const StorageCell = ({ location, garments, onClick, isSelected }: Props) => {
-  const status = getWorstConfidence(garments);
+  const status = getWorstConfidence(garments, location.lastVisitedAt);
   const displayName = location.customName ?? location.label;
 
   return (

--- a/src/components/scan/OpportunisticReviewDialog.tsx
+++ b/src/components/scan/OpportunisticReviewDialog.tsx
@@ -16,6 +16,7 @@ type Props = {
   readonly isOpen: boolean;
   readonly onClose: () => void;
   readonly itemsNeedingReview: readonly Garment[];
+  readonly lastLocationVisitedAt?: number;
   readonly onConfirmAll: () => void;
   readonly onConfirmPartial: (
     confirmations: readonly ScanConfirmation[],
@@ -26,6 +27,7 @@ const OpportunisticReviewDialog = ({
   isOpen,
   onClose,
   itemsNeedingReview,
+  lastLocationVisitedAt,
   onConfirmAll,
   onConfirmPartial,
 }: Props) => {
@@ -73,6 +75,7 @@ const OpportunisticReviewDialog = ({
                 key={garment.id}
                 garment={garment}
                 mode="overview"
+                lastLocationVisitedAt={lastLocationVisitedAt}
               />
             ))}
           </div>
@@ -98,6 +101,7 @@ const OpportunisticReviewDialog = ({
                 key={garment.id}
                 garment={garment}
                 mode="individual"
+                lastLocationVisitedAt={lastLocationVisitedAt}
                 isConfirmed={confirmationMap.get(garment.id) ?? true}
                 onToggle={handleToggle}
               />

--- a/src/components/scan/ReviewItemRow.tsx
+++ b/src/components/scan/ReviewItemRow.tsx
@@ -12,12 +12,19 @@ type ReviewMode = "overview" | "individual";
 type Props = {
   readonly garment: Garment;
   readonly mode: ReviewMode;
+  readonly lastLocationVisitedAt?: number;
   readonly isConfirmed?: boolean;
   readonly onToggle?: (garmentId: string, confirmed: boolean) => void;
 };
 
-const ReviewItemRow = ({ garment, mode, isConfirmed, onToggle }: Props) => {
-  const confidence = getConfidence(garment);
+const ReviewItemRow = ({
+  garment,
+  mode,
+  lastLocationVisitedAt,
+  isConfirmed,
+  onToggle,
+}: Props) => {
+  const confidence = getConfidence({ ...garment, lastLocationVisitedAt });
   const label = getConfidenceLabel(confidence);
 
   return (

--- a/src/lib/confidence.test.ts
+++ b/src/lib/confidence.test.ts
@@ -71,6 +71,88 @@ describe("getConfidence", () => {
     const garment = createGarment({ status: "lost" });
     expect(getConfidence(garment)).toBe(0);
   });
+
+  describe("場所訪問ブースト", () => {
+    it("lastLocationVisitedAtがundefinedのとき従来と同じ結果を返す", () => {
+      const garment = createGarment({
+        lastScannedAt: Date.now() - 15 * MS_PER_DAY,
+        confidenceDecayDays: 30,
+      });
+      expect(getConfidence(garment)).toBeCloseTo(0.5, 1);
+    });
+
+    it("訪問が新しくかつ減衰期間内ならブーストが適用される", () => {
+      const now = Date.now();
+      const garment = createGarment({
+        lastScannedAt: now - 15 * MS_PER_DAY,
+        confidenceDecayDays: 30,
+      });
+      expect(
+        getConfidence({ ...garment, lastLocationVisitedAt: now }),
+      ).toBeCloseTo(0.75, 2);
+    });
+
+    it("訪問が3.5日前（減衰半ば）ならブースト0.125が加算される", () => {
+      const now = Date.now();
+      const garment = createGarment({
+        lastScannedAt: now - 15 * MS_PER_DAY,
+        confidenceDecayDays: 30,
+      });
+      expect(
+        getConfidence({
+          ...garment,
+          lastLocationVisitedAt: now - 3.5 * MS_PER_DAY,
+        }),
+      ).toBeCloseTo(0.625, 2);
+    });
+
+    it("訪問が7日より古ければブーストは0", () => {
+      const now = Date.now();
+      const garment = createGarment({
+        lastScannedAt: now - 15 * MS_PER_DAY,
+        confidenceDecayDays: 30,
+      });
+      expect(
+        getConfidence({
+          ...garment,
+          lastLocationVisitedAt: now - 8 * MS_PER_DAY,
+        }),
+      ).toBeCloseTo(0.5, 1);
+    });
+
+    it("ブーストを加算しても1.0を超えない", () => {
+      const now = Date.now();
+      const garment = createGarment({
+        lastScannedAt: now - 3 * MS_PER_DAY,
+        confidenceDecayDays: 30,
+      });
+      expect(getConfidence({ ...garment, lastLocationVisitedAt: now })).toBe(1);
+    });
+
+    it("訪問がスキャンと同じ時刻ならブースト0（<=判定）", () => {
+      const now = Date.now();
+      const garment = createGarment({
+        lastScannedAt: now - 15 * MS_PER_DAY,
+        confidenceDecayDays: 30,
+      });
+      expect(
+        getConfidence({
+          ...garment,
+          lastLocationVisitedAt: now - 15 * MS_PER_DAY,
+        }),
+      ).toBeCloseTo(0.5, 1);
+    });
+
+    it("checked_outステータスではブーストも無効", () => {
+      const now = Date.now();
+      const garment = createGarment({
+        status: "checked_out",
+        lastScannedAt: now - 15 * MS_PER_DAY,
+        confidenceDecayDays: 30,
+      });
+      expect(getConfidence({ ...garment, lastLocationVisitedAt: now })).toBe(0);
+    });
+  });
 });
 
 describe("getConfidenceLabel", () => {

--- a/src/lib/confidence.ts
+++ b/src/lib/confidence.ts
@@ -2,6 +2,8 @@ import type { ConfidenceLabel, GarmentStatus } from "@/types";
 import {
   CONFIDENCE_THRESHOLD,
   GARMENT_STATUS,
+  LOCATION_VISIT_BOOST_MAX,
+  LOCATION_VISIT_DECAY_DAYS,
   MS_PER_DAY,
   ORPHAN_CHECKOUT_THRESHOLD_DAYS,
 } from "@/lib/constants";
@@ -14,14 +16,32 @@ export type ConfidenceInput = {
   readonly locationStabilityScore?: number;
 };
 
+const getVisitBoost = (
+  lastScannedAt: number,
+  lastLocationVisitedAt: number | undefined,
+): number =>
+  lastLocationVisitedAt === undefined || lastLocationVisitedAt <= lastScannedAt
+    ? 0
+    : Math.max(
+        0,
+        LOCATION_VISIT_BOOST_MAX *
+          (1 -
+            (Date.now() - lastLocationVisitedAt) /
+              MS_PER_DAY /
+              LOCATION_VISIT_DECAY_DAYS),
+      );
+
 export const getConfidence = (input: ConfidenceInput): number =>
   input.status === GARMENT_STATUS.STORED
-    ? Math.max(
-        0,
-        1 -
-          (Date.now() - input.lastScannedAt) /
-            MS_PER_DAY /
-            input.confidenceDecayDays,
+    ? Math.min(
+        1,
+        Math.max(
+          0,
+          1 -
+            (Date.now() - input.lastScannedAt) /
+              MS_PER_DAY /
+              input.confidenceDecayDays,
+        ) + getVisitBoost(input.lastScannedAt, input.lastLocationVisitedAt),
       )
     : 0;
 
@@ -37,12 +57,14 @@ export const getItemsNeedingReview = <
 >(
   garments: readonly T[],
   locationId: string,
+  lastLocationVisitedAt?: number,
 ): readonly T[] =>
   garments.filter(
     (g) =>
       g.locationId === locationId &&
       g.status === GARMENT_STATUS.STORED &&
-      getConfidence(g) < CONFIDENCE_THRESHOLD.CONFIRMED,
+      getConfidence({ ...g, lastLocationVisitedAt }) <
+        CONFIDENCE_THRESHOLD.CONFIRMED,
   );
 
 export const getElapsedDays = (lastScannedAt: number): number =>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -31,6 +31,9 @@ export const SEASONAL_CONFIDENCE_DECAY_DAYS = 90;
 
 export const ORPHAN_CHECKOUT_THRESHOLD_DAYS = 3;
 
+export const LOCATION_VISIT_BOOST_MAX = 0.25;
+export const LOCATION_VISIT_DECAY_DAYS = 7;
+
 export const MS_PER_DAY = 86_400_000;
 
 export const SYNC_ACTION_TYPE = Object.freeze({

--- a/src/stores/garmentAtoms.ts
+++ b/src/stores/garmentAtoms.ts
@@ -51,6 +51,10 @@ export const confirmAllGarmentsAtom = atom(
     await getDb().garments.bulkPut(
       storedGarments.map((g) => ({ ...g, lastScannedAt: now, updatedAt: now })),
     );
+    await getDb()
+      .storageLocations.where("id")
+      .equals(locationId)
+      .modify({ lastVisitedAt: now });
     await getDb().syncQueue.bulkAdd(
       storedGarments.map((g) => ({
         type: SYNC_ACTION_TYPE.GARMENT_UPDATE,

--- a/src/stores/garmentAtoms.ts
+++ b/src/stores/garmentAtoms.ts
@@ -3,6 +3,7 @@ import { getDb } from "@/lib/db/dexie";
 import { GARMENT_STATUS, SYNC_ACTION_TYPE } from "@/lib/constants";
 import type { Garment, ScanConfirmation } from "@/types";
 import { createEntityAtoms, createRestoreAtom } from "./createEntityAtoms";
+import { refreshStorageLocationsAtom } from "./locationAtoms";
 
 const {
   dataAtom: garmentsAtom,
@@ -63,12 +64,21 @@ export const confirmAllGarmentsAtom = atom(
       })),
     );
     set(refreshGarmentsAtom);
+    set(refreshStorageLocationsAtom);
   },
 );
 
 export const confirmPartialGarmentsAtom = atom(
   undefined,
-  async (_get, _set, confirmations: readonly ScanConfirmation[]) => {
+  async (
+    _get,
+    set,
+    input: {
+      readonly locationId: string;
+      readonly confirmations: readonly ScanConfirmation[];
+    },
+  ) => {
+    const { locationId, confirmations } = input;
     const now = Date.now();
     const confirmedIds = confirmations
       .filter((c) => c.confirmed)
@@ -124,5 +134,12 @@ export const confirmPartialGarmentsAtom = atom(
         createdAt: now,
       })),
     );
+
+    await getDb()
+      .storageLocations.where("id")
+      .equals(locationId)
+      .modify({ lastVisitedAt: now });
+    set(refreshGarmentsAtom);
+    set(refreshStorageLocationsAtom);
   },
 );

--- a/src/stores/locationAtoms.ts
+++ b/src/stores/locationAtoms.ts
@@ -91,6 +91,7 @@ const buildLocations = ({
           description: undefined,
           row: 0,
           col: 0,
+          lastVisitedAt: undefined,
           createdAt: now,
         },
       ]
@@ -106,6 +107,7 @@ const buildLocations = ({
           description: undefined,
           row,
           col,
+          lastVisitedAt: undefined,
           createdAt: now,
         };
       });

--- a/src/stores/syncAtoms.ts
+++ b/src/stores/syncAtoms.ts
@@ -197,6 +197,7 @@ const pullServerState = async (): Promise<SyncResult> => {
       description: l.description ?? undefined,
       row: l.row,
       col: l.col,
+      lastVisitedAt: l.lastVisitedAt ?? undefined,
       createdAt: l.createdAt,
     }));
 

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -68,6 +68,7 @@ export const createTestStorageLocation = (
   description: undefined,
   row: 0,
   col: 0,
+  lastVisitedAt: undefined,
   createdAt: FIXED_NOW,
   ...overrides,
 });

--- a/src/test/helpers/seedDb.ts
+++ b/src/test/helpers/seedDb.ts
@@ -57,6 +57,7 @@ const toStorageLocation = (
   description: undefined,
   row: raw.row,
   col: raw.col,
+  lastVisitedAt: undefined,
   createdAt: raw.createdAt,
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,6 +78,7 @@ export type StorageLocation = {
   readonly description: string | undefined;
   readonly row: number;
   readonly col: number;
+  readonly lastVisitedAt: number | undefined;
   readonly createdAt: number;
 };
 

--- a/workers/src/repositories/location-repository.ts
+++ b/workers/src/repositories/location-repository.ts
@@ -35,6 +35,7 @@ const toStorageLocation = (
   description: row.description ?? undefined,
   row: row.row,
   col: row.col,
+  lastVisitedAt: row.lastVisitedAt ?? undefined,
   createdAt: row.createdAt,
 });
 
@@ -348,6 +349,25 @@ export const updateLocation = async ({
       customName: customName ?? null,
       description: description ?? null,
     })
+    .where(
+      and(eq(storageLocations.id, id), eq(storageLocations.userId, userId)),
+    );
+};
+
+export const updateLastVisitedAt = async ({
+  drizzleDb,
+  id,
+  userId,
+  visitedAt,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly id: string;
+  readonly userId: string;
+  readonly visitedAt: number;
+}): Promise<void> => {
+  await drizzleDb
+    .update(storageLocations)
+    .set({ lastVisitedAt: visitedAt })
     .where(
       and(eq(storageLocations.id, id), eq(storageLocations.userId, userId)),
     );

--- a/workers/src/services/digest-service.ts
+++ b/workers/src/services/digest-service.ts
@@ -9,6 +9,7 @@ import { createId } from "@paralleldrive/cuid2";
 import type { Logger } from "../lib/logger";
 import type { DrizzleDB } from "../db/client";
 import * as garmentRepo from "../repositories/garment-repository";
+import * as locationRepo from "../repositories/location-repository";
 import * as digestRepo from "../repositories/digest-repository";
 import { type ServiceResult, serviceError, serviceOk } from "./types";
 
@@ -28,17 +29,33 @@ export const generateDigestForUser = async ({
     logger,
   });
 
+  const locations = await locationRepo.findLocationsByUserId({
+    drizzleDb,
+    userId,
+  });
+  const visitedAtByLocationId = new Map(
+    locations.map((l) => [l.id, l.lastVisitedAt]),
+  );
+  const getGarmentConfidence = (g: (typeof garments)[number]): number =>
+    getConfidence({
+      ...g,
+      lastLocationVisitedAt:
+        g.locationId !== undefined
+          ? visitedAtByLocationId.get(g.locationId)
+          : undefined,
+    });
+
   const unknownItems: readonly DigestUnknownItem[] = garments
     .filter((g) => {
       if (g.status !== GARMENT_STATUS.STORED) {
         return false;
       }
-      return getConfidence(g) < CONFIDENCE_THRESHOLD.UNCERTAIN;
+      return getGarmentConfidence(g) < CONFIDENCE_THRESHOLD.UNCERTAIN;
     })
     .map((g) => ({
       garmentId: g.id,
       garmentName: g.name,
-      confidence: getConfidence(g),
+      confidence: getGarmentConfidence(g),
     }));
 
   const orphanedGarments = getOrphanedCheckouts(

--- a/workers/src/services/scan-service.ts
+++ b/workers/src/services/scan-service.ts
@@ -1,5 +1,6 @@
 import { GARMENT_STATUS } from "@shared/lib/constants";
 import type { DrizzleDB } from "../db/client";
+import * as locationRepo from "../repositories/location-repository";
 import * as scanRepo from "../repositories/scan-repository";
 import { type ServiceResult, serviceError, serviceOk } from "./types";
 
@@ -29,6 +30,13 @@ export const checkin = async ({
       `${String(garmentIds.length - totalChanges)}件の服が見つかりませんでした`,
     );
   }
+
+  await locationRepo.updateLastVisitedAt({
+    drizzleDb,
+    id: locationId,
+    userId,
+    visitedAt: Date.now(),
+  });
 
   return serviceOk({ success: true, checkedInCount: totalChanges });
 };
@@ -70,6 +78,12 @@ export const confirmAll = async ({
     drizzleDb,
     userId,
     locationId,
+  });
+  await locationRepo.updateLastVisitedAt({
+    drizzleDb,
+    id: locationId,
+    userId,
+    visitedAt: Date.now(),
   });
   return serviceOk({ success: true, confirmedCount });
 };

--- a/workers/src/services/scan-service.ts
+++ b/workers/src/services/scan-service.ts
@@ -96,10 +96,12 @@ type Confirmation = {
 export const confirmPartial = async ({
   drizzleDb,
   userId,
+  locationId,
   confirmations,
 }: {
   readonly drizzleDb: DrizzleDB;
   readonly userId: string;
+  readonly locationId: string;
   readonly confirmations: readonly Confirmation[];
 }): Promise<
   ServiceResult<{
@@ -109,6 +111,12 @@ export const confirmPartial = async ({
   }>
 > => {
   await scanRepo.batchConfirmPartial({ drizzleDb, userId, confirmations });
+  await locationRepo.updateLastVisitedAt({
+    drizzleDb,
+    id: locationId,
+    userId,
+    visitedAt: Date.now(),
+  });
 
   const confirmedCount = confirmations.filter((c) => c.confirmed).length;
   const deniedCount = confirmations.length - confirmedCount;

--- a/workers/src/test/cross-router.scenario.test.ts
+++ b/workers/src/test/cross-router.scenario.test.ts
@@ -131,6 +131,7 @@ describe("ルーター横断シナリオ", () => {
     });
 
     await caller.scan.confirmPartial({
+      locationId,
       confirmations: [
         { garmentId: garment1.id, confirmed: true },
         { garmentId: garment2.id, confirmed: false },

--- a/workers/src/test/scan-workflow.scenario.test.ts
+++ b/workers/src/test/scan-workflow.scenario.test.ts
@@ -194,6 +194,7 @@ describe("スキャン操作シナリオ", () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       const result = await caller.scan.confirmPartial({
+        locationId,
         confirmations: [
           { garmentId: garment1.id, confirmed: true },
           { garmentId: garment2.id, confirmed: false },

--- a/workers/src/trpc/lib/schemas.ts
+++ b/workers/src/trpc/lib/schemas.ts
@@ -40,6 +40,7 @@ export const confirmAllInputSchema = z.object({
 });
 
 export const confirmPartialInputSchema = z.object({
+  locationId: cuidSchema,
   confirmations: z
     .array(
       z.object({

--- a/workers/src/trpc/routers/scan.test.ts
+++ b/workers/src/trpc/routers/scan.test.ts
@@ -103,6 +103,34 @@ describe("scanRouter", () => {
       const garment = await caller.garment.get({ id: garmentId });
       expect(garment.lastScannedAt).toBeGreaterThan(oldTimestamp);
     });
+
+    it("checkin で storage_locations.last_visited_at が更新される", async () => {
+      const { id: caseId } = await insertStorageCase({ db });
+      const { id: locId } = await insertStorageLocation({
+        db,
+        overrides: { caseId },
+      });
+      const { id: garmentId } = await insertGarment({
+        db,
+        overrides: { status: "checked_out" },
+      });
+
+      const before = Date.now();
+      await caller.scan.checkin({
+        locationId: locId,
+        garmentIds: [garmentId],
+      });
+      const after = Date.now();
+
+      const row = await db
+        .prepare("SELECT last_visited_at FROM storage_locations WHERE id = ?1")
+        .bind(locId)
+        .first<{ last_visited_at: number | null }>();
+      expect(row?.last_visited_at).not.toBeNull();
+      const visitedAt = row?.last_visited_at ?? 0;
+      expect(visitedAt).toBeGreaterThanOrEqual(before);
+      expect(visitedAt).toBeLessThanOrEqual(after);
+    });
   });
 
   describe("checkout", () => {
@@ -189,6 +217,31 @@ describe("scanRouter", () => {
       });
 
       expect(result.confirmedCount).toBe(1);
+    });
+
+    it("confirmAll で storage_locations.last_visited_at が更新される", async () => {
+      const { id: caseId } = await insertStorageCase({ db });
+      const { id: locId } = await insertStorageLocation({
+        db,
+        overrides: { caseId },
+      });
+      await insertGarment({
+        db,
+        overrides: { locationId: locId, status: "stored" },
+      });
+
+      const before = Date.now();
+      await caller.scan.confirmAll({ locationId: locId });
+      const after = Date.now();
+
+      const row = await db
+        .prepare("SELECT last_visited_at FROM storage_locations WHERE id = ?1")
+        .bind(locId)
+        .first<{ last_visited_at: number | null }>();
+      expect(row?.last_visited_at).not.toBeNull();
+      const visitedAt = row?.last_visited_at ?? 0;
+      expect(visitedAt).toBeGreaterThanOrEqual(before);
+      expect(visitedAt).toBeLessThanOrEqual(after);
     });
   });
 

--- a/workers/src/trpc/routers/scan.test.ts
+++ b/workers/src/trpc/routers/scan.test.ts
@@ -263,6 +263,7 @@ describe("scanRouter", () => {
       });
 
       const result = await caller.scan.confirmPartial({
+        locationId: locId,
         confirmations: [{ garmentId, confirmed: true }],
       });
 
@@ -285,6 +286,7 @@ describe("scanRouter", () => {
       });
 
       const result = await caller.scan.confirmPartial({
+        locationId: locId,
         confirmations: [{ garmentId, confirmed: false }],
       });
 
@@ -312,6 +314,7 @@ describe("scanRouter", () => {
       });
 
       const result = await caller.scan.confirmPartial({
+        locationId: locId,
         confirmations: [
           { garmentId: g1, confirmed: true },
           { garmentId: g2, confirmed: false },
@@ -326,6 +329,34 @@ describe("scanRouter", () => {
 
       const garment2 = await caller.garment.get({ id: g2 });
       expect(garment2.status).toBe("checked_out");
+    });
+
+    it("confirmPartial で storage_locations.last_visited_at が更新される", async () => {
+      const { id: caseId } = await insertStorageCase({ db });
+      const { id: locId } = await insertStorageLocation({
+        db,
+        overrides: { caseId },
+      });
+      const { id: garmentId } = await insertGarment({
+        db,
+        overrides: { locationId: locId, status: "stored" },
+      });
+
+      const before = Date.now();
+      await caller.scan.confirmPartial({
+        locationId: locId,
+        confirmations: [{ garmentId, confirmed: true }],
+      });
+      const after = Date.now();
+
+      const row = await db
+        .prepare("SELECT last_visited_at FROM storage_locations WHERE id = ?1")
+        .bind(locId)
+        .first<{ last_visited_at: number | null }>();
+      expect(row?.last_visited_at).not.toBeNull();
+      const visitedAt = row?.last_visited_at ?? 0;
+      expect(visitedAt).toBeGreaterThanOrEqual(before);
+      expect(visitedAt).toBeLessThanOrEqual(after);
     });
   });
 

--- a/workers/src/trpc/routers/scan.ts
+++ b/workers/src/trpc/routers/scan.ts
@@ -56,6 +56,7 @@ export const scanRouter = router({
         await scanService.confirmPartial({
           drizzleDb: createDrizzle(ctx.env.DB),
           userId: TEMP_USER_ID,
+          locationId: input.locationId,
           confirmations: input.confirmations,
         }),
       ),


### PR DESCRIPTION
## Summary

- 場所 QR スキャン時に `storage_locations.last_visited_at` を更新し、信頼度計算で訪問ブーストを適用
- 最大 +0.25 のブーストを 7 日で線形減衰（`LOCATION_VISIT_BOOST_MAX`, `LOCATION_VISIT_DECAY_DAYS` を定数として追加）
- `scan.checkin` / `scan.confirmAll` で location の `last_visited_at` をサーバー側で更新
- digest-service で locationId から lastLocationVisitedAt を解決して渡す

Closes #63

## 変更内容

### 信頼度ロジック (`src/lib/confidence.ts`)
`getConfidence` にブースト計算を追加。`lastLocationVisitedAt > lastScannedAt` のとき、訪問からの経過日数に応じて最大 0.25 のブーストを加算（7 日で 0 に減衰）。

### バックエンド
- `location-repository.ts`: `updateLastVisitedAt` メソッドを追加、`toStorageLocation` に `lastVisitedAt` を含める
- `scan-service.ts`: `checkin` / `confirmAll` で `locationRepo.updateLastVisitedAt` を呼び出し
- `digest-service.ts`: 全 garment の locationId から location の `lastVisitedAt` を解決して `getConfidence` に渡す

### フロントエンド
- `StorageLocation` 型に `lastVisitedAt: number | undefined` を追加
- `confirmAllGarmentsAtom`: IndexedDB の `storageLocations.lastVisitedAt` を楽観的更新
- 信頼度の主要呼び出し箇所（スキャンページ、ケース詳細、服一覧、`StorageCell`、`StorageCaseCard`、`ReviewItemRow`、`ConfidenceIndicator`、`ConfidenceStats`、`RecentItems`）で `lastLocationVisitedAt` を渡すよう更新
- `getItemsNeedingReview` のシグネチャに optional な `lastLocationVisitedAt` を追加

## Test plan

- [x] `pnpm test` — 573 tests passing
- [x] `pnpm vitest run --project workers` — 150 tests passing (scan.test に last_visited_at 検証テスト 2 件追加)
- [x] `pnpm typecheck` — 通過
- [x] `pnpm lint` — 通過
- [x] `src/lib/confidence.test.ts` — 新規テスト 7 件追加（訪問ブーストの各挙動）
- [x] `workers/src/trpc/routers/scan.test.ts` — checkin / confirmAll で `last_visited_at` が更新されることを検証

## 受け入れ条件

- [x] 場所QRスキャン時に `last_visited_at` が更新される
- [x] 信頼度計算に訪問ブーストが反映される
- [x] ブーストの最大値が 0.25、減衰期間が 7 日
- [x] 定数が名前付き定数として定義されている (`src/lib/constants.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)