### PR TITLE
chore: worktree_created フックでローカル D1 マイグレーションも適用

### DIFF
--- a/.dmux-hooks/worktree_created
+++ b/.dmux-hooks/worktree_created
@@ -2,18 +2,21 @@
 # dmux worktree_created hook
 # 1. 親リポの .claude/settings.local.json を新 worktree にマージし、
 #    Claude Code permissions を引き継ぐ
-# 2. pnpm 依存解決 + i18n コンパイルを背景で走らせ、Claude の Stop hook
-#    (precheck:full) が node_modules / messages.mjs 欠落で落ちないようにする
+# 2. pnpm 依存解決 + i18n コンパイル + ローカル D1 マイグレーションを
+#    背景で走らせ、Claude の Stop hook (precheck:full) や API 開発が
+#    node_modules / messages.mjs / 未適用マイグレーションで落ちないようにする
 
 set -uo pipefail
 
-# 依存解決と i18n コンパイルを background で開始（dmux を止めない）
+# 依存解決・i18n コンパイル・ローカル D1 マイグレーションを background で開始
+# （dmux を止めない）
 if [ -f "$DMUX_WORKTREE_PATH/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
-  echo "[Hook] installing deps & compiling i18n (background)"
+  echo "[Hook] installing deps & compiling i18n & applying local migrations (background)"
   (
     cd "$DMUX_WORKTREE_PATH" && \
     pnpm install --prefer-offline && \
-    (pnpm i18n:compile 2>/dev/null || true)
+    (pnpm i18n:compile 2>/dev/null || true) && \
+    (pnpm db:migrate:local 2>/dev/null || true)
   ) &
 fi
 


### PR DESCRIPTION
## Summary
- `.dmux-hooks/worktree_created` の background ブロックに `pnpm db:migrate:local` を追加。
- 新 worktree で `.wrangler/state/v3/d1` が空のまま放置されて API 開発・workers テストが動かない問題を解消する（worktree ごとに `.wrangler/` が独立しているため）。
- 既存の `pnpm install --prefer-offline` → `pnpm i18n:compile` の後段に並べる形で、main の構造を踏襲した最小差分。失敗しても次の処理に影響しないよう `2>/dev/null || true` で握りつぶす方針も既存に合わせた。

## Test plan
- [x] `bash -n .dmux-hooks/worktree_created` で構文 OK
- [x] 実行権限 `-rwxr-xr-x` を維持
- [ ] 新規 dmux pane を作成し、`node_modules` / `src/locales/*/messages.mjs` / `.wrangler/state/v3/d1/*.sqlite` が自動生成されることを確認
- [ ] 既存挙動（`.claude/settings.local.json` のマージ）が回帰していないことを確認

## 備考
シェルスクリプトのみの変更のため `pnpm precheck` の対象外（TS / lint / i18n / test には影響しない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)