### PR TITLE
feat: チェックアウト時の「ついで確認」シート (C-2)

### DIFF
--- a/src/components/garment/GarmentLocationRow.tsx
+++ b/src/components/garment/GarmentLocationRow.tsx
@@ -4,22 +4,81 @@ import { useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { MapPin } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
-import type { Garment } from "@/types";
-import { GARMENT_STATUS } from "@/lib/constants";
-import { updateGarmentAtom } from "@/stores/garmentAtoms";
+import type { Garment, StorageLocation } from "@/types";
+import { GARMENT_STATUS, REVIEW_THRESHOLD_DEFAULT } from "@/lib/constants";
+import {
+  activeGarmentsAtom,
+  confirmAllGarmentsAtom,
+  updateGarmentAtom,
+} from "@/stores/garmentAtoms";
 import { storageCasesAtom, storageLocationsAtom } from "@/stores/locationAtoms";
+import {
+  getItemsNeedingReview,
+  getLocationStabilityScore,
+  getReviewThreshold,
+} from "@/lib/confidence";
 import Card from "@/components/ui/Card";
 import LocationPicker from "@/components/garment/LocationPicker";
+import CheckoutConfirmSheet from "@/components/scan/CheckoutConfirmSheet";
 
 type Props = {
   readonly garment: Garment;
 };
 
+type CheckoutSheetState = {
+  readonly locationId: string;
+  readonly uncertainItemCount: number;
+};
+
+const computeCheckoutSheetState = ({
+  prevLocationId,
+  excludeGarmentId,
+  allGarments,
+  locations,
+}: {
+  readonly prevLocationId: string;
+  readonly excludeGarmentId: string;
+  readonly allGarments: readonly Garment[];
+  readonly locations: readonly StorageLocation[];
+}): CheckoutSheetState | undefined => {
+  const prevLocation = locations.find((l) => l.id === prevLocationId);
+  const otherItems = allGarments.filter(
+    (g) =>
+      g.id !== excludeGarmentId &&
+      g.locationId === prevLocationId &&
+      g.status === GARMENT_STATUS.STORED,
+  );
+  const threshold =
+    prevLocation !== undefined
+      ? getReviewThreshold(
+          getLocationStabilityScore({
+            confirmAllCount: prevLocation.confirmAllCount,
+            correctionCount: prevLocation.correctionCount,
+          }),
+        )
+      : REVIEW_THRESHOLD_DEFAULT;
+  const needsReview = getItemsNeedingReview(otherItems, prevLocationId, {
+    threshold,
+    lastLocationVisitedAt: prevLocation?.lastVisitedAt,
+  });
+  return needsReview.length === 0
+    ? undefined
+    : {
+        locationId: prevLocationId,
+        uncertainItemCount: needsReview.length,
+      };
+};
+
 const GarmentLocationRow = ({ garment }: Props) => {
   const updateGarment = useSetAtom(updateGarmentAtom);
+  const confirmAll = useSetAtom(confirmAllGarmentsAtom);
   const cases = useAtomValue(storageCasesAtom);
   const locations = useAtomValue(storageLocationsAtom);
+  const allGarments = useAtomValue(activeGarmentsAtom);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [checkoutSheet, setCheckoutSheet] = useState<
+    CheckoutSheetState | undefined
+  >(undefined);
 
   const currentLocation =
     garment.locationId !== undefined
@@ -36,6 +95,12 @@ const GarmentLocationRow = ({ garment }: Props) => {
 
   const handleLocationChange = async (locationId: string | undefined) => {
     const now = Date.now();
+    const prevLocationId = garment.locationId;
+    const isCheckout =
+      garment.status === GARMENT_STATUS.STORED &&
+      locationId === undefined &&
+      prevLocationId !== undefined;
+
     await updateGarment({
       ...garment,
       locationId,
@@ -48,6 +113,27 @@ const GarmentLocationRow = ({ garment }: Props) => {
       updatedAt: now,
     });
     setIsPickerOpen(false);
+
+    if (isCheckout && prevLocationId !== undefined) {
+      const nextSheet = computeCheckoutSheetState({
+        prevLocationId,
+        excludeGarmentId: garment.id,
+        allGarments,
+        locations,
+      });
+      if (nextSheet !== undefined) {
+        setCheckoutSheet(nextSheet);
+      }
+    }
+  };
+
+  const handleConfirmAll = async () => {
+    if (checkoutSheet === undefined) return;
+    await confirmAll(checkoutSheet.locationId);
+  };
+
+  const handleSheetClose = () => {
+    setCheckoutSheet(undefined);
   };
 
   return (
@@ -82,6 +168,13 @@ const GarmentLocationRow = ({ garment }: Props) => {
         onClose={() => setIsPickerOpen(false)}
         onSelect={handleLocationChange}
         currentLocationId={garment.locationId}
+      />
+
+      <CheckoutConfirmSheet
+        isOpen={checkoutSheet !== undefined}
+        onClose={handleSheetClose}
+        uncertainItemCount={checkoutSheet?.uncertainItemCount ?? 0}
+        onConfirmAll={handleConfirmAll}
       />
     </>
   );

--- a/src/components/scan/CheckoutConfirmSheet.test.tsx
+++ b/src/components/scan/CheckoutConfirmSheet.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "@/test/testUtils";
+import CheckoutConfirmSheet from "./CheckoutConfirmSheet";
+
+describe("CheckoutConfirmSheet", () => {
+  const mockOnClose = vi.fn();
+  const mockOnConfirmAll = vi.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+    mockOnConfirmAll.mockClear();
+  });
+
+  it("isOpen=false の場合は何も表示されない", async () => {
+    await renderWithProviders(
+      <CheckoutConfirmSheet
+        isOpen={false}
+        onClose={mockOnClose}
+        uncertainItemCount={3}
+        onConfirmAll={mockOnConfirmAll}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "全部ある" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "スキップ" })).toBeNull();
+  });
+
+  it("isOpen=true でタイトルと未確認件数、ボタンが表示される", async () => {
+    await renderWithProviders(
+      <CheckoutConfirmSheet
+        isOpen
+        onClose={mockOnClose}
+        uncertainItemCount={3}
+        onConfirmAll={mockOnConfirmAll}
+      />,
+    );
+
+    expect(
+      screen.getByText("この引き出しの他の服、まだありますか？"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/3 件が最後のスキャンから時間が経っています/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "全部ある" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "スキップ" }),
+    ).toBeInTheDocument();
+  });
+
+  it("「全部ある」ボタンで onConfirmAll と onClose が呼ばれる", async () => {
+    await renderWithProviders(
+      <CheckoutConfirmSheet
+        isOpen
+        onClose={mockOnClose}
+        uncertainItemCount={2}
+        onConfirmAll={mockOnConfirmAll}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "全部ある" }));
+
+    expect(mockOnConfirmAll).toHaveBeenCalledOnce();
+    expect(mockOnClose).toHaveBeenCalledOnce();
+  });
+
+  it("「スキップ」ボタンで onClose のみが呼ばれる", async () => {
+    await renderWithProviders(
+      <CheckoutConfirmSheet
+        isOpen
+        onClose={mockOnClose}
+        uncertainItemCount={2}
+        onConfirmAll={mockOnConfirmAll}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "スキップ" }));
+
+    expect(mockOnClose).toHaveBeenCalledOnce();
+    expect(mockOnConfirmAll).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/scan/CheckoutConfirmSheet.tsx
+++ b/src/components/scan/CheckoutConfirmSheet.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import { msg } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import BottomSheet from "@/components/ui/BottomSheet";
+import Button from "@/components/ui/Button";
+
+type Props = {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly uncertainItemCount: number;
+  readonly onConfirmAll: () => void;
+};
+
+const CheckoutConfirmSheet = ({
+  isOpen,
+  onClose,
+  uncertainItemCount,
+  onConfirmAll,
+}: Props) => {
+  const { i18n } = useLingui();
+  const title = i18n._(msg`この引き出しの他の服、まだありますか？`);
+  const description = i18n._(
+    msg`${uncertainItemCount} 件が最後のスキャンから時間が経っています`,
+  );
+
+  const handleConfirmAll = () => {
+    onConfirmAll();
+    onClose();
+  };
+
+  return (
+    <BottomSheet isOpen={isOpen} onClose={onClose} title={title}>
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-text-secondary">{description}</p>
+        <div className="flex flex-col gap-2">
+          <Button variant="primary" fullWidth onClick={handleConfirmAll}>
+            <Trans>全部ある</Trans>
+          </Button>
+          <Button variant="ghost" fullWidth onClick={onClose}>
+            <Trans>スキップ</Trans>
+          </Button>
+        </div>
+      </div>
+    </BottomSheet>
+  );
+};
+
+export default CheckoutConfirmSheet;

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -106,6 +106,10 @@ msgstr "{needsReviewCount} items need review"
 msgid "{size}件表示"
 msgstr "Show {size}"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "{uncertainItemCount} 件が最後のスキャンから時間が経っています"
+msgstr "{uncertainItemCount} items haven't been scanned in a while"
+
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件 有効"
 msgstr "{validCount} valid"
@@ -420,6 +424,10 @@ msgstr "No garments in this location"
 msgid "この場所の全服を確認済みにする"
 msgstr "Mark all garments in this location as confirmed"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "この引き出しの他の服、まだありますか？"
+msgstr "Are all the other clothes in this drawer still there?"
+
 #: src/app/garments/page.tsx
 #: src/components/dashboard/WardrobeAnalytics.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
@@ -446,6 +454,10 @@ msgstr "Put away"
 #: src/lib/i18n-labels.ts
 msgid "シューズ"
 msgstr "Shoes"
+
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "スキップ"
+msgstr "Skip"
 
 #: src/app/scan/page.tsx
 #: src/lib/nav-items.ts
@@ -840,6 +852,7 @@ msgstr "Please create a storage location first"
 msgid "全ドール"
 msgstr "All dolls"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
 msgstr "All present"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -106,6 +106,10 @@ msgstr "{needsReviewCount}着 要確認"
 msgid "{size}件表示"
 msgstr "{size}件表示"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "{uncertainItemCount} 件が最後のスキャンから時間が経っています"
+msgstr "{uncertainItemCount} 件が最後のスキャンから時間が経っています"
+
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件 有効"
 msgstr "{validCount}件 有効"
@@ -420,6 +424,10 @@ msgstr "この場所には服がありません"
 msgid "この場所の全服を確認済みにする"
 msgstr "この場所の全服を確認済みにする"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "この引き出しの他の服、まだありますか？"
+msgstr "この引き出しの他の服、まだありますか？"
+
 #: src/app/garments/page.tsx
 #: src/components/dashboard/WardrobeAnalytics.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
@@ -446,6 +454,10 @@ msgstr "しまった"
 #: src/lib/i18n-labels.ts
 msgid "シューズ"
 msgstr "シューズ"
+
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "スキップ"
+msgstr "スキップ"
 
 #: src/app/scan/page.tsx
 #: src/lib/nav-items.ts
@@ -840,6 +852,7 @@ msgstr "先に収納場所を作成してください"
 msgid "全ドール"
 msgstr "全ドール"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
 msgstr "全部ある"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -106,6 +106,10 @@ msgstr "{needsReviewCount}벌 확인 필요"
 msgid "{size}件表示"
 msgstr "{size}건 표시"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "{uncertainItemCount} 件が最後のスキャンから時間が経っています"
+msgstr "{uncertainItemCount}개 아이템이 마지막 스캔 이후 시간이 지났습니다"
+
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件 有効"
 msgstr "{validCount}건 유효"
@@ -420,6 +424,10 @@ msgstr "이 장소에 의류가 없습니다"
 msgid "この場所の全服を確認済みにする"
 msgstr "이 장소의 모든 옷을 확인 완료로 표시"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "この引き出しの他の服、まだありますか？"
+msgstr "이 서랍의 다른 옷들, 아직 있나요?"
+
 #: src/app/garments/page.tsx
 #: src/components/dashboard/WardrobeAnalytics.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
@@ -446,6 +454,10 @@ msgstr "넣어뒀음"
 #: src/lib/i18n-labels.ts
 msgid "シューズ"
 msgstr "슈즈"
+
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "スキップ"
+msgstr "건너뛰기"
 
 #: src/app/scan/page.tsx
 #: src/lib/nav-items.ts
@@ -840,6 +852,7 @@ msgstr "먼저 수납 장소를 만들어 주세요"
 msgid "全ドール"
 msgstr "모든 인형"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
 msgstr "전부 있음"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -106,6 +106,10 @@ msgstr "{needsReviewCount}件 待确认"
 msgid "{size}件表示"
 msgstr "显示{size}项"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "{uncertainItemCount} 件が最後のスキャンから時間が経っています"
+msgstr "{uncertainItemCount} 件自上次扫描以来已过去一段时间"
+
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件 有効"
 msgstr "{validCount}项有效"
@@ -420,6 +424,10 @@ msgstr "这个位置没有衣服"
 msgid "この場所の全服を確認済みにする"
 msgstr "将此位置的所有衣服标记为已确认"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "この引き出しの他の服、まだありますか？"
+msgstr "这个抽屉里的其他衣服都还在吗？"
+
 #: src/app/garments/page.tsx
 #: src/components/dashboard/WardrobeAnalytics.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
@@ -446,6 +454,10 @@ msgstr "已收好"
 #: src/lib/i18n-labels.ts
 msgid "シューズ"
 msgstr "鞋子"
+
+#: src/components/scan/CheckoutConfirmSheet.tsx
+msgid "スキップ"
+msgstr "跳过"
 
 #: src/app/scan/page.tsx
 #: src/lib/nav-items.ts
@@ -840,6 +852,7 @@ msgstr "请先创建收纳位置"
 msgid "全ドール"
 msgstr "所有娃娃"
 
+#: src/components/scan/CheckoutConfirmSheet.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
 msgstr "全部都在"

--- a/workers/src/repositories/scan-repository.ts
+++ b/workers/src/repositories/scan-repository.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and, ne, sql } from "drizzle-orm";
 import { GARMENT_STATUS } from "@shared/lib/constants";
 import type { DrizzleDB } from "../db/client";
 import { garments } from "../db/schema";
