### PR TITLE
test: backend image/digest/sync のテストを追加 (Unit 20/21 of #143)

### DIFF
--- a/workers/src/queues/digest-consumer.test.ts
+++ b/workers/src/queues/digest-consumer.test.ts
@@ -1,0 +1,137 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createLogger } from "../lib/logger";
+import { handleDigestQueue } from "./digest-consumer";
+import * as digestService from "../services/digest-service";
+import { serviceOk, serviceError } from "../services/types";
+
+vi.mock("../services/digest-service", async () => {
+  const actual = await vi.importActual<typeof import("../services/digest-service")>(
+    "../services/digest-service",
+  );
+  return {
+    ...actual,
+    generateDigestForUser: vi.fn(),
+  };
+});
+
+const mockedGenerate = vi.mocked(digestService.generateDigestForUser);
+
+const logger = createLogger({ minLevel: "error" });
+
+type StubMessage = Message & {
+  readonly ack: ReturnType<typeof vi.fn>;
+  readonly retry: ReturnType<typeof vi.fn>;
+};
+
+const buildMessage = (body: unknown): StubMessage => ({
+  id: "msg-1",
+  body,
+  ack: vi.fn(),
+  retry: vi.fn(),
+  timestamp: new Date(),
+  attempts: 1,
+});
+
+const buildBatch = (messages: readonly StubMessage[]): MessageBatch => ({
+  queue: "digest",
+  messages,
+  ackAll: vi.fn(),
+  retryAll: vi.fn(),
+});
+
+beforeEach(() => {
+  mockedGenerate.mockReset();
+});
+
+describe("handleDigestQueue", () => {
+  it("isDigestQueueMessage が false の場合 warn して ack する", async () => {
+    const warnSpy = vi.spyOn(logger, "warn");
+    const message = buildMessage({ type: "unknown" });
+    const batch = buildBatch([message]);
+
+    await handleDigestQueue({ batch, env, logger });
+
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+    expect(mockedGenerate).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "unknown queue message type",
+      expect.objectContaining({ body: { type: "unknown" } }),
+    );
+  });
+
+  it("body が record でない場合も warn して ack する", async () => {
+    const message = buildMessage("not-an-object");
+    const batch = buildBatch([message]);
+
+    await handleDigestQueue({ batch, env, logger });
+
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  it("type が generate_digest だが userId が無い場合も warn して ack する", async () => {
+    const message = buildMessage({ type: "generate_digest" });
+    const batch = buildBatch([message]);
+
+    await handleDigestQueue({ batch, env, logger });
+
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(mockedGenerate).not.toHaveBeenCalled();
+  });
+
+  it("result.ok が true の場合 ack する", async () => {
+    mockedGenerate.mockResolvedValue(
+      serviceOk({ digest: undefined, skipped: true }),
+    );
+
+    const message = buildMessage({
+      type: "generate_digest",
+      userId: "user-1",
+    });
+    const batch = buildBatch([message]);
+
+    await handleDigestQueue({ batch, env, logger });
+
+    expect(mockedGenerate).toHaveBeenCalledTimes(1);
+    expect(mockedGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1" }),
+    );
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  it("result.ok が false の場合 retry する", async () => {
+    mockedGenerate.mockResolvedValue(
+      serviceError("INTERNAL_ERROR", "DB connection failed"),
+    );
+
+    const message = buildMessage({
+      type: "generate_digest",
+      userId: "user-2",
+    });
+    const batch = buildBatch([message]);
+
+    await handleDigestQueue({ batch, env, logger });
+
+    expect(mockedGenerate).toHaveBeenCalledTimes(1);
+    expect(message.retry).toHaveBeenCalledTimes(1);
+    expect(message.ack).not.toHaveBeenCalled();
+  });
+
+  it("複数メッセージを並行処理し、それぞれ独立に ack/retry する", async () => {
+    mockedGenerate
+      .mockResolvedValueOnce(serviceOk({ digest: undefined, skipped: true }))
+      .mockResolvedValueOnce(serviceError("INTERNAL_ERROR", "fail"));
+
+    const ok = buildMessage({ type: "generate_digest", userId: "user-ok" });
+    const ng = buildMessage({ type: "generate_digest", userId: "user-ng" });
+    const batch = buildBatch([ok, ng]);
+
+    await handleDigestQueue({ batch, env, logger });
+
+    expect(ok.ack).toHaveBeenCalledTimes(1);
+    expect(ng.retry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/workers/src/queues/digest-consumer.test.ts
+++ b/workers/src/queues/digest-consumer.test.ts
@@ -1,4 +1,5 @@
 import { env } from "cloudflare:test";
+import type { Message, MessageBatch } from "@cloudflare/workers-types";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createLogger } from "../lib/logger";
 import { handleDigestQueue } from "./digest-consumer";
@@ -6,9 +7,9 @@ import * as digestService from "../services/digest-service";
 import { serviceOk, serviceError } from "../services/types";
 
 vi.mock("../services/digest-service", async () => {
-  const actual = await vi.importActual<typeof import("../services/digest-service")>(
-    "../services/digest-service",
-  );
+  const actual = await vi.importActual<
+    typeof import("../services/digest-service")
+  >("../services/digest-service");
   return {
     ...actual,
     generateDigestForUser: vi.fn(),

--- a/workers/src/routes/image.scenario.test.ts
+++ b/workers/src/routes/image.scenario.test.ts
@@ -49,13 +49,10 @@ const buildMultipartRequest = ({
   if (file !== undefined) {
     form.append("file", file);
   }
-  return new Request(
-    `http://localhost/api/images/upload/${garmentId}`,
-    {
-      method: "POST",
-      body: form,
-    },
-  );
+  return new Request(`http://localhost/api/images/upload/${garmentId}`, {
+    method: "POST",
+    body: form,
+  });
 };
 
 describe("imageRoutes /upload/:garmentId", () => {
@@ -81,14 +78,11 @@ describe("imageRoutes /upload/:garmentId", () => {
   it("Content-Type が multipart/form-data でない場合 400 を返す", async () => {
     const app = buildApp();
     const garmentId = createId();
-    const req = new Request(
-      `http://localhost/api/images/upload/${garmentId}`,
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ foo: "bar" }),
-      },
-    );
+    const req = new Request(`http://localhost/api/images/upload/${garmentId}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ foo: "bar" }),
+    });
     const res = await app.fetch(req, env);
     expect(res.status).toBe(400);
     const message = await parseError(res);

--- a/workers/src/routes/image.scenario.test.ts
+++ b/workers/src/routes/image.scenario.test.ts
@@ -1,0 +1,171 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { z } from "zod";
+import type { Env } from "../types";
+import type { Auth } from "../auth";
+import type { Logger } from "../lib/logger";
+import { createLogger } from "../lib/logger";
+import { imageRoutes } from "./image";
+import { createId } from "@paralleldrive/cuid2";
+
+type Variables = {
+  auth: Auth;
+  requestId: string;
+  logger: Logger;
+};
+
+const errorSchema = z.object({ error: z.string() });
+const imageUrlSchema = z.object({ imageUrl: z.string() });
+
+const parseError = async (res: Response): Promise<string> => {
+  const data = await res.json();
+  return errorSchema.parse(data).error;
+};
+
+const parseImageUrl = async (res: Response): Promise<string> => {
+  const data = await res.json();
+  return imageUrlSchema.parse(data).imageUrl;
+};
+
+const buildApp = () => {
+  const app = new Hono<{ Bindings: Env; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("logger", createLogger({ minLevel: "error" }));
+    await next();
+  });
+  app.route("/api/images", imageRoutes);
+  return app;
+};
+
+const buildMultipartRequest = ({
+  garmentId,
+  file,
+}: {
+  readonly garmentId: string;
+  readonly file: File | undefined;
+}): Request => {
+  const form = new FormData();
+  if (file !== undefined) {
+    form.append("file", file);
+  }
+  return new Request(
+    `http://localhost/api/images/upload/${garmentId}`,
+    {
+      method: "POST",
+      body: form,
+    },
+  );
+};
+
+describe("imageRoutes /upload/:garmentId", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("garmentId が空文字の場合 (ルート不一致) 404 を返す", async () => {
+    const app = buildApp();
+    const req = new Request("http://localhost/api/images/upload/", {
+      method: "POST",
+      headers: { "content-type": "multipart/form-data; boundary=x" },
+      body: "",
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("Content-Type が multipart/form-data でない場合 400 を返す", async () => {
+    const app = buildApp();
+    const garmentId = createId();
+    const req = new Request(
+      `http://localhost/api/images/upload/${garmentId}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ foo: "bar" }),
+      },
+    );
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(400);
+    const message = await parseError(res);
+    expect(message).toContain("multipart/form-data");
+  });
+
+  it("file フィールドが欠落している場合 400 を返す", async () => {
+    const app = buildApp();
+    const garmentId = createId();
+    const req = buildMultipartRequest({ garmentId, file: undefined });
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(400);
+    const message = await parseError(res);
+    expect(message).toBe("file field is required");
+  });
+
+  it("validateFile が失敗する MIME (image/gif) の場合 400 を返す", async () => {
+    const app = buildApp();
+    const garmentId = createId();
+    const file = new File([new Uint8Array([1, 2, 3])], "x.gif", {
+      type: "image/gif",
+    });
+    const req = buildMultipartRequest({ garmentId, file });
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(400);
+    const message = await parseError(res);
+    expect(message).toContain("image/gif");
+  });
+
+  it("R2 への upload が失敗した場合 500 を返す", async () => {
+    const app = buildApp();
+    const garmentId = createId();
+    const file = new File([new Uint8Array([1, 2, 3])], "x.png", {
+      type: "image/png",
+    });
+
+    const putSpy = vi
+      .spyOn(env.BUCKET, "put")
+      .mockRejectedValue(new Error("R2 disconnected"));
+
+    const req = buildMultipartRequest({ garmentId, file });
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(500);
+    const message = await parseError(res);
+    expect(message).toBe("R2 disconnected");
+    expect(putSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("正常系: R2 に put して imageUrl を返す", async () => {
+    const app = buildApp();
+    const garmentId = createId();
+    const file = new File([new Uint8Array([10, 20, 30])], "x.png", {
+      type: "image/png",
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const putSpy = vi.spyOn(env.BUCKET, "put");
+
+    const req = buildMultipartRequest({ garmentId, file });
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    const url = await parseImageUrl(res);
+    expect(url).toBe(
+      `${env.R2_PUBLIC_URL}/garments/temp-user-001/${garmentId}/1700000000000.png`,
+    );
+    expect(putSpy).toHaveBeenCalledTimes(1);
+    const firstCall = putSpy.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    expect(firstCall?.[0]).toBe(
+      `garments/temp-user-001/${garmentId}/1700000000000.png`,
+    );
+    expect(firstCall?.[2]).toEqual({
+      httpMetadata: { contentType: "image/png" },
+    });
+  });
+});

--- a/workers/src/services/image-service.errors.test.ts
+++ b/workers/src/services/image-service.errors.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type {
+  Blob as WorkersBlob,
   R2Bucket,
   R2ObjectBody,
+  ReadableStream as WorkersReadableStream,
 } from "@cloudflare/workers-types";
 import { createLogger } from "../lib/logger";
 import { uploadImage, getImage, deleteImage } from "./image-service";
@@ -38,6 +40,10 @@ const buildStubBucket = (
   return { bucket, stub };
 };
 
+const notImplemented = (): never => {
+  throw new Error("not implemented in stub");
+};
+
 const buildR2ObjectBody = ({
   body,
   contentType,
@@ -49,6 +55,8 @@ const buildR2ObjectBody = ({
 }): R2ObjectBody => {
   const httpMetadata = contentType !== undefined ? { contentType } : {};
   // R2ObjectBody の必要メソッドだけ揃えた object を返す
+  // image-service が触るのは httpMetadata / arrayBuffer / httpEtag のみ。
+  // それ以外は呼ばれないため throw するスタブで型を満たす。
   const obj: R2ObjectBody = {
     key: "k",
     version: "v",
@@ -61,12 +69,16 @@ const buildR2ObjectBody = ({
     customMetadata: {},
     storageClass: "Standard",
     range: undefined,
-    body: undefined,
+    get body(): WorkersReadableStream {
+      return notImplemented();
+    },
     bodyUsed: false,
-    arrayBuffer: () => Promise.resolve(body),
-    text: () => Promise.resolve(""),
-    json: () => Promise.resolve({}),
-    blob: () => Promise.resolve(new Blob()),
+    arrayBuffer: async () => await Promise.resolve(body),
+    bytes: async () => await Promise.resolve(new Uint8Array(body)),
+    text: async () => await Promise.resolve(""),
+    json: async <T>(): Promise<T> => await Promise.resolve(notImplemented()),
+    blob: async (): Promise<WorkersBlob> =>
+      await Promise.resolve(notImplemented()),
     writeHttpMetadata: () => undefined,
   };
   return obj;

--- a/workers/src/services/image-service.errors.test.ts
+++ b/workers/src/services/image-service.errors.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  R2Bucket,
+  R2ObjectBody,
+} from "@cloudflare/workers-types";
+import { createLogger } from "../lib/logger";
+import { uploadImage, getImage, deleteImage } from "./image-service";
+
+const logger = createLogger({ minLevel: "error" });
+
+type StubBucket = {
+  readonly put: ReturnType<typeof vi.fn>;
+  readonly get: ReturnType<typeof vi.fn>;
+  readonly delete: ReturnType<typeof vi.fn>;
+};
+
+const buildStubBucket = (
+  overrides: Partial<StubBucket> = {},
+): { readonly bucket: R2Bucket; readonly stub: StubBucket } => {
+  const stub: StubBucket = {
+    put: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  };
+  // R2Bucket は head/list/multipart 等もメソッドを持つが、
+  // image-service が触るのは put/get/delete のみ。
+  // テストスタブのため Object.assign で R2Bucket 型に投影する
+  const bucket: R2Bucket = {
+    put: stub.put,
+    get: stub.get,
+    delete: stub.delete,
+    head: vi.fn(),
+    list: vi.fn(),
+    createMultipartUpload: vi.fn(),
+    resumeMultipartUpload: vi.fn(),
+  };
+  return { bucket, stub };
+};
+
+const buildR2ObjectBody = ({
+  body,
+  contentType,
+  httpEtag,
+}: {
+  readonly body: ArrayBuffer;
+  readonly contentType: string | undefined;
+  readonly httpEtag: string;
+}): R2ObjectBody => {
+  const httpMetadata = contentType !== undefined ? { contentType } : {};
+  // R2ObjectBody の必要メソッドだけ揃えた object を返す
+  const obj: R2ObjectBody = {
+    key: "k",
+    version: "v",
+    size: body.byteLength,
+    etag: httpEtag,
+    httpEtag,
+    checksums: { toJSON: () => ({}) },
+    uploaded: new Date(),
+    httpMetadata,
+    customMetadata: {},
+    storageClass: "Standard",
+    range: undefined,
+    body: undefined,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(body),
+    text: () => Promise.resolve(""),
+    json: () => Promise.resolve({}),
+    blob: () => Promise.resolve(new Blob()),
+    writeHttpMetadata: () => undefined,
+  };
+  return obj;
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("uploadImage エラーパス", () => {
+  it("R2.put が reject した場合 INTERNAL_ERROR を返す", async () => {
+    const { bucket, stub } = buildStubBucket({
+      put: vi.fn().mockRejectedValue(new Error("network down")),
+    });
+
+    const result = await uploadImage({
+      bucket,
+      key: "k1",
+      body: new ArrayBuffer(8),
+      mimeType: "image/png",
+      logger,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INTERNAL_ERROR");
+      expect(result.error.message).toBe("network down");
+    }
+    expect(stub.put).toHaveBeenCalledTimes(1);
+  });
+
+  it("R2.put が非 Error を reject した場合フォールバックメッセージを返す", async () => {
+    const { bucket } = buildStubBucket({
+      put: vi.fn().mockRejectedValue("string error"),
+    });
+
+    const result = await uploadImage({
+      bucket,
+      key: "k2",
+      body: new ArrayBuffer(8),
+      mimeType: "image/png",
+      logger,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe("R2 upload failed");
+    }
+  });
+
+  it("正常系: R2.put が解決すると ok を返す", async () => {
+    const { bucket, stub } = buildStubBucket({
+      put: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await uploadImage({
+      bucket,
+      key: "k3",
+      body: new ArrayBuffer(4),
+      mimeType: "image/png",
+      logger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.key).toBe("k3");
+    }
+    expect(stub.put).toHaveBeenCalledWith("k3", expect.any(ArrayBuffer), {
+      httpMetadata: { contentType: "image/png" },
+    });
+  });
+});
+
+describe("getImage エラーパス", () => {
+  it("R2.get が reject した場合 INTERNAL_ERROR を返す", async () => {
+    const { bucket } = buildStubBucket({
+      get: vi.fn().mockRejectedValue(new Error("R2 down")),
+    });
+
+    const result = await getImage({ bucket, key: "k1", logger });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INTERNAL_ERROR");
+      expect(result.error.message).toBe("R2 down");
+    }
+  });
+
+  it("R2.get が非 Error を reject した場合フォールバックメッセージを返す", async () => {
+    const { bucket } = buildStubBucket({
+      get: vi.fn().mockRejectedValue(123),
+    });
+
+    const result = await getImage({ bucket, key: "k1", logger });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe("R2 get failed");
+    }
+  });
+
+  it("R2.get が null を返した場合 NOT_FOUND を返す", async () => {
+    const { bucket } = buildStubBucket({
+      get: vi.fn().mockResolvedValue(null),
+    });
+
+    const result = await getImage({ bucket, key: "missing", logger });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.message).toBe("Image not found");
+    }
+  });
+
+  it("httpMetadata?.contentType が undefined の場合 application/octet-stream にフォールバック", async () => {
+    const body = new ArrayBuffer(16);
+    const obj = buildR2ObjectBody({
+      body,
+      contentType: undefined,
+      httpEtag: "etag-1",
+    });
+    const { bucket } = buildStubBucket({
+      get: vi.fn().mockResolvedValue(obj),
+    });
+
+    const result = await getImage({ bucket, key: "k", logger });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.contentType).toBe("application/octet-stream");
+      expect(result.data.httpEtag).toBe("etag-1");
+      expect(result.data.body).toBe(body);
+    }
+  });
+
+  it("httpMetadata?.contentType が定義されていればそれを返す", async () => {
+    const body = new ArrayBuffer(8);
+    const obj = buildR2ObjectBody({
+      body,
+      contentType: "image/png",
+      httpEtag: "etag-2",
+    });
+    const { bucket } = buildStubBucket({
+      get: vi.fn().mockResolvedValue(obj),
+    });
+
+    const result = await getImage({ bucket, key: "k", logger });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.contentType).toBe("image/png");
+    }
+  });
+});
+
+describe("deleteImage エラーパス", () => {
+  it("R2.delete が reject した場合 INTERNAL_ERROR を返す", async () => {
+    const { bucket } = buildStubBucket({
+      delete: vi.fn().mockRejectedValue(new Error("delete failed")),
+    });
+
+    const result = await deleteImage({ bucket, key: "k1", logger });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INTERNAL_ERROR");
+      expect(result.error.message).toBe("delete failed");
+    }
+  });
+
+  it("R2.delete が非 Error を reject した場合フォールバックメッセージを返す", async () => {
+    const { bucket } = buildStubBucket({
+      delete: vi.fn().mockRejectedValue(undefined),
+    });
+
+    const result = await deleteImage({ bucket, key: "k1", logger });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe("R2 delete failed");
+    }
+  });
+
+  it("正常系: 削除に成功する", async () => {
+    const { bucket, stub } = buildStubBucket({
+      delete: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await deleteImage({ bucket, key: "k1", logger });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.success).toBe(true);
+    }
+    expect(stub.delete).toHaveBeenCalledWith("k1");
+  });
+});

--- a/workers/src/services/sync-processors.errors.test.ts
+++ b/workers/src/services/sync-processors.errors.test.ts
@@ -1,0 +1,297 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createDrizzle } from "../db/client";
+import { createLogger } from "../lib/logger";
+import * as syncRepo from "../repositories/sync-repository";
+import { ACTION_PROCESSORS } from "./sync-processors";
+
+vi.mock("../repositories/sync-repository", () => ({
+  upsertGarment: vi.fn().mockResolvedValue(undefined),
+  deleteGarment: vi.fn().mockResolvedValue(undefined),
+  upsertStorageCase: vi.fn().mockResolvedValue(undefined),
+  upsertStorageLocation: vi.fn().mockResolvedValue(undefined),
+  upsertDoll: vi.fn().mockResolvedValue(undefined),
+  deleteDoll: vi.fn().mockResolvedValue(undefined),
+  upsertCoordinate: vi.fn().mockResolvedValue(undefined),
+  deleteCoordinate: vi.fn().mockResolvedValue(undefined),
+  deleteStorageCaseWithCascade: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockedRepo = vi.mocked(syncRepo);
+
+const logger = createLogger({ minLevel: "error" });
+// 実際のリポジトリ呼び出しは vi.mock で差し替え済み。型を満たすために実 DB を渡す
+const drizzleDb = createDrizzle(env.DB);
+const ctx = { drizzleDb, userId: "user-1", logger } as const;
+
+const NOW = 1_700_000_000_000;
+
+const validGarmentPayload = {
+  id: "g-1",
+  userId: "user-original",
+  name: "テスト服",
+  category: "dress",
+  dollSizes: ["MSD"],
+  colors: [],
+  tags: [],
+  status: "stored",
+  lastScannedAt: NOW,
+  confidenceDecayDays: 30,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const validCasePayload = {
+  id: "c-1",
+  userId: "user-original",
+  name: "テストケース",
+  rows: 3,
+  cols: 2,
+  createdAt: NOW,
+};
+
+const validLocationPayload = {
+  id: "l-1",
+  userId: "user-original",
+  caseId: "c-1",
+  label: "A-1",
+  row: 0,
+  col: 0,
+  createdAt: NOW,
+};
+
+const validDollPayload = {
+  id: "d-1",
+  userId: "user-original",
+  name: "テストドール",
+  bodySize: "MSD",
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const validCoordinatePayload = {
+  id: "co-1",
+  userId: "user-original",
+  name: "テストコーデ",
+  garmentIds: ["g-1"],
+  isAiGenerated: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+beforeEach(() => {
+  Object.values(mockedRepo).forEach((fn) => {
+    fn.mockClear();
+    fn.mockResolvedValue(undefined);
+  });
+});
+
+describe("ACTION_PROCESSORS — safeParse 失敗時に BAD_REQUEST を返す", () => {
+  it("garment:create に不正な payload を渡すと BAD_REQUEST", async () => {
+    const processor = ACTION_PROCESSORS["garment:create"]!;
+    const result = await processor(ctx, { invalid: true });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.message).toContain("Invalid garment payload");
+    }
+    expect(mockedRepo.upsertGarment).not.toHaveBeenCalled();
+  });
+
+  it("garment:delete に不正な payload を渡すと BAD_REQUEST", async () => {
+    const processor = ACTION_PROCESSORS["garment:delete"]!;
+    const result = await processor(ctx, { foo: "bar" });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+    }
+    expect(mockedRepo.deleteGarment).not.toHaveBeenCalled();
+  });
+
+  it("storageCase:update に不正な payload を渡すと BAD_REQUEST", async () => {
+    const processor = ACTION_PROCESSORS["storageCase:update"]!;
+    const result = await processor(ctx, { id: "" });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("Invalid storageCase payload");
+    }
+  });
+
+  it("storageCase:delete に不正な payload を渡すと BAD_REQUEST", async () => {
+    const processor = ACTION_PROCESSORS["storageCase:delete"]!;
+    const result = await processor(ctx, {});
+
+    expect(result.ok).toBe(false);
+    expect(mockedRepo.deleteStorageCaseWithCascade).not.toHaveBeenCalled();
+  });
+
+  it("storageLocation:create に不正な payload を渡すと BAD_REQUEST", async () => {
+    const processor = ACTION_PROCESSORS["storageLocation:create"]!;
+    const result = await processor(ctx, { id: "x" });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("Invalid storageLocation payload");
+    }
+  });
+
+  it("storageLocation:update に不正な payload を渡すと BAD_REQUEST", async () => {
+    const processor = ACTION_PROCESSORS["storageLocation:update"]!;
+    const result = await processor(ctx, { invalid: true });
+
+    expect(result.ok).toBe(false);
+    expect(mockedRepo.upsertStorageLocation).not.toHaveBeenCalled();
+  });
+
+  it("doll:create に不正な payload を渡すと BAD_REQUEST", async () => {
+    const processor = ACTION_PROCESSORS["doll:create"]!;
+    const result = await processor(ctx, {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("Invalid doll payload");
+    }
+    expect(mockedRepo.upsertDoll).not.toHaveBeenCalled();
+  });
+
+  it("doll:delete に不正な payload を渡すと BAD_REQUEST", async () => {
+    const processor = ACTION_PROCESSORS["doll:delete"]!;
+    const result = await processor(ctx, {});
+
+    expect(result.ok).toBe(false);
+    expect(mockedRepo.deleteDoll).not.toHaveBeenCalled();
+  });
+
+  it("coordinate:create に不正な payload を渡すと BAD_REQUEST", async () => {
+    const processor = ACTION_PROCESSORS["coordinate:create"]!;
+    const result = await processor(ctx, { id: "" });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("Invalid coordinate payload");
+    }
+    expect(mockedRepo.upsertCoordinate).not.toHaveBeenCalled();
+  });
+
+  it("coordinate:delete に不正な payload を渡すと BAD_REQUEST", async () => {
+    const processor = ACTION_PROCESSORS["coordinate:delete"]!;
+    const result = await processor(ctx, {});
+
+    expect(result.ok).toBe(false);
+    expect(mockedRepo.deleteCoordinate).not.toHaveBeenCalled();
+  });
+});
+
+describe("storageCase:create の二形式", () => {
+  it("with locations 形式: case を upsert し、locations も upsert する", async () => {
+    const processor = ACTION_PROCESSORS["storageCase:create"]!;
+    const payload = {
+      storageCase: validCasePayload,
+      locations: [
+        validLocationPayload,
+        { ...validLocationPayload, id: "l-2", label: "A-2", col: 1 },
+      ],
+    };
+
+    const result = await processor(ctx, payload);
+
+    expect(result.ok).toBe(true);
+    expect(mockedRepo.upsertStorageCase).toHaveBeenCalledTimes(1);
+    expect(mockedRepo.upsertStorageLocation).toHaveBeenCalledTimes(2);
+  });
+
+  it("case-only 形式: case のみ upsert する", async () => {
+    const processor = ACTION_PROCESSORS["storageCase:create"]!;
+
+    const result = await processor(ctx, validCasePayload);
+
+    expect(result.ok).toBe(true);
+    expect(mockedRepo.upsertStorageCase).toHaveBeenCalledTimes(1);
+    expect(mockedRepo.upsertStorageLocation).not.toHaveBeenCalled();
+  });
+
+  it("どちらの形式にも該当しない場合 BAD_REQUEST を返す", async () => {
+    const processor = ACTION_PROCESSORS["storageCase:create"]!;
+
+    const result = await processor(ctx, { id: "missing-fields" });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+      expect(result.error.message).toContain(
+        "Invalid storageCase:create payload",
+      );
+    }
+  });
+});
+
+describe("hasLocationCounters の OR 分岐", () => {
+  it("confirmAllCount が指定されている場合 includeCounters=true で呼ばれる", async () => {
+    const processor = ACTION_PROCESSORS["storageLocation:create"]!;
+    const payload = { ...validLocationPayload, confirmAllCount: 5 };
+
+    await processor(ctx, payload);
+
+    expect(mockedRepo.upsertStorageLocation).toHaveBeenCalledWith(
+      expect.objectContaining({ includeCounters: true }),
+    );
+  });
+
+  it("correctionCount が指定されている場合 includeCounters=true", async () => {
+    const processor = ACTION_PROCESSORS["storageLocation:create"]!;
+    const payload = { ...validLocationPayload, correctionCount: 2 };
+
+    await processor(ctx, payload);
+
+    expect(mockedRepo.upsertStorageLocation).toHaveBeenCalledWith(
+      expect.objectContaining({ includeCounters: true }),
+    );
+  });
+
+  it("lastVisitedAt が指定されている場合 includeCounters=true", async () => {
+    const processor = ACTION_PROCESSORS["storageLocation:create"]!;
+    const payload = { ...validLocationPayload, lastVisitedAt: NOW };
+
+    await processor(ctx, payload);
+
+    expect(mockedRepo.upsertStorageLocation).toHaveBeenCalledWith(
+      expect.objectContaining({ includeCounters: true }),
+    );
+  });
+
+  it("カウンタ系がいずれも未定義の場合 includeCounters=false", async () => {
+    const processor = ACTION_PROCESSORS["storageLocation:update"]!;
+
+    await processor(ctx, validLocationPayload);
+
+    expect(mockedRepo.upsertStorageLocation).toHaveBeenCalledWith(
+      expect.objectContaining({ includeCounters: false }),
+    );
+  });
+});
+
+describe("正常系の最終確認 (回帰)", () => {
+  it("garment:create が処理される", async () => {
+    const processor = ACTION_PROCESSORS["garment:create"]!;
+    const result = await processor(ctx, validGarmentPayload);
+    expect(result.ok).toBe(true);
+    expect(mockedRepo.upsertGarment).toHaveBeenCalledTimes(1);
+  });
+
+  it("doll:create が処理される", async () => {
+    const processor = ACTION_PROCESSORS["doll:create"]!;
+    const result = await processor(ctx, validDollPayload);
+    expect(result.ok).toBe(true);
+    expect(mockedRepo.upsertDoll).toHaveBeenCalledTimes(1);
+  });
+
+  it("coordinate:create が処理される", async () => {
+    const processor = ACTION_PROCESSORS["coordinate:create"]!;
+    const result = await processor(ctx, validCoordinatePayload);
+    expect(result.ok).toBe(true);
+    expect(mockedRepo.upsertCoordinate).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Issue #143 のテストカバレッジ拡充の一環として、backend の image route / image-service エラーパス / digest queue consumer / sync-processors エラーパスのテストを追加。image route の 6 分岐、image-service の R2.put/get/delete reject + object null + httpMetadata フォールバック、digest-consumer の isDigestQueueMessage false / success / failure、sync-processors の safeParse 失敗 + hasLocationCounters OR + storageCaseCreate 2 形式を網羅。全 43 テスト緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #143