### PR TITLE
chore: dmux worktree 作成時に Claude permissions を引き継ぐフックを追加

### DIFF
--- a/.dmux-hooks/AGENTS.md
+++ b/.dmux-hooks/AGENTS.md
@@ -1,0 +1,410 @@
+# dmux Hooks System - Agent Reference
+
+**Auto-generated documentation for AI agents**
+
+This document contains everything an AI agent needs to create, modify, and understand dmux hooks. It is automatically generated from the dmux source code and embedded in the binary.
+
+## What You're Working On
+
+You are editing hooks for **dmux**, a tmux pane manager that creates AI-powered development workflows. Each pane runs in its own git worktree with an AI agent.
+
+## Your Goal
+
+Create executable bash scripts in `.dmux-hooks/` that run automatically at key lifecycle events.
+
+## Quick Start
+
+1. **Create a hook file**: `touch .dmux-hooks/worktree_created`
+2. **Make it executable**: `chmod +x .dmux-hooks/worktree_created`
+3. **Add shebang**: Start with `#!/bin/bash`
+4. **Use environment variables**: Access `$DMUX_ROOT`, `$DMUX_WORKTREE_PATH`, etc.
+5. **Test it**: Set env vars manually and run the script
+
+## Hook Execution Model
+
+- **Non-blocking**: Hooks run in background (detached processes)
+- **Silent failures**: Hook errors are logged but don't stop dmux
+- **Environment-based**: All context passed via environment variables
+- **Version controlled**: Hooks in `.dmux-hooks/` are shared with team
+- **Priority resolution**: `.dmux-hooks/` → `.dmux/hooks/` → `~/.dmux/hooks/`
+
+## Available Hooks
+
+### Pane Lifecycle Hooks
+
+| Hook | When | Common Use Cases |
+|------|------|------------------|
+| `before_pane_create` | Before pane creation | Validation, notifications, pre-flight checks |
+| `pane_created` | After pane, before worktree | Configure tmux settings, prepare environment |
+| `worktree_created` | After full setup | Install deps, copy configs, setup git |
+| `before_pane_close` | Before closing | Save state, backup uncommitted work |
+| `pane_closed` | After closed | Cleanup resources, analytics, notifications |
+
+### Worktree Lifecycle Hooks
+
+| Hook | When | Common Use Cases |
+|------|------|------------------|
+| `before_worktree_remove` | Before worktree removal | Archive worktree, save artifacts |
+| `worktree_removed` | After worktree removed | Cleanup external references |
+
+### Merge Lifecycle Hooks
+
+| Hook | When | Common Use Cases |
+|------|------|------------------|
+| `pre_merge` | Before merge operation | Run final tests, create backups |
+| `post_merge` | After successful merge | Deploy, close issues, notify team |
+
+### Interactive Hooks (with HTTP callbacks)
+
+| Hook | When | Common Use Cases |
+|------|------|------------------|
+| `run_test` | When tests triggered | Run test suite, report status via HTTP |
+| `run_dev` | When dev server triggered | Start dev server, create tunnel, report URL |
+
+
+## Environment Variables
+
+### Always Available
+```bash
+DMUX_ROOT="/path/to/project"           # Project root directory
+DMUX_SERVER_PORT="3142"                # HTTP server port
+```
+
+### Pane Context (most hooks)
+```bash
+DMUX_PANE_ID="dmux-1234567890"         # dmux pane identifier
+DMUX_SLUG="fix-auth-bug"               # Branch/worktree name
+DMUX_PROMPT="Fix authentication bug"   # User's prompt
+DMUX_AGENT="claude"                    # Agent type (registry id, e.g. claude, codex, opencode)
+DMUX_TMUX_PANE_ID="%38"                # tmux pane ID
+```
+
+### Worktree Context
+```bash
+DMUX_WORKTREE_PATH="/path/.dmux/worktrees/fix-auth-bug"
+DMUX_BRANCH="fix-auth-bug"             # Same as slug
+```
+
+### Merge Context
+```bash
+DMUX_TARGET_BRANCH="main"              # Branch being merged into
+```
+
+## HTTP Callback API
+
+Interactive hooks (`run_test` and `run_dev`) can update dmux UI via HTTP.
+
+### Update Test Status
+```bash
+curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/test"   -H "Content-Type: application/json"   -d '{"status": "running", "output": "optional test output"}'
+
+# Status values: "running" | "passed" | "failed"
+```
+
+### Update Dev Server
+```bash
+curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/dev"   -H "Content-Type: application/json"   -d '{"status": "running", "url": "http://localhost:3000"}'
+
+# Status values: "running" | "stopped"
+# url: Can be localhost or tunnel URL (ngrok, cloudflared, etc.)
+```
+
+## Common Patterns
+
+### Pattern 1: Install Dependencies
+```bash
+#!/bin/bash
+# .dmux-hooks/worktree_created
+
+cd "$DMUX_WORKTREE_PATH"
+
+if [ -f "pnpm-lock.yaml" ]; then
+  pnpm install --prefer-offline &
+elif [ -f "package-lock.json" ]; then
+  npm install &
+elif [ -f "yarn.lock" ]; then
+  yarn install &
+elif [ -f "Gemfile" ]; then
+  bundle install &
+elif [ -f "requirements.txt" ]; then
+  pip install -r requirements.txt &
+elif [ -f "Cargo.toml" ]; then
+  cargo build &
+fi
+```
+
+### Pattern 2: Copy Configuration
+```bash
+#!/bin/bash
+# .dmux-hooks/worktree_created
+
+# Copy environment file
+if [ -f "$DMUX_ROOT/.env.local" ]; then
+  cp "$DMUX_ROOT/.env.local" "$DMUX_WORKTREE_PATH/.env.local"
+fi
+
+# Copy other config files
+for file in .env.development .npmrc .yarnrc; do
+  if [ -f "$DMUX_ROOT/$file" ]; then
+    cp "$DMUX_ROOT/$file" "$DMUX_WORKTREE_PATH/$file"
+  fi
+done
+```
+
+### Pattern 3: Run Tests with Status Updates
+```bash
+#!/bin/bash
+# .dmux-hooks/run_test
+
+set -e
+cd "$DMUX_WORKTREE_PATH"
+API="http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/test"
+
+# Update: starting
+curl -s -X PUT "$API" -H "Content-Type: application/json"   -d '{"status": "running"}' > /dev/null
+
+# Run tests and capture output
+OUTPUT_FILE="/tmp/dmux-test-$DMUX_PANE_ID.txt"
+if pnpm test > "$OUTPUT_FILE" 2>&1; then
+  STATUS="passed"
+else
+  STATUS="failed"
+fi
+
+# Get output (truncate if too long)
+OUTPUT=$(head -c 5000 "$OUTPUT_FILE")
+
+# Update: complete
+curl -s -X PUT "$API" -H "Content-Type: application/json"   -d "$(jq -n --arg status "$STATUS" --arg output "$OUTPUT"     '{status: $status, output: $output}')" > /dev/null
+
+rm -f "$OUTPUT_FILE"
+```
+
+### Pattern 4: Dev Server with Tunnel
+```bash
+#!/bin/bash
+# .dmux-hooks/run_dev
+
+set -e
+cd "$DMUX_WORKTREE_PATH"
+API="http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/dev"
+
+# Start dev server in background
+LOG_FILE="/tmp/dmux-dev-$DMUX_PANE_ID.log"
+pnpm dev > "$LOG_FILE" 2>&1 &
+DEV_PID=$!
+
+# Wait for server to start
+sleep 5
+
+# Detect port from logs
+PORT=$(grep -oP 'localhost:Kd+' "$LOG_FILE" | head -1)
+[ -z "$PORT" ] && PORT=3000
+
+# Optional: Create tunnel with cloudflared
+if command -v cloudflared &> /dev/null; then
+  TUNNEL=$(cloudflared tunnel --url "http://localhost:$PORT" 2>&1 |     grep -oP 'https://[a-z0-9-]+.trycloudflare.com' | head -1)
+  URL="${TUNNEL:-http://localhost:$PORT}"
+else
+  URL="http://localhost:$PORT"
+fi
+
+# Report status
+curl -s -X PUT "$API" -H "Content-Type: application/json"   -d "{"status": "running", "url": "$URL"}" > /dev/null
+
+echo "[Hook] Dev server running at $URL (PID: $DEV_PID)"
+```
+
+### Pattern 5: Post-Merge Deployment
+```bash
+#!/bin/bash
+# .dmux-hooks/post_merge
+
+set -e
+cd "$DMUX_ROOT"
+
+# Only deploy from main/master
+if [ "$DMUX_TARGET_BRANCH" != "main" ] && [ "$DMUX_TARGET_BRANCH" != "master" ]; then
+  exit 0
+fi
+
+# Push to remote
+git push origin "$DMUX_TARGET_BRANCH"
+
+# Trigger deployment (example: Vercel)
+if [ -n "$VERCEL_TOKEN" ]; then
+  curl -s -X POST "https://api.vercel.com/v1/deployments"     -H "Authorization: Bearer $VERCEL_TOKEN"     -H "Content-Type: application/json"     -d '{"name": "my-project"}' > /dev/null
+fi
+
+# Close GitHub issue if prompt contains #123
+ISSUE=$(echo "$DMUX_PROMPT" | grep -oP '#Kd+' | head -1)
+if [ -n "$ISSUE" ] && command -v gh &> /dev/null; then
+  gh issue close "$ISSUE"     -c "Resolved in $DMUX_SLUG, merged to $DMUX_TARGET_BRANCH"     2>/dev/null || true
+fi
+```
+
+## Best Practices
+
+1. **Always start with shebang**: `#!/bin/bash`
+2. **Set error handling**: `set -e` (exit on error)
+3. **Make executable**: `chmod +x .dmux-hooks/hook_name`
+4. **Background long operations**: Append `&` to avoid blocking
+5. **Check for required tools**: `command -v tool &> /dev/null`
+6. **Log for debugging**: `echo "[Hook] message" >> "$DMUX_ROOT/.dmux/hooks.log"`
+7. **Handle missing vars gracefully**: `[ -z "$VAR" ] && exit 0`
+8. **Use silent curl**: `curl -s` to avoid noise in logs
+9. **Clean up temp files**: Remove files in `/tmp/`
+10. **Test before committing**: Run hooks manually with mock env vars
+
+## Testing Hooks
+
+### Manual Testing
+```bash
+# 1. Set environment variables
+export DMUX_ROOT="$(pwd)"
+export DMUX_PANE_ID="test-pane"
+export DMUX_SLUG="test-branch"
+export DMUX_WORKTREE_PATH="$(pwd)"
+export DMUX_SERVER_PORT="3142"
+export DMUX_AGENT="claude"
+export DMUX_PROMPT="Test prompt"
+
+# 2. Run hook directly
+./.dmux-hooks/worktree_created
+
+# 3. Check exit code
+echo $?  # Should be 0 for success
+```
+
+### Syntax Check
+```bash
+# Check for syntax errors without running
+bash -n ./.dmux-hooks/worktree_created
+```
+
+### Shellcheck (if available)
+```bash
+shellcheck ./.dmux-hooks/worktree_created
+```
+
+## Project Context Analysis
+
+Before creating hooks, analyze these files in the project:
+
+### Package Manager Detection
+```bash
+# Check which package manager is used
+if [ -f "pnpm-lock.yaml" ]; then
+  # Use: pnpm install, pnpm test, pnpm dev
+elif [ -f "package-lock.json" ]; then
+  # Use: npm install, npm test, npm run dev
+elif [ -f "yarn.lock" ]; then
+  # Use: yarn install, yarn test, yarn dev
+fi
+```
+
+### Test Command Discovery
+```bash
+# Read package.json to find test command
+cat package.json | grep '"test"'
+# Or with jq:
+jq -r '.scripts.test' package.json
+```
+
+### Dev Command Discovery
+```bash
+# Read package.json to find dev command
+cat package.json | grep '"dev"'
+# Or with jq:
+jq -r '.scripts.dev' package.json
+```
+
+### Environment Variables
+```bash
+# Check for .env files to copy
+ls -la | grep '.env'
+```
+
+### Build System
+```bash
+# Detect build system
+if [ -f "vite.config.ts" ]; then
+  # Vite project
+elif [ -f "next.config.js" ]; then
+  # Next.js project
+elif [ -f "nuxt.config.ts" ]; then
+  # Nuxt project
+fi
+```
+
+## Common Mistakes to Avoid
+
+❌ **Blocking operations**: `sleep 60` (blocks dmux)
+✅ **Background long tasks**: `slow_operation &`
+
+❌ **Hardcoded paths**: `/Users/me/project`
+✅ **Use variables**: `"$DMUX_ROOT"`
+
+❌ **Assuming tools exist**: `pnpm install`
+✅ **Check first**: `command -v pnpm && pnpm install`
+
+❌ **No error handling**: Script fails silently
+✅ **Set error mode**: `set -e` or check exit codes
+
+❌ **Forgetting executable bit**: Hook won't run
+✅ **Make executable**: `chmod +x`
+
+❌ **Noisy output**: Clutters dmux logs
+✅ **Silent operations**: `curl -s`, `> /dev/null 2>&1`
+
+❌ **Not testing**: Deploy and hope
+✅ **Test manually**: Run with mock env vars first
+
+## Debugging
+
+If a hook isn't working:
+
+1. **Check if file exists**: `ls -la .dmux-hooks/`
+2. **Check permissions**: Should show `x` in `rwxr-xr-x`
+3. **Check syntax**: `bash -n .dmux-hooks/hook_name`
+4. **Test manually**: Set env vars and run
+5. **Check logs**: dmux logs to stderr with `[Hooks]` prefix
+6. **Simplify**: Remove complex parts, test basic version
+7. **Check tool availability**: `command -v required_tool`
+
+### Debug Mode
+```bash
+#!/bin/bash
+# Add to top of hook for debugging
+set -x  # Print each command before executing
+set -e  # Exit on error
+
+# Your hook logic here
+```
+
+## Summary Checklist
+
+When creating a new hook:
+
+- [ ] Create file in `.dmux-hooks/`
+- [ ] Add shebang: `#!/bin/bash`
+- [ ] Make executable: `chmod +x`
+- [ ] Add `set -e` for error handling
+- [ ] Use environment variables (never hardcode paths)
+- [ ] Background long operations with `&`
+- [ ] Check for required tools before using
+- [ ] Test manually with mock env vars
+- [ ] Add comments explaining what it does
+- [ ] Commit to version control
+
+## Getting Help
+
+- **Full documentation**: See `HOOKS.md` in project root
+- **Claude-specific tips**: See `CLAUDE.md` in `.dmux-hooks/`
+- **Examples**: Check `.dmux-hooks/examples/` directory
+- **dmux API**: See `API.md` for REST endpoints
+
+---
+
+*This documentation was auto-generated from dmux source code.*
+*Version: 2026-03-21*