@@ -97,14 +97,66 @@ export const findGarmentIdAndStatus = async ({
   readonly drizzleDb: DrizzleDB;
   readonly userId: string;
   readonly garmentId: string;
-}): Promise<{ readonly id: string; readonly status: string } | undefined> => {
+}): Promise<
+  | {
+      readonly id: string;
+      readonly status: string;
+      readonly locationId: string | null;
+    }
+  | undefined
+> => {
   const row = await drizzleDb
-    .select({ id: garments.id, status: garments.status })
+    .select({
+      id: garments.id,
+      status: garments.status,
+      locationId: garments.locationId,
+    })
     .from(garments)
     .where(and(eq(garments.id, garmentId), eq(garments.userId, userId)))
     .get();
 
   return row ?? undefined;
+};
+
+export type StoredGarmentForConfidence = {
+  readonly id: string;
+  readonly lastScannedAt: number;
+  readonly confidenceDecayDays: number;
+  readonly confidenceDecayDaysOverride: number | null;
+  readonly recentCheckoutCount: number;
+};
+
+export const listStoredGarmentsAtLocationExcluding = async ({
+  drizzleDb,
+  userId,
+  locationId,
+  excludeGarmentId,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly userId: string;
+  readonly locationId: string;
+  readonly excludeGarmentId: string;
+}): Promise<readonly StoredGarmentForConfidence[]> => {
+  const rows = await drizzleDb
+    .select({
+      id: garments.id,
+      lastScannedAt: garments.lastScannedAt,
+      confidenceDecayDays: garments.confidenceDecayDays,
+      confidenceDecayDaysOverride: garments.confidenceDecayDaysOverride,
+      recentCheckoutCount: garments.recentCheckoutCount,
+    })
+    .from(garments)
+    .where(
+      and(
+        eq(garments.locationId, locationId),
+        eq(garments.userId, userId),
+        eq(garments.status, GARMENT_STATUS.STORED),
+        ne(garments.id, excludeGarmentId),
+      ),
+    )
+    .all();
+
+  return rows;
 };
 
 export const confirmAllAtLocation = async ({

--- a/workers/src/services/scan-service.ts
+++ b/workers/src/services/scan-service.ts
@@ -1,4 +1,8 @@
-import { GARMENT_STATUS } from "@shared/lib/constants";
+import {
+  GARMENT_STATUS,
+  REVIEW_THRESHOLD_DEFAULT,
+} from "@shared/lib/constants";
+import { getConfidence } from "@shared/lib/confidence";
 import type { DrizzleDB } from "../db/client";
 import * as locationRepo from "../repositories/location-repository";
 import * as scanRepo from "../repositories/scan-repository";
@@ -49,7 +53,13 @@ export const checkout = async ({
   readonly drizzleDb: DrizzleDB;
   readonly userId: string;
   readonly garmentId: string;
-}): Promise<ServiceResult<{ readonly success: true }>> => {
+}): Promise<
+  ServiceResult<{
+    readonly success: true;
+    readonly sameLocationItemCount: number;
+    readonly uncertainItemCount: number;
+  }>
+> => {
   const existing = await scanRepo.findGarmentIdAndStatus({
     drizzleDb,
     userId,
@@ -59,8 +69,34 @@ export const checkout = async ({
     return serviceError("NOT_FOUND", "指定された服が見つかりません");
   }
 
+  const prevLocationId = existing.locationId;
+  const others =
+    prevLocationId === null
+      ? []
+      : await scanRepo.listStoredGarmentsAtLocationExcluding({
+          drizzleDb,
+          userId,
+          locationId: prevLocationId,
+          excludeGarmentId: garmentId,
+        });
+  const sameLocationItemCount = others.length;
+  const uncertainItemCount = others.filter(
+    (g) =>
+      getConfidence({
+        lastScannedAt: g.lastScannedAt,
+        confidenceDecayDays: g.confidenceDecayDays,
+        status: GARMENT_STATUS.STORED,
+        recentCheckoutCount: g.recentCheckoutCount,
+        confidenceDecayDaysOverride: g.confidenceDecayDaysOverride ?? undefined,
+      }) < REVIEW_THRESHOLD_DEFAULT,
+  ).length;
+
   await scanRepo.checkout({ drizzleDb, userId, garmentId });
-  return serviceOk({ success: true });
+  return serviceOk({
+    success: true,
+    sameLocationItemCount,
+    uncertainItemCount,
+  });
 };
 
 export const confirmAll = async ({


### PR DESCRIPTION
## Summary

- ガーメント詳細画面でチェックアウト（場所セレクタを「なし」に変更）が起きた直後に、同じ引き出しに他の信頼度低アイテムがあれば「この引き出しの他の服、まだありますか？」ボトムシートを表示
- 「全部ある」で既存の `confirmAllGarmentsAtom` を呼び、同じ `locationId` の全 stored アイテムの `lastScannedAt` をリセット（＝信頼度回復）
- 「スキップ」では何もせずにシートを閉じる
- バックエンド `scan-service.checkout` のレスポンスに `sameLocationItemCount` / `uncertainItemCount` を追加（将来活用用の土台）

## 実装詳細

- UI: `src/components/scan/CheckoutConfirmSheet.tsx`（`BottomSheet` ベース）
- トリガー: `src/components/garment/GarmentLocationRow.tsx` のチェックアウト動線
- 表示判定: フロント側で IndexedDB + `getItemsNeedingReview` / `getReviewThreshold` / `getLocationStabilityScore` を用いて動的閾値で判定
- バックエンド: `listStoredGarmentsAtLocationExcluding` 追加、`findGarmentIdAndStatus` に `locationId` を含めるよう拡張、`scan-service.checkout` で信頼度計算（閾値 `REVIEW_THRESHOLD_DEFAULT` = 0.7）

## 非対象

- scan 画面に「服 QR → チェックアウト」という新動線を追加すること（現状動線が存在しないため）
- `GarmentLocationRow` 以外のチェックアウト経路（`confirmPartial` の denied、`bulkCapture` の初期状態）へのシート表示

## Test plan

- [x] `pnpm test` で 611 件全 PASS（新規 CheckoutConfirmSheet テスト 4 件含む）
- [x] `pnpm precheck`（typecheck / lint / format:check / i18n:check）全 PASS
- [ ] 手動 E2E: 信頼度低のアイテムが同じ引き出しに残る状態でチェックアウト → シート表示を確認
- [ ] 手動 E2E: 「全部ある」で信頼度が回復、「スキップ」で状態不変を確認
- [ ] 手動 E2E: 他アイテムがない引き出しではシート非表示を確認

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)