### PR TITLE
test: DollForm の追加カバレッジ (Unit 13/21 of #143)

### DIFF
--- a/src/components/doll/DollForm.extra.test.tsx
+++ b/src/components/doll/DollForm.extra.test.tsx
@@ -350,9 +350,21 @@ describe("DollForm (extra coverage)", () => {
     });
     expect(button).toBeDisabled();
 
+    // disabled ボタンを経由しない経路（Enter キー等）でも submit が抑止されることを
+    // 検証するため、フォームの submit イベントを直接発火させる。
+    const form = button.closest("form");
+    expect(form).not.toBeNull();
+    if (form == null) return;
+    fireEvent.submit(form);
+
+    // 一定時間待っても副作用が一切起きていないことを確認
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
     const { getDb } = await import("@/lib/db/dexie");
     const db = getDb();
-    const before = await db.dolls.toArray();
-    expect(before.length).toBe(0);
+    const after = await db.dolls.toArray();
+    expect(after.length).toBe(0);
+    expect(mockRouter.push).not.toHaveBeenCalled();
+    expect(mockUpload).not.toHaveBeenCalled();
   });
 });

--- a/src/components/doll/DollForm.extra.test.tsx
+++ b/src/components/doll/DollForm.extra.test.tsx
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FIXED_NOW } from "@/test/mocks/db";
+import { renderWithProviders } from "@/test/testUtils";
+import { createTestDoll } from "@/test/factories";
+import DollForm from "./DollForm";
+
+const mockRouter = vi.hoisted(() => ({
+  push: vi.fn(),
+  back: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+}));
+
+const mockUpload = vi.hoisted(() => vi.fn());
+const mockResetUpload = vi.hoisted(() => vi.fn());
+const mockUploadState = vi.hoisted(() => ({
+  value: { status: "idle" } as
+    | { status: "idle" }
+    | { status: "compressing" }
+    | { status: "uploading" }
+    | { status: "success"; imageUrl: string }
+    | { status: "error"; message: string },
+}));
+
+vi.mock("@/hooks/useImageUpload", () => ({
+  useImageUpload: () => ({
+    uploadState: mockUploadState.value,
+    upload: mockUpload,
+    reset: mockResetUpload,
+  }),
+}));
+
+vi.mock("@paralleldrive/cuid2", () => ({
+  createId: () => "test-cuid",
+}));
+
+const EXISTING_IMAGE_URL = "https://cdn.example.com/existing.png";
+const UPLOADED_IMAGE_URL = "https://cdn.example.com/uploaded.png";
+
+const selectFileInput = (file: File): void => {
+  const input = document.querySelector('input[type="file"]');
+  expect(input).not.toBeNull();
+  if (input == null) return;
+  fireEvent.change(input, { target: { files: [file] } });
+};
+
+const createPngFile = (name = "new.png"): File =>
+  new File(["dummy"], name, { type: "image/png" });
+
+describe("DollForm (extra coverage)", () => {
+  beforeEach(() => {
+    vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+    mockRouter.push.mockClear();
+    mockUpload.mockClear();
+    mockResetUpload.mockClear();
+    mockUploadState.value = { status: "idle" };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("空白文字のみの名前では登録ボタンが disabled のまま", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm />);
+
+    await user.type(screen.getByLabelText("名前"), "   ");
+
+    expect(screen.getByRole("button", { name: "登録する" })).toBeDisabled();
+  });
+
+  it("maker / customizer / headModel を入力すると trim 済み値が保存される", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm />);
+
+    await user.type(screen.getByLabelText("名前"), "リナ");
+    await user.type(screen.getByLabelText("ヘッド型番"), "  DDH-01  ");
+    await user.type(screen.getByLabelText("メーカー"), "  ボークス  ");
+    await user.type(screen.getByLabelText("カスタマイザー"), "  カスタムA  ");
+    await user.click(screen.getByRole("button", { name: "登録する" }));
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await waitFor(async () => {
+      const dolls = await db.dolls.toArray();
+      expect(dolls.length).toBe(1);
+      expect(dolls[0]?.headModel).toBe("DDH-01");
+      expect(dolls[0]?.maker).toBe("ボークス");
+      expect(dolls[0]?.customizer).toBe("カスタムA");
+    });
+  });
+
+  it("空白のみの maker / customizer / headModel / memo は undefined として保存される", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm />);
+
+    await user.type(screen.getByLabelText("名前"), "リナ");
+    await user.type(screen.getByLabelText("ヘッド型番"), "   ");
+    await user.type(screen.getByLabelText("メーカー"), "   ");
+    await user.type(screen.getByLabelText("カスタマイザー"), "   ");
+    await user.type(screen.getByLabelText("メモ"), "   ");
+    await user.click(screen.getByRole("button", { name: "登録する" }));
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await waitFor(async () => {
+      const dolls = await db.dolls.toArray();
+      expect(dolls.length).toBe(1);
+      expect(dolls[0]?.headModel).toBeUndefined();
+      expect(dolls[0]?.maker).toBeUndefined();
+      expect(dolls[0]?.customizer).toBeUndefined();
+      expect(dolls[0]?.memo).toBeUndefined();
+    });
+  });
+
+  it("ボディサイズを切り替えると選択値が保存される", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm />);
+
+    await user.type(screen.getByLabelText("名前"), "リナ");
+    await user.selectOptions(screen.getByLabelText("ボディサイズ"), "MSD");
+    await user.click(screen.getByRole("button", { name: "登録する" }));
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await waitFor(async () => {
+      const dolls = await db.dolls.toArray();
+      expect(dolls[0]?.bodySize).toBe("MSD");
+    });
+  });
+
+  it("ボディサイズに不正な値が来た場合は元の値のまま", async () => {
+    await renderWithProviders(<DollForm />);
+
+    const select = screen.getByLabelText("ボディサイズ");
+    fireEvent.change(select, { target: { value: "INVALID" } });
+
+    expect(select).toHaveValue("SD");
+  });
+
+  it("編集モード: initial values がフォームにセットされ、ボタンが '更新する' に切り替わる", async () => {
+    const doll = createTestDoll({
+      id: "doll-edit-1",
+      name: "既存ドール",
+      headModel: "DDH-09",
+      bodySize: "MSD",
+      maker: "アゾン",
+      customizer: "作者A",
+      memo: "メモあり",
+      imageUrl: EXISTING_IMAGE_URL,
+    });
+
+    await renderWithProviders(<DollForm doll={doll} />);
+
+    expect(screen.getByLabelText("名前")).toHaveValue("既存ドール");
+    expect(screen.getByLabelText("ヘッド型番")).toHaveValue("DDH-09");
+    expect(screen.getByLabelText("メーカー")).toHaveValue("アゾン");
+    expect(screen.getByLabelText("カスタマイザー")).toHaveValue("作者A");
+    expect(screen.getByLabelText("メモ")).toHaveValue("メモあり");
+    expect(screen.getByLabelText("ボディサイズ")).toHaveValue("MSD");
+    expect(screen.getByAltText("プレビュー")).toHaveAttribute(
+      "src",
+      EXISTING_IMAGE_URL,
+    );
+    expect(
+      screen.getByRole("button", { name: "更新する" }),
+    ).toBeInTheDocument();
+  });
+
+  it("編集モード: 更新フローで Dexie が更新され詳細画面に遷移する", async () => {
+    const doll = createTestDoll({
+      id: "doll-edit-2",
+      name: "旧名",
+      bodySize: "SD",
+    });
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await db.dolls.add(doll);
+
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm doll={doll} />);
+
+    await user.clear(screen.getByLabelText("名前"));
+    await user.type(screen.getByLabelText("名前"), "新名");
+    await user.click(screen.getByRole("button", { name: "更新する" }));
+
+    await waitFor(async () => {
+      const updated = await db.dolls.get("doll-edit-2");
+      expect(updated?.name).toBe("新名");
+      expect(updated?.updatedAt).toBe(FIXED_NOW);
+    });
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith("/dolls/doll-edit-2");
+    });
+  });
+
+  it("編集モード: 画像未選択なら元の imageUrl がそのまま保持される", async () => {
+    const doll = createTestDoll({
+      id: "doll-edit-3",
+      name: "リナ",
+      imageUrl: EXISTING_IMAGE_URL,
+    });
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await db.dolls.add(doll);
+
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm doll={doll} />);
+
+    await user.click(screen.getByRole("button", { name: "更新する" }));
+
+    await waitFor(async () => {
+      const updated = await db.dolls.get("doll-edit-3");
+      expect(updated?.imageUrl).toBe(EXISTING_IMAGE_URL);
+    });
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it("画像を新規選択するとプレビューが切り替わり upload が呼ばれる", async () => {
+    mockUpload.mockResolvedValue(UPLOADED_IMAGE_URL);
+    const doll = createTestDoll({
+      id: "doll-edit-4",
+      name: "リナ",
+      imageUrl: EXISTING_IMAGE_URL,
+    });
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await db.dolls.add(doll);
+
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm doll={doll} />);
+
+    expect(screen.getByAltText("プレビュー")).toHaveAttribute(
+      "src",
+      EXISTING_IMAGE_URL,
+    );
+
+    const file = createPngFile();
+    selectFileInput(file);
+
+    await waitFor(() => {
+      expect(screen.getByAltText("プレビュー").getAttribute("src")).toContain(
+        "blob:",
+      );
+    });
+    expect(mockResetUpload).toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "更新する" }));
+
+    await waitFor(() => {
+      expect(mockUpload).toHaveBeenCalledWith({
+        file,
+        garmentId: "doll-edit-4",
+      });
+    });
+    await waitFor(async () => {
+      const updated = await db.dolls.get("doll-edit-4");
+      expect(updated?.imageUrl).toBe(UPLOADED_IMAGE_URL);
+    });
+  });
+
+  it("画像アップロードが失敗した場合は元の imageUrl が維持される", async () => {
+    mockUpload.mockRejectedValue(new Error("upload failed"));
+    const doll = createTestDoll({
+      id: "doll-edit-5",
+      name: "リナ",
+      imageUrl: EXISTING_IMAGE_URL,
+    });
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await db.dolls.add(doll);
+
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm doll={doll} />);
+
+    const file = createPngFile();
+    selectFileInput(file);
+
+    await user.click(screen.getByRole("button", { name: "更新する" }));
+
+    await waitFor(async () => {
+      const updated = await db.dolls.get("doll-edit-5");
+      expect(updated?.imageUrl).toBe(EXISTING_IMAGE_URL);
+    });
+  });
+
+  it("新規登録時に画像を選択するとアップロード結果が保存される", async () => {
+    mockUpload.mockResolvedValue(UPLOADED_IMAGE_URL);
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm />);
+
+    await user.type(screen.getByLabelText("名前"), "リナ");
+
+    const file = createPngFile();
+    selectFileInput(file);
+
+    await user.click(screen.getByRole("button", { name: "登録する" }));
+
+    await waitFor(() => {
+      expect(mockUpload).toHaveBeenCalledWith({
+        file,
+        garmentId: "test-cuid",
+      });
+    });
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await waitFor(async () => {
+      const dolls = await db.dolls.toArray();
+      expect(dolls[0]?.imageUrl).toBe(UPLOADED_IMAGE_URL);
+    });
+  });
+
+  it("新規登録 + 画像アップロード失敗時は imageUrl が undefined で保存される", async () => {
+    mockUpload.mockRejectedValue(new Error("upload failed"));
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm />);
+
+    await user.type(screen.getByLabelText("名前"), "リナ");
+
+    const file = createPngFile();
+    selectFileInput(file);
+
+    await user.click(screen.getByRole("button", { name: "登録する" }));
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await waitFor(async () => {
+      const dolls = await db.dolls.toArray();
+      expect(dolls.length).toBe(1);
+      expect(dolls[0]?.imageUrl).toBeUndefined();
+    });
+  });
+
+  it("圧縮中は送信が抑止される (handleSubmit 早期 return)", async () => {
+    mockUploadState.value = { status: "compressing" };
+    const user = userEvent.setup();
+    await renderWithProviders(<DollForm />);
+
+    await user.type(screen.getByLabelText("名前"), "リナ");
+    const button = screen.getByRole("button", {
+      name: "アップロード中...",
+    });
+    expect(button).toBeDisabled();
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    const before = await db.dolls.toArray();
+    expect(before.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `src/components/doll/DollForm.extra.test.tsx` を新規追加し、DollForm の未カバー branch を補完
- 既存 `DollForm.test.tsx` は変更せず、追加分は extra ファイルで分離
- カバレッジ: Lines 71% → 98.33%、Branches → 91.66% (44/48)、Functions → 100%

## Coverage details
追加した観点:
- maker / customizer / headModel の optional (空白のみ → undefined) 分岐
- 編集モードの initial values 反映と '更新する' ボタン表示
- 編集モード: 更新フローでの Dexie 更新と詳細画面への遷移
- 画像未選択時に元の imageUrl を保持
- 画像変更時の preview 切替と upload 呼び出し
- 画像アップロード失敗時のフォールバック (新規/編集双方)
- bodySize 切替 (有効値) と不正値の弾き
- 空白のみの名前で submit ボタンが disabled
- 圧縮中の submit 抑止

## Test plan
- [x] `./node_modules/.bin/vitest run src/components/doll/DollForm.test.tsx src/components/doll/DollForm.extra.test.tsx` (18/18 緑)
- [x] `pnpm precheck` (errors 0)
- [x] `npx tsc-files --noEmit -p tsconfig.app.json src/components/doll/DollForm.extra.test.tsx`
- [x] `npx eslint src/components/doll/DollForm.extra.test.tsx`

Refs #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)