--- a/.dmux-hooks/AGENTS.md
+++ b/.dmux-hooks/AGENTS.md
@@ -32,45 +32,46 @@ Create executable bash scripts in `.dmux-hooks/` that run automatically at key l
 
 ### Pane Lifecycle Hooks
 
-| Hook | When | Common Use Cases |
-|------|------|------------------|
-| `before_pane_create` | Before pane creation | Validation, notifications, pre-flight checks |
-| `pane_created` | After pane, before worktree | Configure tmux settings, prepare environment |
-| `worktree_created` | After full setup | Install deps, copy configs, setup git |
-| `before_pane_close` | Before closing | Save state, backup uncommitted work |
-| `pane_closed` | After closed | Cleanup resources, analytics, notifications |
+| Hook                 | When                        | Common Use Cases                             |
+| -------------------- | --------------------------- | -------------------------------------------- |
+| `before_pane_create` | Before pane creation        | Validation, notifications, pre-flight checks |
+| `pane_created`       | After pane, before worktree | Configure tmux settings, prepare environment |
+| `worktree_created`   | After full setup            | Install deps, copy configs, setup git        |
+| `before_pane_close`  | Before closing              | Save state, backup uncommitted work          |
+| `pane_closed`        | After closed                | Cleanup resources, analytics, notifications  |
 
 ### Worktree Lifecycle Hooks
 
-| Hook | When | Common Use Cases |
-|------|------|------------------|
+| Hook                     | When                    | Common Use Cases                 |
+| ------------------------ | ----------------------- | -------------------------------- |
 | `before_worktree_remove` | Before worktree removal | Archive worktree, save artifacts |
-| `worktree_removed` | After worktree removed | Cleanup external references |
+| `worktree_removed`       | After worktree removed  | Cleanup external references      |
 
 ### Merge Lifecycle Hooks
 
-| Hook | When | Common Use Cases |
-|------|------|------------------|
-| `pre_merge` | Before merge operation | Run final tests, create backups |
+| Hook         | When                   | Common Use Cases                  |
+| ------------ | ---------------------- | --------------------------------- |
+| `pre_merge`  | Before merge operation | Run final tests, create backups   |
 | `post_merge` | After successful merge | Deploy, close issues, notify team |
 
 ### Interactive Hooks (with HTTP callbacks)
 
-| Hook | When | Common Use Cases |
-|------|------|------------------|
-| `run_test` | When tests triggered | Run test suite, report status via HTTP |
-| `run_dev` | When dev server triggered | Start dev server, create tunnel, report URL |
-
+| Hook       | When                      | Common Use Cases                            |
+| ---------- | ------------------------- | ------------------------------------------- |
+| `run_test` | When tests triggered      | Run test suite, report status via HTTP      |
+| `run_dev`  | When dev server triggered | Start dev server, create tunnel, report URL |
 
 ## Environment Variables
 
 ### Always Available
+
 ```bash
 DMUX_ROOT="/path/to/project"           # Project root directory
 DMUX_SERVER_PORT="3142"                # HTTP server port
 ```
 
 ### Pane Context (most hooks)
+
 ```bash
 DMUX_PANE_ID="dmux-1234567890"         # dmux pane identifier
 DMUX_SLUG="fix-auth-bug"               # Branch/worktree name
@@ -80,12 +81,14 @@ DMUX_TMUX_PANE_ID="%38"                # tmux pane ID
 ```
 
 ### Worktree Context
+
 ```bash
 DMUX_WORKTREE_PATH="/path/.dmux/worktrees/fix-auth-bug"
 DMUX_BRANCH="fix-auth-bug"             # Same as slug
 ```
 
 ### Merge Context
+
 ```bash
 DMUX_TARGET_BRANCH="main"              # Branch being merged into
 ```
@@ -95,6 +98,7 @@ DMUX_TARGET_BRANCH="main"              # Branch being merged into
 Interactive hooks (`run_test` and `run_dev`) can update dmux UI via HTTP.
 
 ### Update Test Status
+
 ```bash
 curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/test"   -H "Content-Type: application/json"   -d '{"status": "running", "output": "optional test output"}'
 
@@ -102,6 +106,7 @@ curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/test"   
 ```
 
 ### Update Dev Server
+
 ```bash
 curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/dev"   -H "Content-Type: application/json"   -d '{"status": "running", "url": "http://localhost:3000"}'
 
@@ -112,6 +117,7 @@ curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/dev"   -
 ## Common Patterns
 
 ### Pattern 1: Install Dependencies
+
 ```bash
 #!/bin/bash
 # .dmux-hooks/worktree_created
@@ -134,6 +140,7 @@ fi
 ```
 
 ### Pattern 2: Copy Configuration
+
 ```bash
 #!/bin/bash
 # .dmux-hooks/worktree_created
@@ -152,6 +159,7 @@ done
 ```
 
 ### Pattern 3: Run Tests with Status Updates
+
 ```bash
 #!/bin/bash
 # .dmux-hooks/run_test
@@ -181,6 +189,7 @@ rm -f "$OUTPUT_FILE"
 ```
 
 ### Pattern 4: Dev Server with Tunnel
+
 ```bash
 #!/bin/bash
 # .dmux-hooks/run_dev
@@ -216,6 +225,7 @@ echo "[Hook] Dev server running at $URL (PID: $DEV_PID)"
 ```
 
 ### Pattern 5: Post-Merge Deployment
+
 ```bash
 #!/bin/bash
 # .dmux-hooks/post_merge
@@ -259,6 +269,7 @@ fi
 ## Testing Hooks
 
 ### Manual Testing
+
 ```bash
 # 1. Set environment variables
 export DMUX_ROOT="$(pwd)"
@@ -277,12 +288,14 @@ echo $?  # Should be 0 for success
 ```
 
 ### Syntax Check
+
 ```bash
 # Check for syntax errors without running
 bash -n ./.dmux-hooks/worktree_created
 ```
 
 ### Shellcheck (if available)
+
 ```bash
 shellcheck ./.dmux-hooks/worktree_created
 ```
@@ -292,6 +305,7 @@ shellcheck ./.dmux-hooks/worktree_created
 Before creating hooks, analyze these files in the project:
 
 ### Package Manager Detection
+
 ```bash
 # Check which package manager is used
 if [ -f "pnpm-lock.yaml" ]; then
@@ -304,6 +318,7 @@ fi
 ```
 
 ### Test Command Discovery
+
 ```bash
 # Read package.json to find test command
 cat package.json | grep '"test"'
@@ -312,6 +327,7 @@ jq -r '.scripts.test' package.json
 ```
 
 ### Dev Command Discovery
+
 ```bash
 # Read package.json to find dev command
 cat package.json | grep '"dev"'
@@ -320,12 +336,14 @@ jq -r '.scripts.dev' package.json
 ```
 
 ### Environment Variables
+
 ```bash
 # Check for .env files to copy
 ls -la | grep '.env'
 ```
 
 ### Build System
+
 ```bash
 # Detect build system
 if [ -f "vite.config.ts" ]; then
@@ -373,6 +391,7 @@ If a hook isn't working:
 7. **Check tool availability**: `command -v required_tool`
 
 ### Debug Mode
+
 ```bash
 #!/bin/bash
 # Add to top of hook for debugging
@@ -406,5 +425,5 @@ When creating a new hook:
 
 ---
 
-*This documentation was auto-generated from dmux source code.*
-*Version: 2026-03-21*
+_This documentation was auto-generated from dmux source code._
+_Version: 2026-03-21_

--- a/.dmux-hooks/CLAUDE.md
+++ b/.dmux-hooks/CLAUDE.md
@@ -1,0 +1,410 @@
+# dmux Hooks System - Agent Reference
+
+**Auto-generated documentation for AI agents**
+
+This document contains everything an AI agent needs to create, modify, and understand dmux hooks. It is automatically generated from the dmux source code and embedded in the binary.
+
+## What You're Working On
+
+You are editing hooks for **dmux**, a tmux pane manager that creates AI-powered development workflows. Each pane runs in its own git worktree with an AI agent.
+
+## Your Goal
+
+Create executable bash scripts in `.dmux-hooks/` that run automatically at key lifecycle events.
+
+## Quick Start
+
+1. **Create a hook file**: `touch .dmux-hooks/worktree_created`
+2. **Make it executable**: `chmod +x .dmux-hooks/worktree_created`
+3. **Add shebang**: Start with `#!/bin/bash`
+4. **Use environment variables**: Access `$DMUX_ROOT`, `$DMUX_WORKTREE_PATH`, etc.
+5. **Test it**: Set env vars manually and run the script
+
+## Hook Execution Model
+
+- **Non-blocking**: Hooks run in background (detached processes)
+- **Silent failures**: Hook errors are logged but don't stop dmux
+- **Environment-based**: All context passed via environment variables
+- **Version controlled**: Hooks in `.dmux-hooks/` are shared with team
+- **Priority resolution**: `.dmux-hooks/` → `.dmux/hooks/` → `~/.dmux/hooks/`
+
+## Available Hooks
+
+### Pane Lifecycle Hooks
+
+| Hook | When | Common Use Cases |
+|------|------|------------------|
+| `before_pane_create` | Before pane creation | Validation, notifications, pre-flight checks |
+| `pane_created` | After pane, before worktree | Configure tmux settings, prepare environment |
+| `worktree_created` | After full setup | Install deps, copy configs, setup git |
+| `before_pane_close` | Before closing | Save state, backup uncommitted work |
+| `pane_closed` | After closed | Cleanup resources, analytics, notifications |
+
+### Worktree Lifecycle Hooks
+
+| Hook | When | Common Use Cases |
+|------|------|------------------|
+| `before_worktree_remove` | Before worktree removal | Archive worktree, save artifacts |
+| `worktree_removed` | After worktree removed | Cleanup external references |
+
+### Merge Lifecycle Hooks
+
+| Hook | When | Common Use Cases |
+|------|------|------------------|
+| `pre_merge` | Before merge operation | Run final tests, create backups |
+| `post_merge` | After successful merge | Deploy, close issues, notify team |
+
+### Interactive Hooks (with HTTP callbacks)
+
+| Hook | When | Common Use Cases |
+|------|------|------------------|
+| `run_test` | When tests triggered | Run test suite, report status via HTTP |
+| `run_dev` | When dev server triggered | Start dev server, create tunnel, report URL |
+
+
+## Environment Variables
+
+### Always Available
+```bash
+DMUX_ROOT="/path/to/project"           # Project root directory
+DMUX_SERVER_PORT="3142"                # HTTP server port
+```
+
+### Pane Context (most hooks)
+```bash
+DMUX_PANE_ID="dmux-1234567890"         # dmux pane identifier
+DMUX_SLUG="fix-auth-bug"               # Branch/worktree name
+DMUX_PROMPT="Fix authentication bug"   # User's prompt
+DMUX_AGENT="claude"                    # Agent type (registry id, e.g. claude, codex, opencode)
+DMUX_TMUX_PANE_ID="%38"                # tmux pane ID
+```
+
+### Worktree Context
+```bash
+DMUX_WORKTREE_PATH="/path/.dmux/worktrees/fix-auth-bug"
+DMUX_BRANCH="fix-auth-bug"             # Same as slug
+```
+
+### Merge Context
+```bash
+DMUX_TARGET_BRANCH="main"              # Branch being merged into
+```
+
+## HTTP Callback API
+
+Interactive hooks (`run_test` and `run_dev`) can update dmux UI via HTTP.
+
+### Update Test Status
+```bash
+curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/test"   -H "Content-Type: application/json"   -d '{"status": "running", "output": "optional test output"}'
+
+# Status values: "running" | "passed" | "failed"
+```
+
+### Update Dev Server
+```bash
+curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/dev"   -H "Content-Type: application/json"   -d '{"status": "running", "url": "http://localhost:3000"}'
+
+# Status values: "running" | "stopped"
+# url: Can be localhost or tunnel URL (ngrok, cloudflared, etc.)
+```
+
+## Common Patterns
+
+### Pattern 1: Install Dependencies
+```bash
+#!/bin/bash
+# .dmux-hooks/worktree_created
+
+cd "$DMUX_WORKTREE_PATH"
+
+if [ -f "pnpm-lock.yaml" ]; then
+  pnpm install --prefer-offline &
+elif [ -f "package-lock.json" ]; then
+  npm install &
+elif [ -f "yarn.lock" ]; then
+  yarn install &
+elif [ -f "Gemfile" ]; then
+  bundle install &
+elif [ -f "requirements.txt" ]; then
+  pip install -r requirements.txt &
+elif [ -f "Cargo.toml" ]; then
+  cargo build &
+fi
+```
+
+### Pattern 2: Copy Configuration
+```bash
+#!/bin/bash
+# .dmux-hooks/worktree_created
+
+# Copy environment file
+if [ -f "$DMUX_ROOT/.env.local" ]; then
+  cp "$DMUX_ROOT/.env.local" "$DMUX_WORKTREE_PATH/.env.local"
+fi
+
+# Copy other config files
+for file in .env.development .npmrc .yarnrc; do
+  if [ -f "$DMUX_ROOT/$file" ]; then
+    cp "$DMUX_ROOT/$file" "$DMUX_WORKTREE_PATH/$file"
+  fi
+done
+```
+
+### Pattern 3: Run Tests with Status Updates
+```bash
+#!/bin/bash
+# .dmux-hooks/run_test
+
+set -e
+cd "$DMUX_WORKTREE_PATH"
+API="http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/test"
+
+# Update: starting
+curl -s -X PUT "$API" -H "Content-Type: application/json"   -d '{"status": "running"}' > /dev/null
+
+# Run tests and capture output
+OUTPUT_FILE="/tmp/dmux-test-$DMUX_PANE_ID.txt"
+if pnpm test > "$OUTPUT_FILE" 2>&1; then
+  STATUS="passed"
+else
+  STATUS="failed"
+fi
+
+# Get output (truncate if too long)
+OUTPUT=$(head -c 5000 "$OUTPUT_FILE")
+
+# Update: complete
+curl -s -X PUT "$API" -H "Content-Type: application/json"   -d "$(jq -n --arg status "$STATUS" --arg output "$OUTPUT"     '{status: $status, output: $output}')" > /dev/null
+
+rm -f "$OUTPUT_FILE"
+```
+
+### Pattern 4: Dev Server with Tunnel
+```bash
+#!/bin/bash
+# .dmux-hooks/run_dev
+
+set -e
+cd "$DMUX_WORKTREE_PATH"
+API="http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/dev"
+
+# Start dev server in background
+LOG_FILE="/tmp/dmux-dev-$DMUX_PANE_ID.log"
+pnpm dev > "$LOG_FILE" 2>&1 &
+DEV_PID=$!
+
+# Wait for server to start
+sleep 5
+
+# Detect port from logs
+PORT=$(grep -oP 'localhost:Kd+' "$LOG_FILE" | head -1)
+[ -z "$PORT" ] && PORT=3000
+
+# Optional: Create tunnel with cloudflared
+if command -v cloudflared &> /dev/null; then
+  TUNNEL=$(cloudflared tunnel --url "http://localhost:$PORT" 2>&1 |     grep -oP 'https://[a-z0-9-]+.trycloudflare.com' | head -1)
+  URL="${TUNNEL:-http://localhost:$PORT}"
+else
+  URL="http://localhost:$PORT"
+fi
+
+# Report status
+curl -s -X PUT "$API" -H "Content-Type: application/json"   -d "{"status": "running", "url": "$URL"}" > /dev/null
+
+echo "[Hook] Dev server running at $URL (PID: $DEV_PID)"
+```
+
+### Pattern 5: Post-Merge Deployment
+```bash
+#!/bin/bash
+# .dmux-hooks/post_merge
+
+set -e
+cd "$DMUX_ROOT"
+
+# Only deploy from main/master
+if [ "$DMUX_TARGET_BRANCH" != "main" ] && [ "$DMUX_TARGET_BRANCH" != "master" ]; then
+  exit 0
+fi
+
+# Push to remote
+git push origin "$DMUX_TARGET_BRANCH"
+
+# Trigger deployment (example: Vercel)
+if [ -n "$VERCEL_TOKEN" ]; then
+  curl -s -X POST "https://api.vercel.com/v1/deployments"     -H "Authorization: Bearer $VERCEL_TOKEN"     -H "Content-Type: application/json"     -d '{"name": "my-project"}' > /dev/null
+fi
+
+# Close GitHub issue if prompt contains #123
+ISSUE=$(echo "$DMUX_PROMPT" | grep -oP '#Kd+' | head -1)
+if [ -n "$ISSUE" ] && command -v gh &> /dev/null; then
+  gh issue close "$ISSUE"     -c "Resolved in $DMUX_SLUG, merged to $DMUX_TARGET_BRANCH"     2>/dev/null || true
+fi
+```
+
+## Best Practices
+
+1. **Always start with shebang**: `#!/bin/bash`
+2. **Set error handling**: `set -e` (exit on error)
+3. **Make executable**: `chmod +x .dmux-hooks/hook_name`
+4. **Background long operations**: Append `&` to avoid blocking
+5. **Check for required tools**: `command -v tool &> /dev/null`
+6. **Log for debugging**: `echo "[Hook] message" >> "$DMUX_ROOT/.dmux/hooks.log"`
+7. **Handle missing vars gracefully**: `[ -z "$VAR" ] && exit 0`
+8. **Use silent curl**: `curl -s` to avoid noise in logs
+9. **Clean up temp files**: Remove files in `/tmp/`
+10. **Test before committing**: Run hooks manually with mock env vars
+
+## Testing Hooks
+
+### Manual Testing
+```bash
+# 1. Set environment variables
+export DMUX_ROOT="$(pwd)"
+export DMUX_PANE_ID="test-pane"
+export DMUX_SLUG="test-branch"
+export DMUX_WORKTREE_PATH="$(pwd)"
+export DMUX_SERVER_PORT="3142"
+export DMUX_AGENT="claude"
+export DMUX_PROMPT="Test prompt"
+
+# 2. Run hook directly
+./.dmux-hooks/worktree_created
+
+# 3. Check exit code
+echo $?  # Should be 0 for success
+```
+
+### Syntax Check
+```bash
+# Check for syntax errors without running
+bash -n ./.dmux-hooks/worktree_created
+```
+
+### Shellcheck (if available)
+```bash
+shellcheck ./.dmux-hooks/worktree_created
+```
+
+## Project Context Analysis
+
+Before creating hooks, analyze these files in the project:
+
+### Package Manager Detection
+```bash
+# Check which package manager is used
+if [ -f "pnpm-lock.yaml" ]; then
+  # Use: pnpm install, pnpm test, pnpm dev
+elif [ -f "package-lock.json" ]; then
+  # Use: npm install, npm test, npm run dev
+elif [ -f "yarn.lock" ]; then
+  # Use: yarn install, yarn test, yarn dev
+fi
+```
+
+### Test Command Discovery
+```bash
+# Read package.json to find test command
+cat package.json | grep '"test"'
+# Or with jq:
+jq -r '.scripts.test' package.json
+```
+
+### Dev Command Discovery
+```bash
+# Read package.json to find dev command
+cat package.json | grep '"dev"'
+# Or with jq:
+jq -r '.scripts.dev' package.json
+```
+
+### Environment Variables
+```bash
+# Check for .env files to copy
+ls -la | grep '.env'
+```
+
+### Build System
+```bash
+# Detect build system
+if [ -f "vite.config.ts" ]; then
+  # Vite project
+elif [ -f "next.config.js" ]; then
+  # Next.js project
+elif [ -f "nuxt.config.ts" ]; then
+  # Nuxt project
+fi
+```
+
+## Common Mistakes to Avoid
+
+❌ **Blocking operations**: `sleep 60` (blocks dmux)
+✅ **Background long tasks**: `slow_operation &`
+
+❌ **Hardcoded paths**: `/Users/me/project`
+✅ **Use variables**: `"$DMUX_ROOT"`
+
+❌ **Assuming tools exist**: `pnpm install`
+✅ **Check first**: `command -v pnpm && pnpm install`
+
+❌ **No error handling**: Script fails silently
+✅ **Set error mode**: `set -e` or check exit codes
+
+❌ **Forgetting executable bit**: Hook won't run
+✅ **Make executable**: `chmod +x`
+
+❌ **Noisy output**: Clutters dmux logs
+✅ **Silent operations**: `curl -s`, `> /dev/null 2>&1`
+
+❌ **Not testing**: Deploy and hope
+✅ **Test manually**: Run with mock env vars first
+
+## Debugging
+
+If a hook isn't working:
+
+1. **Check if file exists**: `ls -la .dmux-hooks/`
+2. **Check permissions**: Should show `x` in `rwxr-xr-x`
+3. **Check syntax**: `bash -n .dmux-hooks/hook_name`
+4. **Test manually**: Set env vars and run
+5. **Check logs**: dmux logs to stderr with `[Hooks]` prefix
+6. **Simplify**: Remove complex parts, test basic version
+7. **Check tool availability**: `command -v required_tool`
+
+### Debug Mode
+```bash
+#!/bin/bash
+# Add to top of hook for debugging
+set -x  # Print each command before executing
+set -e  # Exit on error
+
+# Your hook logic here
+```
+
+## Summary Checklist
+
+When creating a new hook:
+
+- [ ] Create file in `.dmux-hooks/`
+- [ ] Add shebang: `#!/bin/bash`
+- [ ] Make executable: `chmod +x`
+- [ ] Add `set -e` for error handling
+- [ ] Use environment variables (never hardcode paths)
+- [ ] Background long operations with `&`
+- [ ] Check for required tools before using
+- [ ] Test manually with mock env vars
+- [ ] Add comments explaining what it does
+- [ ] Commit to version control
+
+## Getting Help
+
+- **Full documentation**: See `HOOKS.md` in project root
+- **Claude-specific tips**: See `CLAUDE.md` in `.dmux-hooks/`
+- **Examples**: Check `.dmux-hooks/examples/` directory
+- **dmux API**: See `API.md` for REST endpoints
+
+---
+
+*This documentation was auto-generated from dmux source code.*
+*Version: 2026-03-21*

