### PR TITLE
test: CSV/Bulk 関連のテストを追加 (Unit 19/21 of #143)

### DIFF
--- a/src/components/garment/bulk/BulkMetadataForm.test.tsx
+++ b/src/components/garment/bulk/BulkMetadataForm.test.tsx
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { atom } from "jotai";
+import type {
+  BulkCaptureItem,
+  BulkCaptureMetadata,
+  BulkRegistrationStatus,
+} from "@/types";
+import { renderWithProviders } from "@/test/testUtils";
+import BulkMetadataForm from "./BulkMetadataForm";
+
+type BulkStep = "capture" | "metadata" | "registering" | "done";
+
+type MockState = {
+  items: BulkCaptureItem[];
+  metadataMap: Map<string, BulkCaptureMetadata>;
+  currentIndex: number;
+  step: BulkStep;
+  registrationStatus: BulkRegistrationStatus;
+  setMetadataCalls: BulkCaptureMetadata[];
+  setCurrentIndexCalls: number[];
+  setStepCalls: string[];
+  executeRegistrationCalls: number;
+};
+
+const mockState = vi.hoisted<MockState>(() => ({
+  items: [],
+  metadataMap: new Map(),
+  currentIndex: 0,
+  step: "metadata",
+  registrationStatus: { status: "idle" },
+  setMetadataCalls: [],
+  setCurrentIndexCalls: [],
+  setStepCalls: [],
+  executeRegistrationCalls: 0,
+}));
+
+vi.mock("@/stores/bulkCaptureAtoms", () => {
+  const capturedItemsAtom = atom(
+    (_get) => mockState.items,
+    (_get, _set, next: readonly BulkCaptureItem[]) => {
+      mockState.items.splice(0, mockState.items.length, ...next);
+    },
+  );
+  const metadataMapAtom = atom(
+    (_get) => mockState.metadataMap,
+    (_get, _set, next: ReadonlyMap<string, BulkCaptureMetadata>) => {
+      mockState.metadataMap.clear();
+      next.forEach((value, key) => mockState.metadataMap.set(key, value));
+    },
+  );
+  const currentMetadataIndexAtom = atom(
+    (_get) => mockState.currentIndex,
+    (_get, _set, next: number) => {
+      mockState.currentIndex = next;
+      mockState.setCurrentIndexCalls.push(next);
+    },
+  );
+  const bulkCaptureStepAtom = atom(
+    (_get) => mockState.step,
+    (_get, _set, next: BulkStep) => {
+      mockState.step = next;
+      mockState.setStepCalls.push(next);
+    },
+  );
+  const setMetadataAtom = atom(
+    undefined,
+    (_get, _set, metadata: BulkCaptureMetadata) => {
+      mockState.metadataMap.set(metadata.captureId, metadata);
+      mockState.setMetadataCalls.push(metadata);
+    },
+  );
+  const executeBulkRegistrationAtom = atom(undefined, () => {
+    mockState.executeRegistrationCalls += 1;
+  });
+
+  const defaultMetadata = (captureId: string): BulkCaptureMetadata => ({
+    captureId,
+    name: "",
+    category: "tops",
+    dollSize: "SD",
+    colors: [],
+    tags: [],
+    brand: "",
+    confidenceDecayDays: 30,
+  });
+
+  return {
+    capturedItemsAtom,
+    metadataMapAtom,
+    currentMetadataIndexAtom,
+    bulkCaptureStepAtom,
+    setMetadataAtom,
+    executeBulkRegistrationAtom,
+    bulkRegistrationStatusAtom: atom(() => mockState.registrationStatus),
+    addCapturedItemAtom: atom(undefined, () => undefined),
+    removeCapturedItemAtom: atom(undefined, () => undefined),
+    resetBulkCaptureSessionAtom: atom(undefined, () => undefined),
+    getMetadataForItem: (
+      map: ReadonlyMap<string, BulkCaptureMetadata>,
+      captureId: string,
+    ): BulkCaptureMetadata => map.get(captureId) ?? defaultMetadata(captureId),
+  };
+});
+
+const createTestItem = (
+  overrides: Partial<BulkCaptureItem> = {},
+): BulkCaptureItem => ({
+  captureId: "capture-1",
+  blob: new Blob(["test"], { type: "image/png" }),
+  thumbnailUrl: "blob:thumb-1",
+  capturedAt: 1_700_000_000_000,
+  ...overrides,
+});
+
+const createTestMetadata = (
+  overrides: Partial<BulkCaptureMetadata> = {},
+): BulkCaptureMetadata => ({
+  captureId: "capture-1",
+  name: "ドール服",
+  category: "dress",
+  dollSize: "MSD",
+  colors: ["hsl(0,0%,100%)"],
+  tags: ["レース"],
+  brand: "ボークス",
+  confidenceDecayDays: 30,
+  ...overrides,
+});
+
+const resetMockState = () => {
+  mockState.items.splice(0, mockState.items.length);
+  mockState.metadataMap.clear();
+  mockState.currentIndex = 0;
+  mockState.step = "metadata";
+  mockState.registrationStatus = { status: "idle" };
+  mockState.setMetadataCalls.splice(0, mockState.setMetadataCalls.length);
+  mockState.setCurrentIndexCalls.splice(
+    0,
+    mockState.setCurrentIndexCalls.length,
+  );
+  mockState.setStepCalls.splice(0, mockState.setStepCalls.length);
+  mockState.executeRegistrationCalls = 0;
+};
+
+describe("BulkMetadataForm", () => {
+  beforeEach(() => {
+    resetMockState();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("currentItem が undefined の場合は空コンテナのみ描画する", async () => {
+    const { container } = await renderWithProviders(<BulkMetadataForm />);
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.queryByLabelText("名前")).toBeNull();
+  });
+
+  it("最初のアイテム表示時は「戻る」ボタンと「次へ」ボタンを表示する", async () => {
+    mockState.items.push(
+      createTestItem({ captureId: "c1" }),
+      createTestItem({ captureId: "c2", thumbnailUrl: "blob:thumb-2" }),
+    );
+    mockState.metadataMap.set("c1", createTestMetadata({ captureId: "c1" }));
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /戻る/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /次へ/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /前の値を適用/ })).toBeNull();
+  });
+
+  it("最後のアイテム表示時は「前へ」ボタンと「登録開始」ボタンを表示する", async () => {
+    mockState.items.push(
+      createTestItem({ captureId: "c1" }),
+      createTestItem({ captureId: "c2", thumbnailUrl: "blob:thumb-2" }),
+    );
+    mockState.metadataMap.set("c1", createTestMetadata({ captureId: "c1" }));
+    mockState.metadataMap.set(
+      "c2",
+      createTestMetadata({ captureId: "c2", name: "二つ目" }),
+    );
+    mockState.currentIndex = 1;
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /前へ/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "登録開始" }),
+    ).toBeInTheDocument();
+  });
+
+  it("「次へ」ボタンで currentIndex がインクリメントされる", async () => {
+    mockState.items.push(
+      createTestItem({ captureId: "c1" }),
+      createTestItem({ captureId: "c2", thumbnailUrl: "blob:thumb-2" }),
+    );
+    mockState.metadataMap.set("c1", createTestMetadata({ captureId: "c1" }));
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    fireEvent.click(screen.getByRole("button", { name: /次へ/ }));
+
+    expect(mockState.setCurrentIndexCalls).toContain(1);
+  });
+
+  it("「前へ」ボタンで currentIndex がデクリメントされる", async () => {
+    mockState.items.push(
+      createTestItem({ captureId: "c1" }),
+      createTestItem({ captureId: "c2", thumbnailUrl: "blob:thumb-2" }),
+    );
+    mockState.metadataMap.set("c1", createTestMetadata({ captureId: "c1" }));
+    mockState.metadataMap.set("c2", createTestMetadata({ captureId: "c2" }));
+    mockState.currentIndex = 1;
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    fireEvent.click(screen.getByRole("button", { name: /前へ/ }));
+
+    expect(mockState.setCurrentIndexCalls).toContain(0);
+  });
+
+  it("最初のアイテムで「戻る」を押すと step が capture に戻る", async () => {
+    mockState.items.push(createTestItem({ captureId: "c1" }));
+    mockState.metadataMap.set("c1", createTestMetadata({ captureId: "c1" }));
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    fireEvent.click(screen.getByRole("button", { name: /戻る/ }));
+
+    expect(mockState.setStepCalls).toContain("capture");
+  });
+
+  it("全てのアイテムに名前が入っていれば「登録開始」が有効になる", async () => {
+    mockState.items.push(
+      createTestItem({ captureId: "c1" }),
+      createTestItem({ captureId: "c2", thumbnailUrl: "blob:thumb-2" }),
+    );
+    mockState.metadataMap.set(
+      "c1",
+      createTestMetadata({ captureId: "c1", name: "一つ目" }),
+    );
+    mockState.metadataMap.set(
+      "c2",
+      createTestMetadata({ captureId: "c2", name: "二つ目" }),
+    );
+    mockState.currentIndex = 1;
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    expect(screen.getByRole("button", { name: "登録開始" })).toBeEnabled();
+  });
+
+  it("名前が空のアイテムがあると「登録開始」が無効になる", async () => {
+    mockState.items.push(
+      createTestItem({ captureId: "c1" }),
+      createTestItem({ captureId: "c2", thumbnailUrl: "blob:thumb-2" }),
+    );
+    mockState.metadataMap.set(
+      "c1",
+      createTestMetadata({ captureId: "c1", name: "一つ目" }),
+    );
+    mockState.currentIndex = 1;
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    expect(screen.getByRole("button", { name: "登録開始" })).toBeDisabled();
+  });
+
+  it("名前が空白のみだと「登録開始」が無効になる", async () => {
+    mockState.items.push(createTestItem({ captureId: "c1" }));
+    mockState.metadataMap.set(
+      "c1",
+      createTestMetadata({ captureId: "c1", name: "   " }),
+    );
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    expect(screen.getByRole("button", { name: "登録開始" })).toBeDisabled();
+  });
+
+  it("「登録開始」クリックで executeRegistration が呼ばれる", async () => {
+    mockState.items.push(createTestItem({ captureId: "c1" }));
+    mockState.metadataMap.set(
+      "c1",
+      createTestMetadata({ captureId: "c1", name: "完了テスト" }),
+    );
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    fireEvent.click(screen.getByRole("button", { name: "登録開始" }));
+
+    expect(mockState.executeRegistrationCalls).toBe(1);
+  });
+
+  it("「前の値を適用」で前のメタデータが name 空でコピーされる", async () => {
+    mockState.items.push(
+      createTestItem({ captureId: "c1" }),
+      createTestItem({ captureId: "c2", thumbnailUrl: "blob:thumb-2" }),
+    );
+    mockState.metadataMap.set(
+      "c1",
+      createTestMetadata({
+        captureId: "c1",
+        name: "前のアイテム",
+        brand: "ブランドX",
+        dollSize: "SD13",
+        category: "outer",
+        colors: ["hsl(120,50%,50%)"],
+        tags: ["タグA"],
+        confidenceDecayDays: 90,
+      }),
+    );
+    mockState.currentIndex = 1;
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    fireEvent.click(screen.getByRole("button", { name: /前の値を適用/ }));
+
+    expect(mockState.setMetadataCalls.length).toBe(1);
+    const applied = mockState.setMetadataCalls[0];
+    expect(applied?.captureId).toBe("c2");
+    expect(applied?.name).toBe("");
+    expect(applied?.brand).toBe("ブランドX");
+    expect(applied?.dollSize).toBe("SD13");
+    expect(applied?.category).toBe("outer");
+    expect(applied?.colors).toEqual(["hsl(120,50%,50%)"]);
+    expect(applied?.tags).toEqual(["タグA"]);
+    expect(applied?.confidenceDecayDays).toBe(90);
+  });
+
+  it("メタデータフォームの値変更で setMetadata が呼ばれる", async () => {
+    const user = userEvent.setup();
+    mockState.items.push(createTestItem({ captureId: "c1" }));
+    mockState.metadataMap.set("c1", createTestMetadata({ captureId: "c1" }));
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    const nameInput = screen.getByLabelText("名前");
+    await user.type(nameInput, "X");
+
+    expect(mockState.setMetadataCalls.length).toBeGreaterThan(0);
+    expect(mockState.setMetadataCalls.at(-1)?.captureId).toBe("c1");
+  });
+
+  it("currentMetadata が未取得（map に未登録）でもデフォルト値で描画される", async () => {
+    mockState.items.push(createTestItem({ captureId: "c1" }));
+
+    await renderWithProviders(<BulkMetadataForm />);
+
+    expect(screen.getByLabelText("名前")).toHaveValue("");
+    expect(screen.getByText("1 / 1")).toBeInTheDocument();
+  });
+});

