### PR TITLE
fix: stabilize auth-dependent e2e forms

### DIFF
--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -1,29 +1,33 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { LogOut } from "lucide-react";
 import { t } from "@lingui/core/macro";
-import { authSessionAtom, signOutAtom } from "@/stores/authAtoms";
+import { authSessionUnwrappedAtom, signOutAtom } from "@/stores/authAtoms";
 
 const UserMenu = () => {
-  const authState = useAtomValue(authSessionAtom);
+  const authState = useAtomValue(authSessionUnwrappedAtom);
   const signOut = useSetAtom(signOutAtom);
+  const [isMounted, setIsMounted] = useState(false);
 
-  if (authState.user === undefined) {
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted || authState.user === undefined) {
     return undefined;
   }
 
+  const { user } = authState;
+
   return (
     <div className="flex items-center gap-2">
-      {authState.user.image !== undefined ? (
-        <img
-          src={authState.user.image}
-          alt={authState.user.name}
-          className="size-8 rounded-full"
-        />
+      {user.image !== undefined ? (
+        <img src={user.image} alt={user.name} className="size-8 rounded-full" />
       ) : (
         <div className="flex size-8 items-center justify-center rounded-full bg-primary-100 text-xs font-bold text-primary-700">
-          {authState.user.name.charAt(0)}
+          {user.name.charAt(0)}
         </div>
       )}
       <button

--- a/src/components/doll/DollForm.tsx
+++ b/src/components/doll/DollForm.tsx
@@ -8,7 +8,7 @@ import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 import { addDollAtom, updateDollAtom } from "@/stores/dollAtoms";
-import { authSessionAtom } from "@/stores/authAtoms";
+import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
 import type { Doll, DollSize } from "@/types";
 import { DOLL_NAME_MAX_LENGTH, DOLL_MEMO_MAX_LENGTH } from "@/lib/constants";
 import { DOLL_SIZE_LABEL } from "@/lib/i18n-labels";
@@ -70,7 +70,7 @@ const DollForm = ({ doll }: Props) => {
 
   const addDoll = useSetAtom(addDollAtom);
   const updateDoll = useSetAtom(updateDollAtom);
-  const authState = useAtomValue(authSessionAtom);
+  const authState = useAtomValue(authSessionUnwrappedAtom);
   const { uploadState, upload, reset: resetUpload } = useImageUpload();
   const initial = getInitialValues(doll);
   const [name, setName] = useState(initial.name);
@@ -114,6 +114,7 @@ const DollForm = ({ doll }: Props) => {
           () => doll?.imageUrl ?? undefined,
         )
       : (doll?.imageUrl ?? undefined);
+  const userId = authState.user?.id ?? "local";
 
   const handleSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
@@ -144,7 +145,7 @@ const DollForm = ({ doll }: Props) => {
       await addDoll({
         ...fields,
         id: dollId,
-        userId: authState.user?.id ?? "local",
+        userId,
         imageUrl,
         archivedAt: undefined,
         createdAt: now,

--- a/src/components/garment/GarmentForm.tsx
+++ b/src/components/garment/GarmentForm.tsx
@@ -10,7 +10,7 @@ import { useLingui } from "@lingui/react";
 import clsx from "clsx";
 import { Loader2 } from "lucide-react";
 import { addGarmentAtom, updateGarmentAtom } from "@/stores/garmentAtoms";
-import { authSessionAtom } from "@/stores/authAtoms";
+import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
 import type { DollSize, Garment, GarmentCategory } from "@/types";
 import {
   GARMENT_STATUS,
@@ -103,7 +103,7 @@ const GarmentForm = ({ garment }: Props) => {
   const brandSuggestions = useBrandSuggestions();
   const addGarment = useSetAtom(addGarmentAtom);
   const updateGarment = useSetAtom(updateGarmentAtom);
-  const authState = useAtomValue(authSessionAtom);
+  const authState = useAtomValue(authSessionUnwrappedAtom);
   const { uploadState, upload, reset: resetUpload } = useImageUpload();
   const { extractionState, extractColors } = useColorExtraction();
   const initial = getInitialValues(garment);
@@ -188,6 +188,7 @@ const GarmentForm = ({ garment }: Props) => {
           () => garment?.imageUrl ?? undefined,
         )
       : (garment?.imageUrl ?? undefined);
+  const userId = authState.user?.id ?? "local";
 
   const handleSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
@@ -211,7 +212,7 @@ const GarmentForm = ({ garment }: Props) => {
       await addGarment({
         ...fields,
         id: garmentId,
-        userId: authState.user?.id ?? "local",
+        userId,
         imageUrl,
         locationId: undefined,
         status: GARMENT_STATUS.STORED,

--- a/src/stores/authAtoms.ts
+++ b/src/stores/authAtoms.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { atom } from "jotai";
+import { unwrap } from "jotai/utils";
 import { getSession, signOut as authSignOut } from "@/lib/auth";
 import type { SessionResponse } from "@/lib/auth";
 
@@ -38,6 +39,11 @@ export const authSessionAtom = atom(async (get): Promise<AuthState> => {
   const user = extractUser(session);
   return { user, isAuthenticated: user !== undefined };
 });
+
+export const authSessionUnwrappedAtom = unwrap(
+  authSessionAtom,
+  (prev): AuthState => prev ?? { user: undefined, isAuthenticated: false },
+);
 
 export const signOutAtom = atom(undefined, async (_get, set) => {
   await authSignOut().catch(() => undefined);


### PR DESCRIPTION
## Summary
- Prevent auth session resolution from suspending and remounting new doll/garment forms
- Delay rendering the user menu until after mount to avoid auth-driven hydration mismatch
- Keep form-created records using the resolved user id when available, with local fallback

## Verification
- pnpm exec tsc --noEmit -p tsconfig.app.json
- pnpm exec vitest run src/components/auth/UserMenu.test.tsx src/components/doll/DollForm.test.tsx src/components/garment/GarmentForm.test.tsx
- pnpm test:e2e e2e/dolls.spec.ts e2e/garments.spec.ts
- CI=1 pnpm test:e2e