--- a/.dmux-hooks/CLAUDE.md
+++ b/.dmux-hooks/CLAUDE.md
@@ -32,45 +32,46 @@ Create executable bash scripts in `.dmux-hooks/` that run automatically at key l
 
 ### Pane Lifecycle Hooks
 
-| Hook | When | Common Use Cases |
-|------|------|------------------|
-| `before_pane_create` | Before pane creation | Validation, notifications, pre-flight checks |
-| `pane_created` | After pane, before worktree | Configure tmux settings, prepare environment |
-| `worktree_created` | After full setup | Install deps, copy configs, setup git |
-| `before_pane_close` | Before closing | Save state, backup uncommitted work |
-| `pane_closed` | After closed | Cleanup resources, analytics, notifications |
+| Hook                 | When                        | Common Use Cases                             |
+| -------------------- | --------------------------- | -------------------------------------------- |
+| `before_pane_create` | Before pane creation        | Validation, notifications, pre-flight checks |
+| `pane_created`       | After pane, before worktree | Configure tmux settings, prepare environment |
+| `worktree_created`   | After full setup            | Install deps, copy configs, setup git        |
+| `before_pane_close`  | Before closing              | Save state, backup uncommitted work          |
+| `pane_closed`        | After closed                | Cleanup resources, analytics, notifications  |
 
 ### Worktree Lifecycle Hooks
 
-| Hook | When | Common Use Cases |
-|------|------|------------------|
+| Hook                     | When                    | Common Use Cases                 |
+| ------------------------ | ----------------------- | -------------------------------- |
 | `before_worktree_remove` | Before worktree removal | Archive worktree, save artifacts |
-| `worktree_removed` | After worktree removed | Cleanup external references |
+| `worktree_removed`       | After worktree removed  | Cleanup external references      |
 
 ### Merge Lifecycle Hooks
 
-| Hook | When | Common Use Cases |
-|------|------|------------------|
-| `pre_merge` | Before merge operation | Run final tests, create backups |
+| Hook         | When                   | Common Use Cases                  |
+| ------------ | ---------------------- | --------------------------------- |
+| `pre_merge`  | Before merge operation | Run final tests, create backups   |
 | `post_merge` | After successful merge | Deploy, close issues, notify team |
 
 ### Interactive Hooks (with HTTP callbacks)
 
-| Hook | When | Common Use Cases |
-|------|------|------------------|
-| `run_test` | When tests triggered | Run test suite, report status via HTTP |
-| `run_dev` | When dev server triggered | Start dev server, create tunnel, report URL |
-
+| Hook       | When                      | Common Use Cases                            |
+| ---------- | ------------------------- | ------------------------------------------- |
+| `run_test` | When tests triggered      | Run test suite, report status via HTTP      |
+| `run_dev`  | When dev server triggered | Start dev server, create tunnel, report URL |
 
 ## Environment Variables
 
 ### Always Available
+
 ```bash
 DMUX_ROOT="/path/to/project"           # Project root directory
 DMUX_SERVER_PORT="3142"                # HTTP server port
 ```
 
 ### Pane Context (most hooks)
+
 ```bash
 DMUX_PANE_ID="dmux-1234567890"         # dmux pane identifier
 DMUX_SLUG="fix-auth-bug"               # Branch/worktree name
@@ -80,12 +81,14 @@ DMUX_TMUX_PANE_ID="%38"                # tmux pane ID
 ```
 
 ### Worktree Context
+
 ```bash
 DMUX_WORKTREE_PATH="/path/.dmux/worktrees/fix-auth-bug"
 DMUX_BRANCH="fix-auth-bug"             # Same as slug
 ```
 
 ### Merge Context