--- a/src/components/garment/csv/CsvDropZone.test.tsx
+++ b/src/components/garment/csv/CsvDropZone.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/testUtils";
+import CsvDropZone from "./CsvDropZone";
+
+const createCsvFile = ({
+  name = "garments.csv",
+  type = "text/csv",
+  content = "name,category,dollSize\nテスト,tops,SD\n",
+}: {
+  readonly name?: string;
+  readonly type?: string;
+  readonly content?: string;
+} = {}): File => new File([content], name, { type });
+
+const buildDataTransfer = (file: File): DataTransfer => {
+  const dt = new DataTransfer();
+  dt.items.add(file);
+  return dt;
+};
+
+const getDropZone = (): HTMLElement => {
+  const dropZone = document.querySelector<HTMLElement>(".border-dashed");
+  expect(dropZone).not.toBeNull();
+  return dropZone ?? document.body;
+};
+
+describe("CsvDropZone", () => {
+  const createObjectUrlSpy = vi.fn(() => "blob:mock-url");
+  const revokeObjectUrlSpy = vi.fn();
+
+  beforeEach(() => {
+    createObjectUrlSpy.mockClear();
+    revokeObjectUrlSpy.mockClear();
+    vi.spyOn(URL, "createObjectURL").mockImplementation(createObjectUrlSpy);
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(revokeObjectUrlSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("ドロップゾーンとサンプル CSV ボタンが表示される", async () => {
+    const onFileLoaded = vi.fn();
+    await renderWithProviders(<CsvDropZone onFileLoaded={onFileLoaded} />);
+
+    expect(
+      screen.getByText("CSVファイルをドラッグ&ドロップ"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /サンプルCSVをダウンロード/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("text/csv の MIME type を持つファイルをドロップすると onFileLoaded が呼ばれる", async () => {
+    const onFileLoaded = vi.fn();
+    await renderWithProviders(<CsvDropZone onFileLoaded={onFileLoaded} />);
+
+    const file = createCsvFile({ content: "name,category,dollSize\na,b,c" });
+    fireEvent.drop(getDropZone(), { dataTransfer: buildDataTransfer(file) });
+
+    await waitFor(() => {
+      expect(onFileLoaded).toHaveBeenCalledWith(
+        "name,category,dollSize\na,b,c",
+      );
+    });
+  });
+
+  it("拡張子 .csv のファイルは MIME type が違っても受け入れられる", async () => {
+    const onFileLoaded = vi.fn();
+    await renderWithProviders(<CsvDropZone onFileLoaded={onFileLoaded} />);
+
+    const file = createCsvFile({
+      name: "data.CSV",
+      type: "application/octet-stream",
+      content: "header\nvalue",
+    });
+    fireEvent.drop(getDropZone(), { dataTransfer: buildDataTransfer(file) });
+
+    await waitFor(() => {
+      expect(onFileLoaded).toHaveBeenCalledWith("header\nvalue");
+    });
+  });
+
+  it("CSV 以外のファイルをドロップするとエラーメッセージが表示される", async () => {
+    const onFileLoaded = vi.fn();
+    await renderWithProviders(<CsvDropZone onFileLoaded={onFileLoaded} />);
+
+    const file = new File(["{}"], "garments.json", {
+      type: "application/json",
+    });
+    fireEvent.drop(getDropZone(), { dataTransfer: buildDataTransfer(file) });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("CSVファイルを選択してください"),
+      ).toBeInTheDocument();
+    });
+    expect(onFileLoaded).not.toHaveBeenCalled();
+  });
+
+  it("dragOver でドラッグ中の見た目に切り替わる", async () => {
+    const onFileLoaded = vi.fn();
+    await renderWithProviders(<CsvDropZone onFileLoaded={onFileLoaded} />);
+
+    const dropZone = getDropZone();
+
+    fireEvent.dragOver(dropZone, { dataTransfer: new DataTransfer() });
+    await waitFor(() => {
+      expect(dropZone.className).toContain("border-primary-400");
+    });
+
+    fireEvent.dragLeave(dropZone, { dataTransfer: new DataTransfer() });
+    await waitFor(() => {
+      expect(dropZone.className).not.toContain("border-primary-400");
+    });
+  });
+
+  it("空の dataTransfer ではコールバックが呼ばれない", async () => {
+    const onFileLoaded = vi.fn();
+    await renderWithProviders(<CsvDropZone onFileLoaded={onFileLoaded} />);
+
+    fireEvent.drop(getDropZone(), { dataTransfer: new DataTransfer() });
+
+    expect(onFileLoaded).not.toHaveBeenCalled();
+  });
+
+  it("input の change イベントでもファイルを処理する", async () => {
+    const user = userEvent.setup();
+    const onFileLoaded = vi.fn();
+    await renderWithProviders(<CsvDropZone onFileLoaded={onFileLoaded} />);
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(fileInput).toBeTruthy();
+    if (fileInput === null) return;
+
+    const file = createCsvFile({ content: "a,b\n1,2" });
+    await user.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(onFileLoaded).toHaveBeenCalledWith("a,b\n1,2");
+    });
+  });
+
+  it("ファイル未選択の input change ではコールバックが呼ばれない", async () => {
+    const onFileLoaded = vi.fn();
+    await renderWithProviders(<CsvDropZone onFileLoaded={onFileLoaded} />);
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    if (fileInput === null) return;
+
+    fireEvent.change(fileInput, { target: { files: [] } });
+
+    expect(onFileLoaded).not.toHaveBeenCalled();
+  });
+
+  it("サンプル CSV ダウンロードボタンをクリックすると Blob URL が生成される", async () => {
+    const user = userEvent.setup();
+    const onFileLoaded = vi.fn();
+    await renderWithProviders(<CsvDropZone onFileLoaded={onFileLoaded} />);
+
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    const button = screen.getByRole("button", {
+      name: /サンプルCSVをダウンロード/,
+    });
+    await user.click(button);
+
+    expect(createObjectUrlSpy).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+    expect(revokeObjectUrlSpy).toHaveBeenCalled();
+  });
+
+  it("ドロップゾーンクリックで隠しファイル input がクリックされる", async () => {
+    const user = userEvent.setup();
+    const onFileLoaded = vi.fn();
+    await renderWithProviders(<CsvDropZone onFileLoaded={onFileLoaded} />);
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    if (fileInput === null) return;
+
+    const inputClickSpy = vi
+      .spyOn(fileInput, "click")
+      .mockImplementation(() => undefined);
+
+    await user.click(getDropZone());
+
+    expect(inputClickSpy).toHaveBeenCalled();
+  });
+});

--- a/src/lib/csv/validateCsvRow.extra.test.ts
+++ b/src/lib/csv/validateCsvRow.extra.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import { validateCsvRow, generateSampleCsv } from "./validateCsvRow";
+import { CSV_IMPORT } from "@/lib/constants";
+
+describe("validateCsvRow (extra branches)", () => {
+  const validRecord = {
+    name: "ドール服",
+    category: "tops",
+    dollSize: "SD",
+    colors: "",
+    tags: "",
+    brand: "",
+    confidenceDecayDays: "",
+  };
+
+  it("name フィールドが完全に欠落している場合は必須エラー", () => {
+    const result = validateCsvRow({
+      record: { category: "tops", dollSize: "SD" },
+      rowNumber: 5,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors[0]?.field).toBe("name");
+      expect(result.errors[0]?.row).toBe(5);
+    }
+  });
+
+  it("category フィールドが完全に欠落している場合は必須エラー", () => {
+    const result = validateCsvRow({
+      record: { name: "テスト", dollSize: "SD" },
+      rowNumber: 7,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const field = result.errors.find((e) => e.field === "category");
+      expect(field).toBeDefined();
+      expect(field?.message).toBe("カテゴリは必須です");
+    }
+  });
+
+  it("dollSize フィールドが完全に欠落している場合は必須エラー", () => {
+    const result = validateCsvRow({
+      record: { name: "テスト", category: "tops" },
+      rowNumber: 9,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const field = result.errors.find((e) => e.field === "dollSize");
+      expect(field).toBeDefined();
+      expect(field?.message).toBe("ドールサイズは必須です");
+    }
+  });
+
+  it("空白のみの name は必須エラー（trim 後 空文字）", () => {
+    const result = validateCsvRow({
+      record: { ...validRecord, name: "   " },
+      rowNumber: 1,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors[0]?.field).toBe("name");
+    }
+  });
+
+  it("confidenceDecayDays が上限を超える場合はエラー", () => {
+    const result = validateCsvRow({
+      record: { ...validRecord, confidenceDecayDays: "366" },
+      rowNumber: 1,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors[0]?.field).toBe("confidenceDecayDays");
+    }
+  });
+
+  it("confidenceDecayDays が負の整数の場合はエラー", () => {
+    const result = validateCsvRow({
+      record: { ...validRecord, confidenceDecayDays: "-5" },
+      rowNumber: 1,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors[0]?.field).toBe("confidenceDecayDays");
+    }
+  });
+
+  it("confidenceDecayDays が境界値 1 の場合は有効", () => {
+    const result = validateCsvRow({
+      record: { ...validRecord, confidenceDecayDays: "1" },
+      rowNumber: 1,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.confidenceDecayDays).toBe(1);
+    }
+  });
+
+  it("confidenceDecayDays が境界値 365 の場合は有効", () => {
+    const result = validateCsvRow({
+      record: { ...validRecord, confidenceDecayDays: "365" },
+      rowNumber: 1,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.confidenceDecayDays).toBe(365);
+    }
+  });
+
+  it("brand が境界値（100文字ちょうど）の場合は有効", () => {
+    const result = validateCsvRow({
+      record: { ...validRecord, brand: "あ".repeat(100) },
+      rowNumber: 1,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.brand.length).toBe(100);
+    }
+  });
+
+  it("name が境界値（100文字ちょうど）の場合は有効", () => {
+    const result = validateCsvRow({
+      record: { ...validRecord, name: "あ".repeat(100) },
+      rowNumber: 1,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.name.length).toBe(100);
+    }
+  });
+
+  it("colors の各エントリは空白を除去されてパースされる", () => {
+    const result = validateCsvRow({
+      record: { ...validRecord, colors: " hsl(0,0%,100%) | hsl(120,50%,50%) " },
+      rowNumber: 1,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.colors).toEqual([
+        "hsl(0,0%,100%)",
+        "hsl(120,50%,50%)",
+      ]);
+    }
+  });
+
+  it("tags の各エントリは空白を除去されてパースされる", () => {
+    const result = validateCsvRow({
+      record: { ...validRecord, tags: " レース | フォーマル " },
+      rowNumber: 1,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.tags).toEqual(["レース", "フォーマル"]);
+    }
+  });
+
+  it("brand が空白のみの場合は trim 後 空文字として扱う", () => {
+    const result = validateCsvRow({
+      record: { ...validRecord, brand: "   " },
+      rowNumber: 1,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.brand).toBe("");
+    }
+  });
+
+  it("空のレコード（全フィールド undefined）は必須3項目すべてエラー", () => {
+    const result = validateCsvRow({ record: {}, rowNumber: 1 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.length).toBe(3);
+      const fields = result.errors.map((e) => e.field).sort();
+      expect(fields).toEqual(["category", "dollSize", "name"]);
+    }
+  });
+});
+
+describe("generateSampleCsv (extra)", () => {
+  it("ヘッダー行はすべての ALL_HEADERS を含む", () => {
+    const csv = generateSampleCsv();
+    const headerLine = csv.split("\n")[0] ?? "";
+    CSV_IMPORT.ALL_HEADERS.forEach((header) => {
+      expect(headerLine).toContain(header);
+    });
+  });
+
+  it("生成されたサンプル CSV はパース可能な行を含む", () => {
+    const csv = generateSampleCsv();
+    const lines = csv.split("\n");
+    expect(lines.length).toBe(3);
+    expect(lines[1]).toContain("dress");
+    expect(lines[2]).toContain("bottoms");
+  });
+});


### PR DESCRIPTION
## Summary

Issue #143 のテストカバレッジ拡充の一環として、CSV/Bulk 関連のテストを追加。

- `src/components/garment/csv/CsvDropZone.test.tsx`
- `src/components/garment/bulk/BulkMetadataForm.test.tsx`
- `src/lib/csv/validateCsvRow.extra.test.ts`（既存 `validateCsvRow.test.ts` は触らず追加分のみ）

drag/drop、CSV 拡張子判定、空ファイル、サンプル CSV ダウンロード、bulk index 進む/戻る、`allNamed` 計算、currentItem undefined、validateCsvRow 境界エラーを網羅。

## Test plan

- [x] 各 .test.tsx を `pnpm test` で実行 緑
- [ ] CI で `pnpm precheck` が緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #143