### PR TITLE
test: DigestCard と LocaleSelector のテストを追加 (Unit 17/21 of #143)

### DIFF
--- a/src/components/digest/DigestCard.test.tsx
+++ b/src/components/digest/DigestCard.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Digest } from "@/types";
+import { renderWithProviders } from "@/test/testUtils";
+import DigestCard from "./DigestCard";
+
+const mockMarkRead = vi.hoisted(() => vi.fn());
+
+vi.mock("@/stores/digestAtoms", async () => {
+  const { atom: jotaiAtom } =
+    await vi.importActual<typeof import("jotai")>("jotai");
+  return {
+    markDigestReadAtom: jotaiAtom(undefined, (_get, _set, id: string) => {
+      mockMarkRead(id);
+    }),
+  };
+});
+
+const FIXED_TIMESTAMP = new Date("2026-04-01T00:00:00Z").getTime();
+
+const createTestDigest = (overrides: Partial<Digest> = {}): Digest => ({
+  id: "digest-1",
+  userId: "user-1",
+  accuracyScore: 0.85,
+  confirmedCount: 12,
+  uncertainCount: 5,
+  unknownCount: 3,
+  totalGarments: 20,
+  isRead: false,
+  generatedAt: FIXED_TIMESTAMP,
+  createdAt: FIXED_TIMESTAMP,
+  ...overrides,
+});
+
+describe("DigestCard", () => {
+  beforeEach(() => {
+    mockMarkRead.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("未読時は「未読」バッジと既読化ボタンが表示される", async () => {
+    await renderWithProviders(<DigestCard digest={createTestDigest()} />);
+
+    expect(screen.getByText("未読")).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: "既読にする" });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+  });
+
+  it("既読時は「未読」バッジが非表示で、ボタンが無効化される", async () => {
+    await renderWithProviders(
+      <DigestCard digest={createTestDigest({ isRead: true })} />,
+    );
+
+    expect(screen.queryByText("未読")).not.toBeInTheDocument();
+    const button = screen.getByRole("button", { name: "既読済み" });
+    expect(button).toBeDisabled();
+  });
+
+  it("未読ボタンを押すと markRead が digest id で呼ばれる", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(
+      <DigestCard digest={createTestDigest({ id: "digest-99" })} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "既読にする" }));
+
+    expect(mockMarkRead).toHaveBeenCalledTimes(1);
+    expect(mockMarkRead).toHaveBeenCalledWith("digest-99");
+  });
+
+  it("既読時にボタンを押しても markRead は呼ばれない", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(
+      <DigestCard digest={createTestDigest({ isRead: true })} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "既読済み" }));
+
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("accuracyScore がパーセント表示される", async () => {
+    await renderWithProviders(
+      <DigestCard digest={createTestDigest({ accuracyScore: 0.756 })} />,
+    );
+
+    expect(screen.getByText(/76% 正確/)).toBeInTheDocument();
+  });
+
+  it("confirmed/uncertain/unknown の 3 種カウントと総数が表示される", async () => {
+    await renderWithProviders(
+      <DigestCard
+        digest={createTestDigest({
+          confirmedCount: 42,
+          uncertainCount: 7,
+          unknownCount: 2,
+          totalGarments: 51,
+        })}
+      />,
+    );
+
+    expect(screen.getByText("確定")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("要確認")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("不明")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText(/管理中の服: 51着/)).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/LocaleSelector.test.tsx
+++ b/src/components/settings/LocaleSelector.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Locale } from "@/i18n/types";
+import { renderWithProviders } from "@/test/testUtils";
+import LocaleSelector from "./LocaleSelector";
+
+const mockSetLocale = vi.hoisted(() => vi.fn());
+
+vi.mock("@/i18n/localeAtom", async () => {
+  const { atom } = await vi.importActual<typeof import("jotai")>("jotai");
+  const { DEFAULT_LOCALE } =
+    await vi.importActual<typeof import("@/i18n/types")>("@/i18n/types");
+  return {
+    localeAtom: atom<Locale>(DEFAULT_LOCALE),
+    setLocaleAtom: atom(undefined, (_get, _set, locale: Locale) => {
+      mockSetLocale(locale);
+    }),
+  };
+});
+
+describe("LocaleSelector", () => {
+  beforeEach(() => {
+    mockSetLocale.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("初期状態ではメニューが閉じている", async () => {
+    await renderWithProviders(<LocaleSelector />);
+
+    expect(screen.getByRole("button", { name: "言語" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "日本語" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("言語ボタンをクリックするとメニューが開く", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<LocaleSelector />);
+
+    await user.click(screen.getByRole("button", { name: "言語" }));
+
+    expect(screen.getByRole("button", { name: "日本語" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "English" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "한국어" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "中文" })).toBeInTheDocument();
+  });
+
+  it("もう一度クリックするとメニューが閉じる", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<LocaleSelector />);
+
+    const trigger = screen.getByRole("button", { name: "言語" });
+    await user.click(trigger);
+    expect(screen.getByRole("button", { name: "日本語" })).toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(
+      screen.queryByRole("button", { name: "日本語" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("外側の領域を pointerdown でクリックするとメニューが閉じる", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<LocaleSelector />);
+
+    await user.click(screen.getByRole("button", { name: "言語" }));
+    expect(screen.getByRole("button", { name: "English" })).toBeInTheDocument();
+
+    const outsideEvent = new PointerEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      document.body.dispatchEvent(outsideEvent);
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "English" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("各 locale 選択で setLocale が呼ばれメニューが閉じる", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<LocaleSelector />);
+
+    await user.click(screen.getByRole("button", { name: "言語" }));
+    await user.click(screen.getByRole("button", { name: "English" }));
+
+    expect(mockSetLocale).toHaveBeenCalledWith("en");
+    expect(
+      screen.queryByRole("button", { name: "English" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "言語" }));
+    await user.click(screen.getByRole("button", { name: "한국어" }));
+    expect(mockSetLocale).toHaveBeenCalledWith("ko");
+
+    await user.click(screen.getByRole("button", { name: "言語" }));
+    await user.click(screen.getByRole("button", { name: "中文" }));
+    expect(mockSetLocale).toHaveBeenCalledWith("zh");
+
+    await user.click(screen.getByRole("button", { name: "言語" }));
+    await user.click(screen.getByRole("button", { name: "日本語" }));
+    expect(mockSetLocale).toHaveBeenCalledWith("ja");
+
+    expect(mockSetLocale).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
## Summary

GitHub Issue #143 (テストカバレッジ拡充 63.13% → 80%) を 21 ユニットに分解した中の **Unit 17** を担当。

- `src/components/digest/DigestCard.test.tsx` を新規追加
  - 既読/未読の表示切替、`markRead` 呼出、`accuracyScore` パーセント表示、3 種カウント表示を検証
  - DigestCard.tsx カバレッジ: 100% statements / 90% branches / 100% functions / 100% lines
- `src/components/settings/LocaleSelector.test.tsx` を新規追加
  - 開閉トグル、`document.pointerdown` で外側クリック閉じる、各 locale 選択で `setLocaleAtom` 呼出を検証
  - LocaleSelector.tsx カバレッジ: 100% all metrics

mock 戦略:
- `vi.mock("@/stores/digestAtoms")` で `markDigestReadAtom` を spy 付き writeOnly atom に差し替え
- `vi.mock("@/i18n/localeAtom")` で `setLocaleAtom` を spy 付き writeOnly atom に差し替え

## Test plan

- [x] `pnpm test` で 11 件 (DigestCard 6 + LocaleSelector 5) すべて pass
- [x] `pnpm precheck` 通過 (errors 0)
- [x] `pnpm test:coverage` で対象ファイルが上記カバレッジ値に到達

🤖 Generated with [Claude Code](https://claude.com/claude-code)