+
 ```bash
 DMUX_TARGET_BRANCH="main"              # Branch being merged into
 ```
@@ -95,6 +98,7 @@ DMUX_TARGET_BRANCH="main"              # Branch being merged into
 Interactive hooks (`run_test` and `run_dev`) can update dmux UI via HTTP.
 
 ### Update Test Status
+
 ```bash
 curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/test"   -H "Content-Type: application/json"   -d '{"status": "running", "output": "optional test output"}'
 
@@ -102,6 +106,7 @@ curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/test"   
 ```
 
 ### Update Dev Server
+
 ```bash
 curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/dev"   -H "Content-Type: application/json"   -d '{"status": "running", "url": "http://localhost:3000"}'
 
@@ -112,6 +117,7 @@ curl -X PUT "http://localhost:$DMUX_SERVER_PORT/api/panes/$DMUX_PANE_ID/dev"   -
 ## Common Patterns
 
 ### Pattern 1: Install Dependencies
+
 ```bash
 #!/bin/bash
 # .dmux-hooks/worktree_created
@@ -134,6 +140,7 @@ fi
 ```
 
 ### Pattern 2: Copy Configuration
+
 ```bash
 #!/bin/bash
 # .dmux-hooks/worktree_created
@@ -152,6 +159,7 @@ done
 ```
 
 ### Pattern 3: Run Tests with Status Updates
+
 ```bash
 #!/bin/bash
 # .dmux-hooks/run_test
@@ -181,6 +189,7 @@ rm -f "$OUTPUT_FILE"
 ```
 
 ### Pattern 4: Dev Server with Tunnel
+
 ```bash
 #!/bin/bash
 # .dmux-hooks/run_dev
@@ -216,6 +225,7 @@ echo "[Hook] Dev server running at $URL (PID: $DEV_PID)"
 ```
 
 ### Pattern 5: Post-Merge Deployment
+
 ```bash
 #!/bin/bash
 # .dmux-hooks/post_merge
@@ -259,6 +269,7 @@ fi
 ## Testing Hooks
 
 ### Manual Testing
+
 ```bash
 # 1. Set environment variables
 export DMUX_ROOT="$(pwd)"
@@ -277,12 +288,14 @@ echo $?  # Should be 0 for success
 ```
 
 ### Syntax Check
+
 ```bash
 # Check for syntax errors without running
 bash -n ./.dmux-hooks/worktree_created
 ```
 
 ### Shellcheck (if available)
+
 ```bash
 shellcheck ./.dmux-hooks/worktree_created
 ```
@@ -292,6 +305,7 @@ shellcheck ./.dmux-hooks/worktree_created
 Before creating hooks, analyze these files in the project:
 
 ### Package Manager Detection
+
 ```bash
 # Check which package manager is used
 if [ -f "pnpm-lock.yaml" ]; then
@@ -304,6 +318,7 @@ fi
 ```
 
 ### Test Command Discovery
+
 ```bash
 # Read package.json to find test command
 cat package.json | grep '"test"'
@@ -312,6 +327,7 @@ jq -r '.scripts.test' package.json
 ```
 
 ### Dev Command Discovery
+
 ```bash
 # Read package.json to find dev command
 cat package.json | grep '"dev"'
@@ -320,12 +336,14 @@ jq -r '.scripts.dev' package.json
 ```
 
 ### Environment Variables
+
 ```bash
 # Check for .env files to copy
 ls -la | grep '.env'
 ```
 
 ### Build System
+
 ```bash
 # Detect build system
 if [ -f "vite.config.ts" ]; then
@@ -373,6 +391,7 @@ If a hook isn't working:
 7. **Check tool availability**: `command -v required_tool`
 
 ### Debug Mode
+
 ```bash
 #!/bin/bash
 # Add to top of hook for debugging
@@ -406,5 +425,5 @@ When creating a new hook:
 
 ---
 
-*This documentation was auto-generated from dmux source code.*
-*Version: 2026-03-21*
+_This documentation was auto-generated from dmux source code._
+_Version: 2026-03-21_

--- a/.dmux-hooks/README.md
+++ b/.dmux-hooks/README.md
@@ -1,0 +1,53 @@
+# dmux Hooks
+
+This directory contains hooks that run automatically at key lifecycle events in dmux.
+
+## Quick Start
+
+1. **Read the documentation**:
+   - `AGENTS.md` - Complete reference (for any AI agent)
+   - `CLAUDE.md` - Same content (Claude Code looks for this filename)
+
+2. **Check examples**:
+   - `examples/` directory contains starter templates
+
+3. **Create a hook**:
+   ```bash
+   touch worktree_created
+   chmod +x worktree_created
+   nano worktree_created
+   ```
+
+4. **Test it**:
+   ```bash
+   export DMUX_ROOT="$(pwd)"
+   export DMUX_WORKTREE_PATH="$(pwd)"
+   ./worktree_created
+   ```
+
+## Available Hooks
+
+- `before_pane_create` - Before pane creation
+- `pane_created` - After pane created
+- `worktree_created` - After worktree setup
+- `before_pane_close` - Before closing
+- `pane_closed` - After closed
+- `before_worktree_remove` - Before worktree removal
+- `worktree_removed` - After worktree removed
+- `pre_merge` - Before merge
+- `post_merge` - After merge
+- `run_test` - When running tests
+- `run_dev` - When starting dev server
+
+## Documentation
+
+See `AGENTS.md` or `CLAUDE.md` for complete documentation including:
+- Environment variables
+- HTTP callback API
+- Common patterns
+- Best practices
+- Testing strategies
+
+## Note
+
+This directory is **version controlled**. Hooks you create here will be shared with your team.

--- a/.dmux-hooks/README.md
+++ b/.dmux-hooks/README.md
@@ -12,6 +12,7 @@ This directory contains hooks that run automatically at key lifecycle events in 
    - `examples/` directory contains starter templates
 
 3. **Create a hook**:
