### PR TITLE
feat: ダイジェストを正確度スコア型「安心感提供」モデルへ転換 (#68)

### DIFF
--- a/src/components/digest/DigestCard.tsx
+++ b/src/components/digest/DigestCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSetAtom } from "jotai";
-import { Eye, EyeOff, AlertTriangle, Clock, CheckCircle } from "lucide-react";
+import { Eye, EyeOff, Sparkles } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react";
 import { msg } from "@lingui/core/macro";
@@ -23,10 +23,12 @@ const formatDate = (timestamp: number, locale: string): string => {
   });
 };
 
+const formatPercent = (score: number): number => Math.round(score * 100);
+
 const DigestCard = ({ digest }: Props) => {
   const markRead = useSetAtom(markDigestReadAtom);
   const { i18n } = useLingui();
-  const hasIssues = digest.unknownCount > 0 || digest.orphanedCount > 0;
+  const percent = formatPercent(digest.accuracyScore);
 
   const handleMarkRead = async () => {
     if (!digest.isRead) {
@@ -66,64 +68,47 @@ const DigestCard = ({ digest }: Props) => {
         </div>
       </div>
 
-      <div className="mt-3 space-y-2">
-        {hasIssues ? (
-          <>
-            {digest.unknownCount > 0 && (
-              <div className="flex items-start gap-2">
-                <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-500" />
-                <div>
-                  <p className="text-sm text-text-primary">
-                    <Trans>
-                      しばらく確認していない服が{digest.unknownCount}
-                      着あります
-                    </Trans>
-                  </p>
-                  <ul className="mt-1 space-y-0.5">
-                    {digest.unknownItems.map((item) => (
-                      <li
-                        key={item.garmentId}
-                        className="text-xs text-text-secondary"
-                      >
-                        {item.garmentName}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            )}
-            {digest.orphanedCount > 0 && (
-              <div className="flex items-start gap-2">
-                <Clock className="mt-0.5 size-4 shrink-0 text-orange-500" />
-                <div>
-                  <p className="text-sm text-text-primary">
-                    <Trans>
-                      {digest.orphanedCount}
-                      着が取り出されたままのようです
-                    </Trans>
-                  </p>
-                  <ul className="mt-1 space-y-0.5">
-                    {digest.orphanedItems.map((item) => (
-                      <li
-                        key={item.garmentId}
-                        className="text-xs text-text-secondary"
-                      >
-                        {item.garmentName}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            )}
-          </>
-        ) : (
-          <div className="flex items-center gap-2">
-            <CheckCircle className="size-4 text-emerald-500" />
-            <p className="text-sm text-text-primary">
-              <Trans>すべて確認済みです！ワードローブは良い状態です</Trans>
-            </p>
-          </div>
-        )}
+      <div className="mt-3">
+        <p className="text-sm text-text-secondary">
+          <Trans>あなたの在庫状況</Trans>
+        </p>
+        <p className="mt-1 text-3xl font-semibold text-text-primary">
+          <Trans>{percent}% 正確</Trans>
+        </p>
+      </div>
+
+      <dl className="mt-3 grid grid-cols-3 gap-2 text-center">
+        <div className="rounded-lg bg-surface-raised p-2">
+          <dt className="text-xs text-text-secondary">
+            <Trans>確定</Trans>
+          </dt>
+          <dd className="text-base font-medium text-text-primary">
+            {digest.confirmedCount}
+          </dd>
+        </div>
+        <div className="rounded-lg bg-surface-raised p-2">
+          <dt className="text-xs text-text-secondary">
+            <Trans>要確認</Trans>
+          </dt>
+          <dd className="text-base font-medium text-text-primary">
+            {digest.uncertainCount}
+          </dd>
+        </div>
+        <div className="rounded-lg bg-surface-raised p-2">
+          <dt className="text-xs text-text-secondary">
+            <Trans>不明</Trans>
+          </dt>
+          <dd className="text-base font-medium text-text-primary">
+            {digest.unknownCount}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-3 flex items-start gap-2 rounded-lg bg-primary-50/60 p-2">
+        <Sparkles className="mt-0.5 size-4 shrink-0 text-primary-500" />
+        <p className="text-xs text-text-secondary">
+          <Trans>次に引き出しを開けたときに自動で確認されます</Trans>
+        </p>
       </div>
 
       <div className="mt-3 border-t border-border-default pt-2">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -49,6 +49,8 @@ export const CHECKOUT_ACTIVITY_THRESHOLD = Object.freeze({
 
 export const ORPHAN_CHECKOUT_THRESHOLD_DAYS = 3;
 
+export const DIGEST_SKIP_THRESHOLD = 0.95;
+
 export const LOCATION_VISIT_BOOST_MAX = 0.25;
 export const LOCATION_VISIT_DECAY_DAYS = 7;
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -51,10 +51,9 @@ msgstr "{0} registrations succeeded"
 msgid "{0}着"
 msgstr "{0} items"
 
-#. placeholder {0}: digest.orphanedCount
 #: src/components/digest/DigestCard.tsx
-msgid "{0}着が取り出されたままのようです"
-msgstr "{0} garments seem to still be checked out"
+#~ msgid "{0}着が取り出されたままのようです"
+#~ msgstr "{0} garments seem to still be checked out"
 
 #: src/components/dashboard/AlertPanel.tsx
 #~ msgid "{0}着の服が3日以上取り出し中です"
@@ -105,6 +104,10 @@ msgstr "{errorCount} errors"
 #: src/components/location/StorageCaseCard.tsx
 msgid "{needsReviewCount}着 要確認"
 msgstr "{needsReviewCount} items need review"
+
+#: src/components/digest/DigestCard.tsx
+msgid "{percent}% 正確"
+msgstr "{percent}% accurate"
 
 #: src/components/ui/Pagination.tsx
 msgid "{size}件表示"
@@ -315,6 +318,10 @@ msgstr "Accessories"
 msgid "アップロード中..."
 msgstr "Uploading..."
 
+#: src/components/digest/DigestCard.tsx
+msgid "あなたの在庫状況"
+msgstr "Your inventory status"
+
 #: src/components/scan/ReviewItemRow.tsx
 msgid "ある"
 msgstr "Present"
@@ -451,10 +458,9 @@ msgstr "Download sample CSV"
 msgid "シアン"
 msgstr "Cyan"
 
-#. placeholder {0}: digest.unknownCount
 #: src/components/digest/DigestCard.tsx
-msgid "しばらく確認していない服が{0}着あります"
-msgstr "{0} garments have not been checked in a while"
+#~ msgid "しばらく確認していない服が{0}着あります"
+#~ msgstr "{0} garments have not been checked in a while"
 
 #: src/components/dashboard/StaleLocationsCard.tsx
 msgid "しばらく開けていない場所"
@@ -499,8 +505,8 @@ msgid "すべて"
 msgstr "All"
 
 #: src/components/digest/DigestCard.tsx
-msgid "すべて確認済みです！ワードローブは良い状態です"
-msgstr "All confirmed! Your wardrobe is in good shape"
+#~ msgid "すべて確認済みです！ワードローブは良い状態です"
+#~ msgstr "All confirmed! Your wardrobe is in good shape"
 
 #: src/components/dashboard/RecentItems.tsx
 msgid "すべて見る"
@@ -800,6 +806,7 @@ msgstr "No matching garments found"
 msgid "一覧に戻る"
 msgstr "Back to list"
 
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "不明"
@@ -1144,6 +1151,10 @@ msgstr "Unassigned"
 msgid "未配置にする"
 msgstr "Unassign"
 
+#: src/components/digest/DigestCard.tsx
+msgid "次に引き出しを開けたときに自動で確認されます"
+msgstr "Will be confirmed automatically the next time you open the drawer"
+
 #: src/components/ui/Pagination.tsx
 #: src/components/ui/Pagination.tsx
 msgid "次のページ"
@@ -1200,6 +1211,7 @@ msgid "着用可能な服がありません"
 msgstr "No compatible garments"
 
 #: src/components/confidence/ConfidenceStats.tsx
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "確定"
@@ -1289,6 +1301,7 @@ msgid "表示件数"
 msgstr "Items per page"
 
 #: src/components/confidence/ConfidenceStats.tsx
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "要確認"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -51,10 +51,9 @@ msgstr "{0}件の登録に成功しました"
 msgid "{0}着"
 msgstr "{0}着"
 
-#. placeholder {0}: digest.orphanedCount
 #: src/components/digest/DigestCard.tsx
-msgid "{0}着が取り出されたままのようです"
-msgstr "{0}着が取り出されたままのようです"
+#~ msgid "{0}着が取り出されたままのようです"
+#~ msgstr "{0}着が取り出されたままのようです"
 
 #: src/components/dashboard/AlertPanel.tsx
 #~ msgid "{0}着の服が3日以上取り出し中です"
@@ -105,6 +104,10 @@ msgstr "{errorCount}件 エラー"
 #: src/components/location/StorageCaseCard.tsx
 msgid "{needsReviewCount}着 要確認"
 msgstr "{needsReviewCount}着 要確認"
+
+#: src/components/digest/DigestCard.tsx
+msgid "{percent}% 正確"
+msgstr "{percent}% 正確"
 
 #: src/components/ui/Pagination.tsx
 msgid "{size}件表示"
@@ -315,6 +318,10 @@ msgstr "アクセサリー"
 msgid "アップロード中..."
 msgstr "アップロード中..."
 
+#: src/components/digest/DigestCard.tsx
+msgid "あなたの在庫状況"
+msgstr "あなたの在庫状況"
+
 #: src/components/scan/ReviewItemRow.tsx
 msgid "ある"
 msgstr "ある"
@@ -451,10 +458,9 @@ msgstr "サンプルCSVをダウンロード"
 msgid "シアン"
 msgstr "シアン"
 
-#. placeholder {0}: digest.unknownCount
 #: src/components/digest/DigestCard.tsx
-msgid "しばらく確認していない服が{0}着あります"
-msgstr "しばらく確認していない服が{0}着あります"
+#~ msgid "しばらく確認していない服が{0}着あります"
+#~ msgstr "しばらく確認していない服が{0}着あります"
 
 #: src/components/dashboard/StaleLocationsCard.tsx
 msgid "しばらく開けていない場所"
@@ -499,8 +505,8 @@ msgid "すべて"
 msgstr "すべて"
 
 #: src/components/digest/DigestCard.tsx
-msgid "すべて確認済みです！ワードローブは良い状態です"
-msgstr "すべて確認済みです！ワードローブは良い状態です"
+#~ msgid "すべて確認済みです！ワードローブは良い状態です"
+#~ msgstr "すべて確認済みです！ワードローブは良い状態です"
 
 #: src/components/dashboard/RecentItems.tsx
 msgid "すべて見る"
@@ -800,6 +806,7 @@ msgstr "一致する服が見つかりません"
 msgid "一覧に戻る"
 msgstr "一覧に戻る"
 
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "不明"
@@ -1144,6 +1151,10 @@ msgstr "未配置"
 msgid "未配置にする"
 msgstr "未配置にする"
 
+#: src/components/digest/DigestCard.tsx
+msgid "次に引き出しを開けたときに自動で確認されます"
+msgstr "次に引き出しを開けたときに自動で確認されます"
+
 #: src/components/ui/Pagination.tsx
 #: src/components/ui/Pagination.tsx
 msgid "次のページ"
@@ -1200,6 +1211,7 @@ msgid "着用可能な服がありません"
 msgstr "着用可能な服がありません"
 
 #: src/components/confidence/ConfidenceStats.tsx
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "確定"
@@ -1289,6 +1301,7 @@ msgid "表示件数"
 msgstr "表示件数"
 
 #: src/components/confidence/ConfidenceStats.tsx
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "要確認"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -51,10 +51,9 @@ msgstr "{0}건 등록에 성공했습니다"
 msgid "{0}着"
 msgstr "{0}벌"
 
-#. placeholder {0}: digest.orphanedCount
 #: src/components/digest/DigestCard.tsx
-msgid "{0}着が取り出されたままのようです"
-msgstr "{0}벌의 옷이 꺼낸 상태로 남아있는 것 같습니다"
+#~ msgid "{0}着が取り出されたままのようです"
+#~ msgstr "{0}벌의 옷이 꺼낸 상태로 남아있는 것 같습니다"
 
 #: src/components/dashboard/AlertPanel.tsx
 #~ msgid "{0}着の服が3日以上取り出し中です"
@@ -105,6 +104,10 @@ msgstr "{errorCount}건 오류"
 #: src/components/location/StorageCaseCard.tsx
 msgid "{needsReviewCount}着 要確認"
 msgstr "{needsReviewCount}벌 확인 필요"
+
+#: src/components/digest/DigestCard.tsx
+msgid "{percent}% 正確"
+msgstr "{percent}% 정확"
 
 #: src/components/ui/Pagination.tsx
 msgid "{size}件表示"
@@ -315,6 +318,10 @@ msgstr "액세서리"
 msgid "アップロード中..."
 msgstr "업로드 중..."
 
+#: src/components/digest/DigestCard.tsx
+msgid "あなたの在庫状況"
+msgstr "재고 상태"
+
 #: src/components/scan/ReviewItemRow.tsx
 msgid "ある"
 msgstr "있음"
@@ -451,10 +458,9 @@ msgstr "샘플 CSV 다운로드"
 msgid "シアン"
 msgstr "시안"
 
-#. placeholder {0}: digest.unknownCount
 #: src/components/digest/DigestCard.tsx
-msgid "しばらく確認していない服が{0}着あります"
-msgstr "한동안 확인하지 않은 옷이 {0}벌 있습니다"
+#~ msgid "しばらく確認していない服が{0}着あります"
+#~ msgstr "한동안 확인하지 않은 옷이 {0}벌 있습니다"
 
 #: src/components/dashboard/StaleLocationsCard.tsx
 msgid "しばらく開けていない場所"
@@ -499,8 +505,8 @@ msgid "すべて"
 msgstr "전체"
 
 #: src/components/digest/DigestCard.tsx
-msgid "すべて確認済みです！ワードローブは良い状態です"
-msgstr "모두 확인 완료! 옷장 상태가 양호합니다"
+#~ msgid "すべて確認済みです！ワードローブは良い状態です"
+#~ msgstr "모두 확인 완료! 옷장 상태가 양호합니다"
 
 #: src/components/dashboard/RecentItems.tsx
 msgid "すべて見る"
@@ -800,6 +806,7 @@ msgstr "일치하는 옷을 찾을 수 없습니다"
 msgid "一覧に戻る"
 msgstr "목록으로 돌아가기"
 
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "不明"
@@ -1144,6 +1151,10 @@ msgstr "미배치"
 msgid "未配置にする"
 msgstr "미배치로 설정"
 
+#: src/components/digest/DigestCard.tsx
+msgid "次に引き出しを開けたときに自動で確認されます"
+msgstr "다음에 서랍을 열 때 자동으로 확인됩니다"
+
 #: src/components/ui/Pagination.tsx
 #: src/components/ui/Pagination.tsx
 msgid "次のページ"
@@ -1200,6 +1211,7 @@ msgid "着用可能な服がありません"
 msgstr "입힐 수 있는 옷이 없습니다"
 
 #: src/components/confidence/ConfidenceStats.tsx
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "確定"
@@ -1289,6 +1301,7 @@ msgid "表示件数"
 msgstr "표시 건수"
 
 #: src/components/confidence/ConfidenceStats.tsx
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "要確認"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -51,10 +51,9 @@ msgstr "{0}项登记成功"
 msgid "{0}着"
 msgstr "{0}件"
 
-#. placeholder {0}: digest.orphanedCount
 #: src/components/digest/DigestCard.tsx
-msgid "{0}着が取り出されたままのようです"
-msgstr "{0}件衣服似乎仍处于取出状态"
+#~ msgid "{0}着が取り出されたままのようです"
+#~ msgstr "{0}件衣服似乎仍处于取出状态"
 
 #: src/components/dashboard/AlertPanel.tsx
 #~ msgid "{0}着の服が3日以上取り出し中です"
@@ -105,6 +104,10 @@ msgstr "{errorCount}项错误"
 #: src/components/location/StorageCaseCard.tsx
 msgid "{needsReviewCount}着 要確認"
 msgstr "{needsReviewCount}件 待确认"
+
+#: src/components/digest/DigestCard.tsx
+msgid "{percent}% 正確"
+msgstr "{percent}% 准确"
 
 #: src/components/ui/Pagination.tsx
 msgid "{size}件表示"
@@ -315,6 +318,10 @@ msgstr "配饰"
 msgid "アップロード中..."
 msgstr "上传中..."
 
+#: src/components/digest/DigestCard.tsx
+msgid "あなたの在庫状況"
+msgstr "您的库存状态"
+
 #: src/components/scan/ReviewItemRow.tsx
 msgid "ある"
 msgstr "在"
@@ -451,10 +458,9 @@ msgstr "下载示例CSV"
 msgid "シアン"
 msgstr "青色"
 
-#. placeholder {0}: digest.unknownCount
 #: src/components/digest/DigestCard.tsx
-msgid "しばらく確認していない服が{0}着あります"
-msgstr "有{0}件衣服已很久未确认"
+#~ msgid "しばらく確認していない服が{0}着あります"
+#~ msgstr "有{0}件衣服已很久未确认"
 
 #: src/components/dashboard/StaleLocationsCard.tsx
 msgid "しばらく開けていない場所"
@@ -499,8 +505,8 @@ msgid "すべて"
 msgstr "全部"
 
 #: src/components/digest/DigestCard.tsx
-msgid "すべて確認済みです！ワードローブは良い状態です"
-msgstr "全部已确认！衣柜状态良好"
+#~ msgid "すべて確認済みです！ワードローブは良い状態です"
+#~ msgstr "全部已确认！衣柜状态良好"
 
 #: src/components/dashboard/RecentItems.tsx
 msgid "すべて見る"
@@ -800,6 +806,7 @@ msgstr "未找到匹配的衣服"
 msgid "一覧に戻る"
 msgstr "返回列表"
 
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "不明"
@@ -1144,6 +1151,10 @@ msgstr "未分配"
 msgid "未配置にする"
 msgstr "取消分配"
 
+#: src/components/digest/DigestCard.tsx
+msgid "次に引き出しを開けたときに自動で確認されます"
+msgstr "下次打开抽屉时将自动确认"
+
 #: src/components/ui/Pagination.tsx
 #: src/components/ui/Pagination.tsx
 msgid "次のページ"
@@ -1200,6 +1211,7 @@ msgid "着用可能な服がありません"
 msgstr "没有可穿着的衣服"
 
 #: src/components/confidence/ConfidenceStats.tsx
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "確定"
@@ -1289,6 +1301,7 @@ msgid "表示件数"
 msgstr "每页显示数"
 
 #: src/components/confidence/ConfidenceStats.tsx
+#: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
 #: src/lib/i18n-labels.ts
 msgid "要確認"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,25 +124,13 @@ export type Doll = {
   readonly updatedAt: number;
 };
 
-export type DigestUnknownItem = {
-  readonly garmentId: string;
-  readonly garmentName: string;
-  readonly confidence: number;
-};
-
-export type DigestOrphanedItem = {
-  readonly garmentId: string;
-  readonly garmentName: string;
-  readonly checkedOutAt: number;
-};
-
 export type Digest = {
   readonly id: string;
   readonly userId: string;
-  readonly unknownItems: readonly DigestUnknownItem[];
-  readonly orphanedItems: readonly DigestOrphanedItem[];
+  readonly accuracyScore: number;
+  readonly confirmedCount: number;
+  readonly uncertainCount: number;
   readonly unknownCount: number;
-  readonly orphanedCount: number;
   readonly totalGarments: number;
   readonly isRead: boolean;
   readonly generatedAt: number;

--- a/workers/migrations/0011_digest_accuracy.sql
+++ b/workers/migrations/0011_digest_accuracy.sql
@@ -1,0 +1,6 @@
+ALTER TABLE digests DROP COLUMN unknown_items;
+ALTER TABLE digests DROP COLUMN orphaned_items;
+ALTER TABLE digests DROP COLUMN orphaned_count;
+ALTER TABLE digests ADD COLUMN accuracy_score REAL NOT NULL DEFAULT 1.0;
+ALTER TABLE digests ADD COLUMN confirmed_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE digests ADD COLUMN uncertain_count INTEGER NOT NULL DEFAULT 0;

--- a/workers/src/db/schema.ts
+++ b/workers/src/db/schema.ts
@@ -1,5 +1,11 @@
 import { sql } from "drizzle-orm";
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  real,
+  index,
+} from "drizzle-orm/sqlite-core";
 import { jsonArrayColumn } from "./helpers";
 
 export const garments = sqliteTable(
@@ -112,10 +118,10 @@ export const digests = sqliteTable(
   {
     id: text("id").primaryKey(),
     userId: text("user_id").notNull(),
-    unknownItems: text("unknown_items").notNull().default("[]"),
-    orphanedItems: text("orphaned_items").notNull().default("[]"),
+    accuracyScore: real("accuracy_score").notNull().default(1.0),
+    confirmedCount: integer("confirmed_count").notNull().default(0),
+    uncertainCount: integer("uncertain_count").notNull().default(0),
     unknownCount: integer("unknown_count").notNull().default(0),
-    orphanedCount: integer("orphaned_count").notNull().default(0),
     totalGarments: integer("total_garments").notNull().default(0),
     isRead: integer("is_read", { mode: "boolean" }).notNull().default(false),
     generatedAt: integer("generated_at").notNull(),

--- a/workers/src/queues/digest-consumer.ts
+++ b/workers/src/queues/digest-consumer.ts
@@ -41,6 +41,9 @@ export const handleDigestQueue = async ({
       });
 
       if (result.ok) {
+        childLogger.info("digest queue processed", {
+          skipped: result.data.skipped,
+        });
         msg.ack();
       } else {
         childLogger.error("digest generation failed", {

--- a/workers/src/repositories/digest-repository.ts
+++ b/workers/src/repositories/digest-repository.ts
@@ -1,4 +1,4 @@
-import type { Digest, DigestUnknownItem, DigestOrphanedItem } from "@/types";
+import type { Digest } from "@/types";
 import { and, desc, eq, sql } from "drizzle-orm";
 import type { Logger } from "../lib/logger";
 import type { DrizzleDB } from "../db/client";
@@ -7,44 +7,13 @@ import { wrapDbError } from "../trpc/lib/d1-helpers";
 
 type DigestSelectRow = typeof digests.$inferSelect;
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
-const isDigestUnknownItem = (item: unknown): item is DigestUnknownItem =>
-  isRecord(item) &&
-  typeof item.garmentId === "string" &&
-  typeof item.garmentName === "string" &&
-  typeof item.confidence === "number";
-
-const isDigestOrphanedItem = (item: unknown): item is DigestOrphanedItem =>
-  isRecord(item) &&
-  typeof item.garmentId === "string" &&
-  typeof item.garmentName === "string" &&
-  typeof item.checkedOutAt === "number";
-
-const parseUnknownItems = (raw: string): readonly DigestUnknownItem[] => {
-  const parsed: unknown = JSON.parse(raw);
-  if (!Array.isArray(parsed)) {
-    return [];
-  }
-  return parsed.filter(isDigestUnknownItem);
-};
-
-const parseOrphanedItems = (raw: string): readonly DigestOrphanedItem[] => {
-  const parsed: unknown = JSON.parse(raw);
-  if (!Array.isArray(parsed)) {
-    return [];
-  }
-  return parsed.filter(isDigestOrphanedItem);
-};
-
 const toDigest = (row: DigestSelectRow): Digest => ({
   id: row.id,
   userId: row.userId,
-  unknownItems: parseUnknownItems(row.unknownItems),
-  orphanedItems: parseOrphanedItems(row.orphanedItems),
+  accuracyScore: row.accuracyScore,
+  confirmedCount: row.confirmedCount,
+  uncertainCount: row.uncertainCount,
   unknownCount: row.unknownCount,
-  orphanedCount: row.orphanedCount,
   totalGarments: row.totalGarments,
   isRead: row.isRead,
   generatedAt: row.generatedAt,
@@ -54,10 +23,10 @@ const toDigest = (row: DigestSelectRow): Digest => ({
 type DigestInsertData = {
   readonly id: string;
   readonly userId: string;
-  readonly unknownItems: readonly DigestUnknownItem[];
-  readonly orphanedItems: readonly DigestOrphanedItem[];
+  readonly accuracyScore: number;
+  readonly confirmedCount: number;
+  readonly uncertainCount: number;
   readonly unknownCount: number;
-  readonly orphanedCount: number;
   readonly totalGarments: number;
   readonly isRead: boolean;
   readonly generatedAt: number;
@@ -75,11 +44,7 @@ export const insertDigest = async ({
 }): Promise<void> => {
   await drizzleDb
     .insert(digests)
-    .values({
-      ...digest,
-      unknownItems: JSON.stringify(digest.unknownItems),
-      orphanedItems: JSON.stringify(digest.orphanedItems),
-    })
+    .values(digest)
     .catch(wrapDbError({ context: "insert digest", logger }));
 };
 

--- a/workers/src/services/digest-service.ts
+++ b/workers/src/services/digest-service.ts
@@ -1,10 +1,6 @@
-import type { Digest, DigestUnknownItem, DigestOrphanedItem } from "@/types";
-import {
-  CONFIDENCE_THRESHOLD,
-  GARMENT_STATUS,
-  ORPHAN_CHECKOUT_THRESHOLD_DAYS,
-} from "@shared/lib/constants";
-import { getConfidence, getOrphanedCheckouts } from "@/lib/confidence";
+import type { ConfidenceLabel, Digest, Garment } from "@/types";
+import { DIGEST_SKIP_THRESHOLD, GARMENT_STATUS } from "@shared/lib/constants";
+import { getConfidence, getConfidenceLabel } from "@/lib/confidence";
 import { createId } from "@paralleldrive/cuid2";
 import type { Logger } from "../lib/logger";
 import type { DrizzleDB } from "../db/client";
@@ -12,6 +8,42 @@ import * as garmentRepo from "../repositories/garment-repository";
 import * as locationRepo from "../repositories/location-repository";
 import * as digestRepo from "../repositories/digest-repository";
 import { type ServiceResult, serviceError, serviceOk } from "./types";
+
+export type GenerateDigestResult = {
+  readonly digest: Digest | undefined;
+  readonly skipped: boolean;
+};
+
+type ZoneCounts = {
+  readonly confirmedCount: number;
+  readonly uncertainCount: number;
+  readonly unknownCount: number;
+};
+
+const countZones = (
+  garments: readonly Garment[],
+  visitedAtByLocationId: ReadonlyMap<string, number | undefined>,
+): ZoneCounts => {
+  const zeroed = { confirmedCount: 0, uncertainCount: 0, unknownCount: 0 };
+  return garments.reduce<ZoneCounts>((acc, g) => {
+    if (g.status !== GARMENT_STATUS.STORED) {
+      return acc;
+    }
+    const confidence = getConfidence({
+      ...g,
+      lastLocationVisitedAt:
+        g.locationId !== undefined
+          ? visitedAtByLocationId.get(g.locationId)
+          : undefined,
+    });
+    const label: ConfidenceLabel = getConfidenceLabel(confidence);
+    return label === "confirmed"
+      ? { ...acc, confirmedCount: acc.confirmedCount + 1 }
+      : label === "uncertain"
+        ? { ...acc, uncertainCount: acc.uncertainCount + 1 }
+        : { ...acc, unknownCount: acc.unknownCount + 1 };
+  }, zeroed);
+};
 
 export const generateDigestForUser = async ({
   drizzleDb,
@@ -21,7 +53,7 @@ export const generateDigestForUser = async ({
   readonly drizzleDb: DrizzleDB;
   readonly userId: string;
   readonly logger: Logger;
-}): Promise<ServiceResult<Digest>> => {
+}): Promise<ServiceResult<GenerateDigestResult>> => {
   const garments = await garmentRepo.findGarments({
     drizzleDb,
     userId,
@@ -36,61 +68,35 @@ export const generateDigestForUser = async ({
   const visitedAtByLocationId = new Map(
     locations.map((l) => [l.id, l.lastVisitedAt]),
   );
-  const getGarmentConfidence = (g: (typeof garments)[number]): number =>
-    getConfidence({
-      ...g,
-      lastLocationVisitedAt:
-        g.locationId !== undefined
-          ? visitedAtByLocationId.get(g.locationId)
-          : undefined,
-    });
 
-  const unknownItems: readonly DigestUnknownItem[] = garments
-    .filter((g) => {
-      if (g.status !== GARMENT_STATUS.STORED) {
-        return false;
-      }
-      return getGarmentConfidence(g) < CONFIDENCE_THRESHOLD.UNCERTAIN;
-    })
-    .map((g) => ({
-      garmentId: g.id,
-      garmentName: g.name,
-      confidence: getGarmentConfidence(g),
-    }));
-
-  const orphanedGarments = getOrphanedCheckouts(
+  const { confirmedCount, uncertainCount, unknownCount } = countZones(
     garments,
-    ORPHAN_CHECKOUT_THRESHOLD_DAYS,
+    visitedAtByLocationId,
   );
-  const orphanedItems: readonly DigestOrphanedItem[] = orphanedGarments.map(
-    (g) => ({
-      garmentId: g.id,
-      garmentName: g.name,
-      checkedOutAt: g.checkedOutAt ?? 0,
-    }),
-  );
+  const storedTotal = confirmedCount + uncertainCount + unknownCount;
+  const accuracyScore = storedTotal === 0 ? 1 : confirmedCount / storedTotal;
+  const shouldSkip =
+    storedTotal === 0 || accuracyScore >= DIGEST_SKIP_THRESHOLD;
 
   const now = Date.now();
-  const id = createId();
+  const digest: Digest | undefined = shouldSkip
+    ? undefined
+    : {
+        id: createId(),
+        userId,
+        accuracyScore,
+        confirmedCount,
+        uncertainCount,
+        unknownCount,
+        totalGarments: garments.length,
+        isRead: false,
+        generatedAt: now,
+        createdAt: now,
+      };
 
-  const digestData = {
-    id,
-    userId,
-    unknownItems,
-    orphanedItems,
-    unknownCount: unknownItems.length,
-    orphanedCount: orphanedItems.length,
-    totalGarments: garments.length,
-    isRead: false,
-    generatedAt: now,
-    createdAt: now,
-  };
-
-  await digestRepo.insertDigest({
-    drizzleDb,
-    digest: digestData,
-    logger,
-  });
+  if (digest !== undefined) {
+    await digestRepo.insertDigest({ drizzleDb, digest, logger });
+  }
 
   const decrementedCount = await garmentRepo.decrementAllRecentCheckoutCounts({
     drizzleDb,
@@ -98,15 +104,18 @@ export const generateDigestForUser = async ({
     logger,
   });
 
-  logger.info("digest generated", {
+  logger.info("digest generation finished", {
     userId,
-    unknownCount: unknownItems.length,
-    orphanedCount: orphanedItems.length,
+    skipped: shouldSkip,
+    accuracyScore,
+    confirmedCount,
+    uncertainCount,
+    unknownCount,
     totalGarments: garments.length,
     recentCheckoutCountDecremented: decrementedCount,
   });
 
-  return serviceOk(digestData);
+  return serviceOk({ digest, skipped: shouldSkip });
 };
 
 export const getLatestDigest = async ({

--- a/workers/src/trpc/routers/digest.test.ts
+++ b/workers/src/trpc/routers/digest.test.ts
@@ -6,80 +6,142 @@ import { MS_PER_DAY } from "@shared/lib/constants";
 const db = getTestDb();
 const caller = createTestCaller();
 
+const insertConfirmedGarment = async (name: string) =>
+  await insertGarment({
+    db,
+    overrides: {
+      name,
+      lastScannedAt: Date.now(),
+      confidenceDecayDays: 30,
+      confidenceDecayDaysOverride: 30,
+    },
+  });
+
+const insertUnknownGarment = async (name: string) =>
+  await insertGarment({
+    db,
+    overrides: {
+      name,
+      lastScannedAt: Date.now() - MS_PER_DAY * 31,
+      confidenceDecayDays: 30,
+      confidenceDecayDaysOverride: 30,
+    },
+  });
+
+const insertUncertainGarment = async (name: string) =>
+  await insertGarment({
+    db,
+    overrides: {
+      name,
+      lastScannedAt: Date.now() - MS_PER_DAY * 20,
+      confidenceDecayDays: 30,
+      confidenceDecayDaysOverride: 30,
+    },
+  });
+
 beforeEach(async () => {
   await resetDatabase(db);
 });
 
 describe("digestRouter", () => {
   describe("generate", () => {
-    it("garment がない場合でもダイジェストを生成する", async () => {
+    it("stored 件数が 0 ならスキップする", async () => {
       const result = await caller.digest.generate();
-      expect(result.unknownCount).toBe(0);
-      expect(result.orphanedCount).toBe(0);
-      expect(result.totalGarments).toBe(0);
-      expect(result.isRead).toBe(false);
+      expect(result.skipped).toBe(true);
+      expect(result.digest).toBeUndefined();
+
+      const latest = await caller.digest.latest();
+      expect(latest).toBeUndefined();
     });
 
-    it("unknown ゾーンのアイテムを検出する", async () => {
-      const oldTimestamp = Date.now() - MS_PER_DAY * 31;
-      await insertGarment({
-        db,
-        overrides: {
-          name: "古い服",
-          lastScannedAt: oldTimestamp,
-          confidenceDecayDays: 30,
-          confidenceDecayDaysOverride: 30,
-        },
-      });
-      await insertGarment({
-        db,
-        overrides: {
-          name: "新しい服",
-          lastScannedAt: Date.now(),
-          confidenceDecayDays: 30,
-          confidenceDecayDaysOverride: 30,
-        },
-      });
+    it("精度 95% 以上ならスキップして latest を更新しない", async () => {
+      await insertConfirmedGarment("確定な服1");
+      await insertConfirmedGarment("確定な服2");
 
       const result = await caller.digest.generate();
-      expect(result.unknownCount).toBe(1);
-      expect(result.unknownItems).toHaveLength(1);
-      expect(result.unknownItems[0].garmentName).toBe("古い服");
-      expect(result.totalGarments).toBe(2);
+      expect(result.skipped).toBe(true);
+      expect(result.digest).toBeUndefined();
+
+      const latest = await caller.digest.latest();
+      expect(latest).toBeUndefined();
     });
 
-    it("孤立チェックアウトを検出する", async () => {
-      const fourDaysAgo = Date.now() - MS_PER_DAY * 4;
+    it("精度 95% 未満ならダイジェストを生成する", async () => {
+      await insertConfirmedGarment("確定な服");
+      await insertUnknownGarment("不明な服1");
+      await insertUnknownGarment("不明な服2");
+
+      const result = await caller.digest.generate();
+      expect(result.skipped).toBe(false);
+      expect(result.digest).toBeDefined();
+      expect(result.digest?.confirmedCount).toBe(1);
+      expect(result.digest?.unknownCount).toBe(2);
+      expect(result.digest?.uncertainCount).toBe(0);
+      expect(result.digest?.accuracyScore).toBeCloseTo(1 / 3, 5);
+      expect(result.digest?.totalGarments).toBe(3);
+    });
+
+    it("confirmed / uncertain / unknown の件数が正しく分類される", async () => {
+      await insertConfirmedGarment("確定");
+      await insertUncertainGarment("要確認");
+      await insertUnknownGarment("不明");
+
+      const result = await caller.digest.generate();
+      expect(result.skipped).toBe(false);
+      expect(result.digest?.confirmedCount).toBe(1);
+      expect(result.digest?.uncertainCount).toBe(1);
+      expect(result.digest?.unknownCount).toBe(1);
+    });
+
+    it("checked_out / lost の服はゾーン件数に含めない", async () => {
+      await insertConfirmedGarment("確定");
       await insertGarment({
         db,
         overrides: {
-          name: "取り出し中の服",
+          name: "取り出し中",
           status: "checked_out",
-          checkedOutAt: fourDaysAgo,
+          checkedOutAt: Date.now() - MS_PER_DAY,
         },
+      });
+      await insertGarment({
+        db,
+        overrides: { name: "紛失", status: "lost" },
       });
 
       const result = await caller.digest.generate();
-      expect(result.orphanedCount).toBe(1);
-      expect(result.orphanedItems).toHaveLength(1);
-      expect(result.orphanedItems[0].garmentName).toBe("取り出し中の服");
+      expect(result.skipped).toBe(true);
+      expect(result.digest).toBeUndefined();
     });
 
-    it("digest 生成時に recentCheckoutCount が 1 ずつデクリメントされる (下限 0)", async () => {
+    it("生成されたダイジェストに個別アイテムリストが含まれない", async () => {
+      await insertUnknownGarment("古い服1");
+      await insertUnknownGarment("古い服2");
+
+      const result = await caller.digest.generate();
+      expect(result.digest).toBeDefined();
+      if (result.digest === undefined) return;
+
+      expect(result.digest).not.toHaveProperty("unknownItems");
+      expect(result.digest).not.toHaveProperty("orphanedItems");
+      expect(result.digest).not.toHaveProperty("orphanedCount");
+    });
+
+    it("スキップしても recentCheckoutCount はデクリメントされる", async () => {
       const { id: g1 } = await insertGarment({
         db,
-        overrides: { name: "活動的な服", recentCheckoutCount: 3 },
+        overrides: { name: "確定+活動", recentCheckoutCount: 3 },
       });
       const { id: g2 } = await insertGarment({
         db,
-        overrides: { name: "ほぼ動かない服", recentCheckoutCount: 1 },
+        overrides: { name: "確定+低活動", recentCheckoutCount: 1 },
       });
       const { id: g3 } = await insertGarment({
         db,
-        overrides: { name: "止まっている服", recentCheckoutCount: 0 },
+        overrides: { name: "確定+非活動", recentCheckoutCount: 0 },
       });
 
-      await caller.digest.generate();
+      const result = await caller.digest.generate();
+      expect(result.skipped).toBe(true);
 
       const after1 = await caller.garment.get({ id: g1 });
       const after2 = await caller.garment.get({ id: g2 });
@@ -90,41 +152,23 @@ describe("digestRouter", () => {
       expect(after3.recentCheckoutCount).toBe(0);
     });
 
-    it("すべての問題を同時に検出する", async () => {
-      const oldTimestamp = Date.now() - MS_PER_DAY * 31;
-      const fourDaysAgo = Date.now() - MS_PER_DAY * 4;
-
-      await insertGarment({
+    it("生成時にも recentCheckoutCount はデクリメントされる", async () => {
+      const { id: g1 } = await insertGarment({
         db,
         overrides: {
-          name: "古い服",
-          lastScannedAt: oldTimestamp,
+          name: "古い+活動",
+          lastScannedAt: Date.now() - MS_PER_DAY * 31,
           confidenceDecayDays: 30,
           confidenceDecayDaysOverride: 30,
-        },
-      });
-      await insertGarment({
-        db,
-        overrides: {
-          name: "取り出し中",
-          status: "checked_out",
-          checkedOutAt: fourDaysAgo,
-        },
-      });
-      await insertGarment({
-        db,
-        overrides: {
-          name: "正常な服",
-          lastScannedAt: Date.now(),
-          confidenceDecayDays: 30,
-          confidenceDecayDaysOverride: 30,
+          recentCheckoutCount: 3,
         },
       });
 
       const result = await caller.digest.generate();
-      expect(result.unknownCount).toBe(1);
-      expect(result.orphanedCount).toBe(1);
-      expect(result.totalGarments).toBe(3);
+      expect(result.skipped).toBe(false);
+
+      const after = await caller.garment.get({ id: g1 });
+      expect(after.recentCheckoutCount).toBe(2);
     });
   });
 
@@ -138,16 +182,24 @@ describe("digestRouter", () => {
       const now = Date.now();
       await insertDigest({
         db,
-        overrides: { generatedAt: now - MS_PER_DAY },
+        overrides: { generatedAt: now - MS_PER_DAY, accuracyScore: 0.5 },
       });
       await insertDigest({
         db,
-        overrides: { generatedAt: now, totalGarments: 5 },
+        overrides: {
+          generatedAt: now,
+          totalGarments: 5,
+          accuracyScore: 0.8,
+          confirmedCount: 4,
+          unknownCount: 1,
+        },
       });
 
       const result = await caller.digest.latest();
       expect(result).toBeDefined();
       expect(result?.totalGarments).toBe(5);
+      expect(result?.accuracyScore).toBeCloseTo(0.8, 5);
+      expect(result?.confirmedCount).toBe(4);
     });
   });
 
@@ -231,23 +283,19 @@ describe("digestRouter", () => {
 
   describe("generate → latest の統合フロー", () => {
     it("generate で作成したダイジェストを latest で取得できる", async () => {
-      const oldTimestamp = Date.now() - MS_PER_DAY * 31;
-      await insertGarment({
-        db,
-        overrides: {
-          name: "古い服",
-          lastScannedAt: oldTimestamp,
-          confidenceDecayDays: 30,
-          confidenceDecayDaysOverride: 30,
-        },
-      });
+      await insertUnknownGarment("古い服1");
+      await insertUnknownGarment("古い服2");
+      await insertUnknownGarment("古い服3");
 
       const generated = await caller.digest.generate();
       const latest = await caller.digest.latest();
 
+      expect(generated.skipped).toBe(false);
+      expect(generated.digest).toBeDefined();
       expect(latest).toBeDefined();
-      expect(latest?.id).toBe(generated.id);
-      expect(latest?.unknownCount).toBe(1);
+      expect(latest?.id).toBe(generated.digest?.id);
+      expect(latest?.unknownCount).toBe(3);
+      expect(latest?.accuracyScore).toBeCloseTo(0, 5);
     });
   });
 });

--- a/workers/test/helpers/factories.ts
+++ b/workers/test/helpers/factories.ts
@@ -1,5 +1,4 @@
 import { createId } from "@paralleldrive/cuid2";
-import type { DigestUnknownItem, DigestOrphanedItem } from "@/types";
 import { TEMP_USER_ID } from "../../src/trpc/lib/d1-helpers";
 
 type InsertGarmentParams = {
@@ -173,10 +172,10 @@ type InsertDigestParams = {
   readonly db: D1Database;
   readonly overrides?: Partial<{
     readonly id: string;
-    readonly unknownItems: readonly DigestUnknownItem[];
-    readonly orphanedItems: readonly DigestOrphanedItem[];
+    readonly accuracyScore: number;
+    readonly confirmedCount: number;
+    readonly uncertainCount: number;
     readonly unknownCount: number;
-    readonly orphanedCount: number;
     readonly totalGarments: number;
     readonly isRead: boolean;
     readonly generatedAt: number;
@@ -192,16 +191,16 @@ export const insertDigest = async ({
 
   await db
     .prepare(
-      `INSERT INTO digests (id, user_id, unknown_items, orphaned_items, unknown_count, orphaned_count, total_garments, is_read, generated_at, created_at)
+      `INSERT INTO digests (id, user_id, accuracy_score, confirmed_count, uncertain_count, unknown_count, total_garments, is_read, generated_at, created_at)
        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)`,
     )
     .bind(
       id,
       TEMP_USER_ID,
-      JSON.stringify(overrides.unknownItems ?? []),
-      JSON.stringify(overrides.orphanedItems ?? []),
+      overrides.accuracyScore ?? 1,
+      overrides.confirmedCount ?? 0,
+      overrides.uncertainCount ?? 0,
       overrides.unknownCount ?? 0,
-      overrides.orphanedCount ?? 0,
       overrides.totalGarments ?? 0,
       overrides.isRead === true ? 1 : 0,
       overrides.generatedAt ?? now,


### PR DESCRIPTION
Closes #68

## Summary
- 週次ダイジェストを「修正の催促」→「安心感提供」モデルへ転換
- 全体の正確度スコア（確定ゾーン件数 / stored 合計）と確定/要確認/不明の件数を配信
- 精度 95% 以上（または stored 0 件）ならダイジェスト自体の insert をスキップ
- 個別アイテムリスト（unknownItems / orphanedItems）を廃止
- `recent_checkout_count` のバッチ再計算はスキップ時にも必ず実行

## 変更概要
- DB: `0011_digest_accuracy.sql` で `unknown_items` / `orphaned_items` / `orphaned_count` を DROP、`accuracy_score` / `confirmed_count` / `uncertain_count` を ADD（`unknown_count` は "不明ゾーン件数" として意味そのまま保持）
- Service: `generateDigestForUser` が `{ digest: Digest | undefined, skipped: boolean }` を返すよう書き換え。確定/要確認/不明の集計ロジックを `src/lib/confidence.ts` の `getConfidence` / `getConfidenceLabel` で再利用
- Frontend: `DigestCard` を精度スコア + ゾーン別件数 + 「次に引き出しを開けたときに自動で確認されます」案内に再設計（アイテムリスト表示撤去）
- i18n: en/ko/zh 追加エントリの翻訳記入、不要エントリは extract によりコメントアウト

## Test plan
- [x] `pnpm precheck`（typecheck / lint / format / i18n）
- [x] `pnpm test`（全 60 テストファイル 620 テスト通過）
- [x] 新テスト: stored 0 件 / 精度 95% 以上 / 精度 95% 未満 / ゾーン分類 / checked_out・lost 除外 / 個別リスト不在 / スキップ時デクリメント / 生成時デクリメント / 統合フロー

🤖 Generated with [Claude Code](https://claude.com/claude-code)