### PR TITLE
test: 低優先 page/analytics のテストを追加 (Unit 21/21 of #143)

### DIFF
--- a/src/app/locations/[caseId]/page.extra.test.tsx
+++ b/src/app/locations/[caseId]/page.extra.test.tsx
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { testDb, FIXED_NOW } from "@/test/mocks/db";
+import { seedDbFromTestDb } from "@/test/helpers/seedDb";
+import { renderWithProviders } from "@/test/testUtils";
+import { getDb } from "@/lib/db/dexie";
+import { MS_PER_DAY } from "@/lib/constants";
+import CaseDetailPage from "./page";
+
+const mockRouterBack = vi.fn();
+const mockRouterPush = vi.fn();
+const searchParamsRef = vi.hoisted(() => ({
+  current: new URLSearchParams(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ caseId: "case-1" }),
+  useRouter: () => ({ back: mockRouterBack, push: mockRouterPush }),
+  useSearchParams: () => searchParamsRef.current,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    readonly href: string;
+    readonly children: React.ReactNode;
+  } & Record<string, unknown>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("CaseDetailPage (extra)", () => {
+  beforeEach(() => {
+    vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+    mockRouterBack.mockClear();
+    mockRouterPush.mockClear();
+    searchParamsRef.current = new URLSearchParams();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("ケース未発見時に「一覧に戻る」をクリックすると router.push が呼ばれる", async () => {
+    await renderWithProviders(<CaseDetailPage />);
+
+    const link = await screen.findByRole("button", { name: "一覧に戻る" });
+    fireEvent.click(link);
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/locations");
+  });
+
+  it("PageHeader の戻るボタンで router.back が呼ばれる", async () => {
+    await renderWithProviders(<CaseDetailPage />);
+
+    // PageHeader 内の戻るボタンは aria-label を持たない設計のため、順序で取得する
+    const [backButton] = await screen.findAllByRole("button");
+    expect(backButton).toBeDefined();
+    if (backButton !== undefined) {
+      fireEvent.click(backButton);
+    }
+
+    expect(mockRouterBack).toHaveBeenCalled();
+  });
+
+  it("description がある場合に表示される", async () => {
+    testDb.storageCase.create({
+      id: "case-1",
+      name: "ケースA",
+      description: "春物用",
+      rows: 2,
+      cols: 2,
+    });
+    testDb.storageLocation.create({
+      id: "loc-1",
+      caseId: "case-1",
+      label: "A-1",
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<CaseDetailPage />);
+
+    expect(await screen.findByText("春物用")).toBeInTheDocument();
+  });
+
+  it("要確認バッジは需要があるときのみ表示される", async () => {
+    testDb.storageCase.create({ id: "case-1", rows: 1, cols: 1 });
+    testDb.storageLocation.create({
+      id: "loc-1",
+      caseId: "case-1",
+      label: "A-1",
+    });
+    testDb.garment.create({
+      id: "g-old",
+      name: "古い服",
+      locationId: "loc-1",
+      status: "stored",
+      lastScannedAt: FIXED_NOW - 60 * MS_PER_DAY,
+      confidenceDecayDays: 30,
+      confidenceDecayDaysOverride: 30,
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<CaseDetailPage />);
+
+    expect(await screen.findByText("1着 要確認")).toBeInTheDocument();
+  });
+
+  it("StorageGrid 経由で編集モーダルを開いて StorageLocationEditForm を表示する", async () => {
+    testDb.storageCase.create({ id: "case-1", name: "ケースA" });
+    testDb.storageLocation.create({
+      id: "loc-1",
+      caseId: "case-1",
+      label: "A-1",
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<CaseDetailPage />);
+
+    fireEvent.click(await screen.findByText("A-1"));
+    fireEvent.click(screen.getByRole("button", { name: "編集" }));
+
+    expect(screen.getByText("ラベル: A-1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "保存" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "キャンセル" }),
+    ).toBeInTheDocument();
+  });
+
+  it("StorageLocationEditForm 保存で Dexie の location が更新される", async () => {
+    testDb.storageCase.create({ id: "case-1", name: "ケースA" });
+    testDb.storageLocation.create({
+      id: "loc-1",
+      caseId: "case-1",
+      label: "A-1",
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<CaseDetailPage />);
+
+    fireEvent.click(await screen.findByText("A-1"));
+    fireEvent.click(screen.getByRole("button", { name: "編集" }));
+
+    const customNameInput = screen.getByLabelText("カスタム名称");
+    fireEvent.change(customNameInput, { target: { value: "ワンピース用" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(async () => {
+      const updated = await getDb().storageLocations.get("loc-1");
+      expect(updated?.customName).toBe("ワンピース用");
+    });
+  });
+
+  it("StorageLocationEditForm のキャンセルでフォームが閉じる", async () => {
+    testDb.storageCase.create({ id: "case-1", name: "ケースA" });
+    testDb.storageLocation.create({
+      id: "loc-1",
+      caseId: "case-1",
+      label: "A-1",
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<CaseDetailPage />);
+
+    fireEvent.click(await screen.findByText("A-1"));
+    fireEvent.click(screen.getByRole("button", { name: "編集" }));
+
+    expect(screen.getByText("ラベル: A-1")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("ラベル: A-1")).toBeNull();
+    });
+  });
+
+  describe("unit type case", () => {
+    it("unit ケースで「ボックス」ラベルと服一覧を表示する", async () => {
+      testDb.storageCase.create({
+        id: "case-1",
+        name: "コンテナ",
+        type: "unit",
+        rows: 1,
+        cols: 1,
+      });
+      testDb.storageLocation.create({
+        id: "loc-unit",
+        caseId: "case-1",
+        label: "container-loc",
+      });
+      testDb.garment.create({
+        id: "g-1",
+        name: "白いドレス",
+        locationId: "loc-unit",
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<CaseDetailPage />);
+
+      expect(await screen.findByText("ボックス")).toBeInTheDocument();
+      expect(screen.getByText("白いドレス")).toBeInTheDocument();
+    });
+
+    it("unit ケースで服がない場合は空メッセージを表示する", async () => {
+      testDb.storageCase.create({
+        id: "case-1",
+        name: "コンテナ",
+        type: "unit",
+      });
+      testDb.storageLocation.create({
+        id: "loc-unit",
+        caseId: "case-1",
+        label: "container-loc",
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<CaseDetailPage />);
+
+      expect(
+        await screen.findByText("このボックスには服がありません"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "今ここにいなくても確認" }),
+      ).toBeNull();
+    });
+
+    it("unit ケースで stored の服があると記憶確認ボタンを表示する", async () => {
+      testDb.storageCase.create({
+        id: "case-1",
+        name: "コンテナ",
+        type: "unit",
+      });
+      testDb.storageLocation.create({
+        id: "loc-unit",
+        caseId: "case-1",
+        label: "container-loc",
+      });
+      testDb.garment.create({
+        id: "g-1",
+        name: "白いドレス",
+        locationId: "loc-unit",
+        status: "stored",
+        lastScannedAt: FIXED_NOW - 30 * MS_PER_DAY,
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<CaseDetailPage />);
+
+      const button = await screen.findByRole("button", {
+        name: "今ここにいなくても確認",
+      });
+      fireEvent.click(button);
+
+      await waitFor(async () => {
+        const garment = await getDb().garments.get("g-1");
+        expect(garment?.lastScannedAt).toBeGreaterThan(
+          FIXED_NOW - 30 * MS_PER_DAY,
+        );
+      });
+    });
+  });
+});

--- a/src/app/scan/page.extra.test.tsx
+++ b/src/app/scan/page.extra.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, screen, fireEvent, waitFor } from "@testing-library/react";
+import { testDb, FIXED_NOW } from "@/test/mocks/db";
+import { seedDbFromTestDb } from "@/test/helpers/seedDb";
+import { renderWithProviders } from "@/test/testUtils";
+import { MS_PER_DAY } from "@/lib/constants";
+import ScanPage from "./page";
+
+const scanTrigger = vi.hoisted(
+  (): { onScan: ((data: string) => void) | undefined } => ({
+    onScan: undefined,
+  }),
+);
+
+const nfcScanTrigger = vi.hoisted(
+  (): { onScan: ((data: string) => void) | undefined } => ({
+    onScan: undefined,
+  }),
+);
+
+const mockNfcSupported = vi.hoisted(() => ({ value: false }));
+
+vi.mock("@/components/scan/QrScanner", () => ({
+  default: ({
+    onScan,
+  }: {
+    readonly onScan: (data: string) => void;
+    readonly isActive: boolean;
+  }) => {
+    scanTrigger.onScan = onScan;
+    return <div data-testid="qr-scanner" />;
+  },
+}));
+
+vi.mock("@/hooks/useNfcSupported", () => ({
+  useNfcSupported: () => mockNfcSupported.value,
+}));
+
+vi.mock("@/hooks/useNfcReader", () => ({
+  useNfcReader: ({
+    onScan,
+  }: {
+    readonly onScan: (data: string) => void;
+    readonly isActive: boolean;
+  }) => {
+    nfcScanTrigger.onScan = onScan;
+    return { nfcState: { status: "scanning" } };
+  },
+}));
+
+vi.mock("@/components/scan/NfcReader", () => ({
+  default: ({
+    nfcState,
+  }: {
+    readonly nfcState: { readonly status: string };
+  }) => <div data-testid="nfc-reader" data-status={nfcState.status} />,
+}));
+
+vi.mock("@/components/scan/NfcCapabilityBadge", () => ({
+  default: () => <span data-testid="nfc-badge" />,
+}));
+
+const simulateScan = (data: string) => {
+  act(() => {
+    scanTrigger.onScan?.(data);
+  });
+};
+
+describe("ScanPage (extra)", () => {
+  beforeEach(() => {
+    vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+    scanTrigger.onScan = undefined;
+    nfcScanTrigger.onScan = undefined;
+    mockNfcSupported.value = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("不明な prefix の QR は無視される", async () => {
+    testDb.storageLocation.create({ id: "loc-1", label: "A-1" });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<ScanPage />);
+
+    simulateScan("https://example.com/foo");
+
+    expect(
+      screen.getByText("場所のQRをスキャンして、収納場所を設定してください"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("場所を設定しました")).toBeNull();
+    expect(screen.queryByText("スキャンしました")).toBeNull();
+  });
+
+  it("未登録の場所IDをスキャンしても locationId 自体をフォールバックして表示する", async () => {
+    await renderWithProviders(<ScanPage />);
+
+    simulateScan("dwg://l/unknown-loc");
+
+    expect(screen.getByText("場所を設定しました")).toBeInTheDocument();
+    expect(screen.getAllByText("unknown-loc").length).toBeGreaterThan(0);
+  });
+
+  it("未登録の服IDをスキャンしても garmentId 自体をフォールバックして表示する", async () => {
+    testDb.storageLocation.create({ id: "loc-1", label: "A-1" });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<ScanPage />);
+
+    simulateScan("dwg://l/loc-1");
+    simulateScan("dwg://g/unknown-garment");
+
+    expect(screen.getByText("unknown-garment")).toBeInTheDocument();
+    expect(screen.getByText("1着をスキャンしました")).toBeInTheDocument();
+  });
+
+  it("activeLocation 未設定で全確認を押しても何も起きない", async () => {
+    await renderWithProviders(<ScanPage />);
+
+    expect(
+      screen.getByText("場所のQRをスキャンして、収納場所を設定してください"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: "この場所の全服を確認済みにする" }),
+    ).toBeNull();
+  });
+
+  it("信頼度低アイテムなしでは reviewDialog は閉じたまま", async () => {
+    testDb.storageLocation.create({ id: "loc-1", label: "A-1" });
+    testDb.garment.create({
+      id: "g-1",
+      name: "新しい服",
+      locationId: "loc-1",
+      status: "stored",
+      lastScannedAt: FIXED_NOW,
+      confidenceDecayDays: 30,
+      confidenceDecayDaysOverride: 30,
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<ScanPage />);
+
+    simulateScan("dwg://l/loc-1");
+
+    expect(screen.queryByText("全部ある")).toBeNull();
+    expect(screen.queryByText("ズレを直す")).toBeNull();
+  });
+
+  it("ダイアログの「ズレを直す」で個別確認モードに切り替わる", async () => {
+    testDb.storageLocation.create({ id: "loc-1", label: "A-1" });
+    testDb.garment.create({
+      id: "g-1",
+      name: "古いドレス",
+      locationId: "loc-1",
+      status: "stored",
+      lastScannedAt: FIXED_NOW - 20 * MS_PER_DAY,
+      confidenceDecayDays: 30,
+      confidenceDecayDaysOverride: 30,
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<ScanPage />);
+
+    simulateScan("dwg://l/loc-1");
+
+    fireEvent.click(screen.getByRole("button", { name: "ズレを直す" }));
+
+    expect(
+      screen.getByRole("button", { name: "確定する" }),
+    ).toBeInTheDocument();
+  });
+
+  it("個別確認モードで「確定する」を押すと confirmPartial が走りダイアログが閉じる", async () => {
+    testDb.storageLocation.create({ id: "loc-1", label: "A-1" });
+    testDb.garment.create({
+      id: "g-1",
+      name: "古いドレス",
+      locationId: "loc-1",
+      status: "stored",
+      lastScannedAt: FIXED_NOW - 20 * MS_PER_DAY,
+      confidenceDecayDays: 30,
+      confidenceDecayDaysOverride: 30,
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<ScanPage />);
+
+    simulateScan("dwg://l/loc-1");
+
+    fireEvent.click(screen.getByRole("button", { name: "ズレを直す" }));
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "確定する" }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "確定する" })).toBeNull();
+    });
+  });
+
+  it("信頼度低のアイテムでダイアログ表示中も QrScanner / NfcReader 自体は描画される", async () => {
+    mockNfcSupported.value = true;
+    testDb.storageLocation.create({ id: "loc-1", label: "A-1" });
+    testDb.garment.create({
+      id: "g-1",
+      name: "古いドレス",
+      locationId: "loc-1",
+      status: "stored",
+      lastScannedAt: FIXED_NOW - 20 * MS_PER_DAY,
+      confidenceDecayDays: 30,
+      confidenceDecayDaysOverride: 30,
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<ScanPage />);
+
+    simulateScan("dwg://l/loc-1");
+
+    expect(
+      screen.getByRole("button", { name: "全部ある" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("qr-scanner")).toBeInTheDocument();
+    expect(screen.getByTestId("nfc-reader")).toBeInTheDocument();
+  });
+});

--- a/src/lib/wardrobe-analytics.extra.test.ts
+++ b/src/lib/wardrobe-analytics.extra.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseHsl,
+  classifyColor,
+  aggregateByCategory,
+  aggregateByDollSize,
+  aggregateByColor,
+  aggregateByBrand,
+} from "./wardrobe-analytics";
+import type { Garment } from "@/types";
+
+const createGarment = (overrides: Partial<Garment> = {}): Garment => ({
+  id: "g1",
+  userId: "u1",
+  name: "テスト",
+  category: "tops",
+  dollSizes: ["SD"],
+  colors: [],
+  tags: [],
+  imageUrl: undefined,
+  locationId: undefined,
+  status: "stored",
+  lastScannedAt: Date.now(),
+  confidenceDecayDays: 30,
+  confidenceDecayDaysOverride: undefined,
+  recentCheckoutCount: 0,
+  brand: undefined,
+  description: undefined,
+  setContents: undefined,
+  checkedOutAt: undefined,
+  archivedAt: undefined,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  ...overrides,
+});
+
+describe("parseHsl (extra branches)", () => {
+  it("hsl( で始まるが ) で終わらない文字列は undefined", () => {
+    expect(parseHsl("hsl(0, 0%, 50%")).toBeUndefined();
+  });
+
+  it("3 つでないパーツは undefined", () => {
+    expect(parseHsl("hsl(0, 0%)")).toBeUndefined();
+    expect(parseHsl("hsl(0, 0%, 50%, 1)")).toBeUndefined();
+  });
+
+  it("% 接尾辞を欠く s/l は undefined", () => {
+    expect(parseHsl("hsl(0, 0, 50%)")).toBeUndefined();
+    expect(parseHsl("hsl(0, 0%, 50)")).toBeUndefined();
+  });
+
+  it("先頭余白がトリムされる", () => {
+    expect(parseHsl("  hsl(0, 0%, 50%)  ")).toEqual({ h: 0, s: 0, l: 50 });
+  });
+});
+
+describe("classifyColor (extra branches)", () => {
+  it("hex 4 文字や 5 文字は invalid 扱いで black", () => {
+    expect(classifyColor("#abcd")).toBe("black");
+    expect(classifyColor("#abcde")).toBe("black");
+  });
+
+  it("# なし 6 桁 hex も解釈できる", () => {
+    expect(classifyColor("ff0000")).toBe("red");
+  });
+
+  it("hex 3 桁は展開して解釈する", () => {
+    expect(classifyColor("#f00")).toBe("red");
+  });
+
+  it("hex で max=g のケース（緑）", () => {
+    expect(classifyColor("#00ff00")).toBe("green");
+  });
+
+  it("max=min（グレースケール）の hex は無彩色判定される", () => {
+    expect(classifyColor("#808080")).toBe("white");
+    expect(classifyColor("#222222")).toBe("black");
+  });
+
+  it("不正な hex 文字（解釈不可）は black フォールバック", () => {
+    expect(classifyColor("#zzzzzz")).toBe("black");
+  });
+
+  it("ACHROMATIC_LIGHTNESS_MIDPOINT 境界（l=50, s=10 = 無彩色）", () => {
+    // l=50 は midpoint。l < midpoint のみ black 扱い、それ以外（>=）は white
+    expect(classifyColor("hsl(0, 10%, 50%)")).toBe("white");
+    expect(classifyColor("hsl(0, 10%, 49%)")).toBe("black");
+  });
+
+  it("HUE_PRESETS の境界 (hue=359 は red 側に丸める)", () => {
+    expect(classifyColor("hsl(359, 80%, 50%)")).toBe("red");
+  });
+});
+
+describe("aggregateByCategory (extra)", () => {
+  it("カテゴリの並びは降順で同数なら GARMENT_CATEGORIES の順序を維持する", () => {
+    const garments = [
+      createGarment({ id: "g1", category: "tops" }),
+      createGarment({ id: "g2", category: "bottoms" }),
+    ];
+    const result = aggregateByCategory(garments);
+    // tops と bottoms はどちらも 1。GARMENT_CATEGORIES では tops が先
+    expect(result.map((r) => r.category)).toEqual(["tops", "bottoms"]);
+  });
+});
+
+describe("aggregateByDollSize (extra)", () => {
+  it("dollSizes が空配列の garment は集計に寄与しない", () => {
+    const garments = [createGarment({ dollSizes: [] })];
+    expect(aggregateByDollSize(garments)).toEqual([]);
+  });
+
+  it("複数の dollSizes が降順で並ぶ", () => {
+    const garments = [
+      createGarment({ id: "g1", dollSizes: ["MSD"] }),
+      createGarment({ id: "g2", dollSizes: ["MSD"] }),
+      createGarment({ id: "g3", dollSizes: ["SD"] }),
+    ];
+    const result = aggregateByDollSize(garments);
+    expect(result[0]?.dollSize).toBe("MSD");
+    expect(result[0]?.count).toBe(2);
+  });
+});
+
+describe("aggregateByColor (extra)", () => {
+  it("不正な色文字列は black に分類される", () => {
+    const garments = [createGarment({ colors: ["invalid-color"] })];
+    const result = aggregateByColor(garments);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.colorName).toBe("black");
+    expect(result[0]?.count).toBe(1);
+  });
+
+  it("プリセット文字列はキャッシュ経由で同じ色名にマップされる", () => {
+    const garments = [
+      createGarment({
+        id: "g1",
+        colors: ["hsl(0, 0%, 10%)", "hsl(0, 0%, 95%)"],
+      }),
+    ];
+    const result = aggregateByColor(garments);
+    const black = result.find((r) => r.colorName === "black");
+    const white = result.find((r) => r.colorName === "white");
+    expect(black?.count).toBe(1);
+    expect(white?.count).toBe(1);
+  });
+});
+
+describe("aggregateByBrand (extra)", () => {
+  it("topN がデフォルトの 10 を超えるブランド数では上位 10 件のみ", () => {
+    const garments = Array.from({ length: 12 }, (_, i) =>
+      createGarment({ id: `g-${i}`, brand: `brand-${i}` }),
+    );
+    const result = aggregateByBrand({ garments });
+    expect(result).toHaveLength(10);
+  });
+
+  it("topN=0 で空配列を返す", () => {
+    const garments = [createGarment({ brand: "Volks" })];
+    expect(aggregateByBrand({ garments, topN: 0 })).toEqual([]);
+  });
+
+  it("全アイテムが brand=undefined だと空", () => {
+    const garments = [createGarment({ id: "g1" }), createGarment({ id: "g2" })];
+    expect(aggregateByBrand({ garments })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

#143 のテストカバレッジ拡充 (63.13% → 80%) における Unit 21/21 を実装。低優先な page/analytics 系の追加テストをまとめてカバー。

- `src/app/locations/[caseId]/page.extra.test.tsx` (10 tests) — 編集モーダル開閉、`StorageLocationEditForm` 統合、unit ケース表示、未発見時の `router.push`/戻るボタン、要確認バッジ、description 表示
- `src/app/scan/page.extra.test.tsx` (8 tests) — 不明 prefix QR の無視、未登録 ID のフォールバック表示、`activeLocation` 未設定時、信頼度高では dialog 非表示、「ズレを直す」/「確定する」での個別確認モード
- `src/lib/wardrobe-analytics.extra.test.ts` (20 tests) — `parseHsl`/`classifyColor` の境界（hex 3/6 桁、無彩色 lightness 境界、hue 境界）、`aggregateBy*` の追加分岐（空 `dollSizes`、`topN=0`、デフォルト 10 件まで）

3 ファイル合計 38 テストで対象 3 ファイルの Branches を **92.04%** まで引き上げ（Statements 97.26% / Functions 98.07% / Lines 99.24%）。

既存テストは編集せず、新ファイルでの追加のみ。`vitest.config.ts` も無編集。

## Test plan

- [x] `npx vitest run src/app/locations/[caseId]/page.extra.test.tsx` (10 passed)
- [x] `npx vitest run src/app/scan/page.extra.test.tsx` (8 passed)
- [x] `npx vitest run src/lib/wardrobe-analytics.extra.test.ts` (20 passed)
- [x] `pnpm precheck` (typecheck / lint / format / i18n すべて通過)
- [x] `npx vitest run` (全 692 テスト緑)
- [x] coverage 計測で対象 3 ファイル Branches 92.04% 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)