+
    ```bash
    touch worktree_created
    chmod +x worktree_created
@@ -42,6 +43,7 @@ This directory contains hooks that run automatically at key lifecycle events in 
 ## Documentation
 
 See `AGENTS.md` or `CLAUDE.md` for complete documentation including:
+
 - Environment variables
 - HTTP callback API
 - Common patterns

--- a/.dmux-hooks/examples/worktree_created.example
+++ b/.dmux-hooks/examples/worktree_created.example
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Example: worktree_created hook
+#
+# This hook runs after a new worktree is created and the agent is launched.
+# Use it to set up the worktree environment (install deps, copy configs, etc.)
+
+set -e  # Exit on error
+
+echo "[Hook] Setting up worktree: $DMUX_SLUG"
+
+cd "$DMUX_WORKTREE_PATH"
+
+# Install dependencies in background (don't block dmux)
+if [ -f "pnpm-lock.yaml" ]; then
+  echo "[Hook] Installing dependencies with pnpm..."
+  pnpm install --prefer-offline &
+elif [ -f "package-lock.json" ]; then
+  echo "[Hook] Installing dependencies with npm..."
+  npm install &
+elif [ -f "yarn.lock" ]; then
+  echo "[Hook] Installing dependencies with yarn..."
+  yarn install &
+fi
+
+# Copy environment file if it exists
+if [ -f "$DMUX_ROOT/.env.local" ]; then
+  echo "[Hook] Copying .env.local"
+  cp "$DMUX_ROOT/.env.local" "$DMUX_WORKTREE_PATH/.env.local"
+fi
+
+# Keep existing git author identity.
+# Do not set git user.name/user.email in this hook.
+
+# Create a log entry
+echo "[$(date)] Created worktree: $DMUX_SLUG | Agent: $DMUX_AGENT | Prompt: $DMUX_PROMPT" \
+  >> "$DMUX_ROOT/.dmux/worktree_history.log"
+
+echo "[Hook] Worktree setup complete!"

--- a/.dmux-hooks/worktree_created
+++ b/.dmux-hooks/worktree_created
@@ -1,9 +1,21 @@
 #!/bin/bash
 # dmux worktree_created hook
-# 親リポの .claude/settings.local.json を新 worktree にマージし、
-# Claude Code permissions を引き継ぐ。
+# 1. 親リポの .claude/settings.local.json を新 worktree にマージし、
+#    Claude Code permissions を引き継ぐ
+# 2. pnpm 依存解決 + i18n コンパイルを背景で走らせ、Claude の Stop hook
+#    (precheck:full) が node_modules / messages.mjs 欠落で落ちないようにする
 
 set -uo pipefail
+
+# 依存解決と i18n コンパイルを background で開始（dmux を止めない）
+if [ -f "$DMUX_WORKTREE_PATH/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
+  echo "[Hook] installing deps & compiling i18n (background)"
+  (
+    cd "$DMUX_WORKTREE_PATH" && \
+    pnpm install --prefer-offline && \
+    (pnpm i18n:compile 2>/dev/null || true)
+  ) &
+fi
 
 ROOT_SETTINGS="$DMUX_ROOT/.claude/settings.local.json"
 WORKTREE_SETTINGS="$DMUX_WORKTREE_PATH/.claude/settings.local.json"

--- a/.dmux-hooks/worktree_created
+++ b/.dmux-hooks/worktree_created
@@ -1,0 +1,46 @@
+#!/bin/bash
+# dmux worktree_created hook
+# 親リポの .claude/settings.local.json を新 worktree にマージし、
+# Claude Code permissions を引き継ぐ。
+
+set -uo pipefail
+
+ROOT_SETTINGS="$DMUX_ROOT/.claude/settings.local.json"
+WORKTREE_SETTINGS="$DMUX_WORKTREE_PATH/.claude/settings.local.json"
+
+if [ ! -f "$ROOT_SETTINGS" ]; then
+  echo "[Hook] no parent .claude/settings.local.json — skip"
+  exit 0
+fi
+
+mkdir -p "$DMUX_WORKTREE_PATH/.claude"
+
+if [ ! -f "$WORKTREE_SETTINGS" ]; then
+  cp "$ROOT_SETTINGS" "$WORKTREE_SETTINGS"
+  echo "[Hook] copied .claude/settings.local.json"
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[Hook] jq not found — overwriting with parent settings"
+  cp "$ROOT_SETTINGS" "$WORKTREE_SETTINGS"
+  exit 0
+fi
+
+TMP="$(mktemp)"
+if jq -s '
+  .[0] as $a | .[1] as $b |
+  ($a * $b) |
+  .permissions = (
+    (($a.permissions // {}) * ($b.permissions // {}))
+    | .allow = ((($a.permissions.allow // []) + ($b.permissions.allow // [])) | unique)
+    | .deny  = ((($a.permissions.deny  // []) + ($b.permissions.deny  // [])) | unique)
+    | .ask   = ((($a.permissions.ask   // []) + ($b.permissions.ask   // [])) | unique)
+  )
+' "$ROOT_SETTINGS" "$WORKTREE_SETTINGS" > "$TMP"; then
+  mv "$TMP" "$WORKTREE_SETTINGS"
+  echo "[Hook] merged .claude/settings.local.json"
+else
+  echo "[Hook] jq merge failed — keeping worktree file as-is"
+  rm -f "$TMP"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ certificates/
 
 # claude local settings
 .claude/settings.local.json
+
+# dmux runtime metadata and worktrees
+.dmux/


### PR DESCRIPTION
## Summary

- 新しい dmux pane / worktree を作成するたびに Claude Code の `Bash(...)` permissions が全てリセットされ、許可済みのコマンドにも毎度プロンプトが出ていた
- 親リポの `.claude/settings.local.json` に蓄積された permissions を、worktree 作成直後に `worktree_created` フックで自動マージするようにした
- 併せて `.dmux-hooks/` のフック仕様ドキュメント・サンプル一式をリポに取り込み、`.dmux/` を `.gitignore` に追加

## 変更内容

| ファイル | 内容 |
|---|---|
| `.dmux-hooks/worktree_created` | 新規実装。`jq` で親リポと worktree の `permissions.{allow,deny,ask}` を `unique` マージ。`.claude/` ディレクトリ作成・ファイル不在時単純コピー・`jq` 未インストール時のフォールバックも対応 |
| `.dmux-hooks/{CLAUDE,AGENTS,README}.md` / `examples/worktree_created.example` | 既存テンプレート・仕様ドキュメントを git 管理下に取り込み（ローカルにしか存在していなかった）。oxfmt に準拠させるため整形 |
| `.gitignore` | `.dmux/` を追加。dmux 生成物（worktrees / metadata）を追跡対象外に |

## 動作の概要

```
新 worktree 作成
  ↓ dmux が worktree_created フックを実行（環境変数 $DMUX_ROOT, $DMUX_WORKTREE_PATH）
  ↓ 親リポの .claude/settings.local.json を jq でマージ
新 worktree の .claude/settings.local.json に親リポの permissions が引き継がれる
```

- 既存の dmux pane には影響なし。次回以降の新規 pane 作成から自動で効く（commit 不要、フックは ファイル存在＋実行ビットだけで有効化）

## Test plan

- [x] dry-run（worktree 側ファイル不在）: `cp` が走り親リポと同一内容になることを確認
- [x] dry-run（worktree 側ファイル既存）: `jq` でマージされ親 20件 + worktree 独自 1件 → 21件、worktree 独自キー (`enableAllProjectMcpServers`) も保持
- [x] `pnpm precheck` グリーン（typecheck / lint / format:check / i18n:check 全 pass）
- [ ] 実際に新規 dmux pane を立て、`Bash(...)` 系 permissions プロンプトが出ないことを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)