### PR TITLE
refactor(auth): 認証ハードコード撤廃と protectedProcedure 全面適用

### DIFF
--- a/e2e/fixtures/factories.ts
+++ b/e2e/fixtures/factories.ts
@@ -5,12 +5,12 @@ import type {
   StorageLocation,
 } from "../../src/types/index";
 
-const TEMP_USER_ID = "temp-user-001";
+const E2E_TEST_USER_ID = "test-user-001";
 const FIXED_NOW = new Date("2025-06-15T00:00:00Z").getTime();
 
 export const createGarment = (overrides: Partial<Garment> = {}): Garment => ({
   id: "garment-1",
-  userId: TEMP_USER_ID,
+  userId: E2E_TEST_USER_ID,
   name: "テストドレス",
   category: "dress",
   dollSizes: ["SD"],
@@ -35,7 +35,7 @@ export const createGarment = (overrides: Partial<Garment> = {}): Garment => ({
 
 export const createDoll = (overrides: Partial<Doll> = {}): Doll => ({
   id: "doll-1",
-  userId: TEMP_USER_ID,
+  userId: E2E_TEST_USER_ID,
   name: "テストドール",
   headModel: undefined,
   bodySize: "SD",
@@ -53,7 +53,7 @@ export const createStorageCase = (
   overrides: Partial<StorageCase> = {},
 ): StorageCase => ({
   id: "case-1",
-  userId: TEMP_USER_ID,
+  userId: E2E_TEST_USER_ID,
   name: "衣装ケース A",
   type: "grid",
   description: undefined,
@@ -67,7 +67,7 @@ export const createStorageLocation = (
   overrides: Partial<StorageLocation> = {},
 ): StorageLocation => ({
   id: "loc-1",
-  userId: TEMP_USER_ID,
+  userId: E2E_TEST_USER_ID,
   caseId: "case-1",
   label: "A-1",
   customName: undefined,
@@ -81,4 +81,4 @@ export const createStorageLocation = (
   ...overrides,
 });
 
-export { TEMP_USER_ID, FIXED_NOW };
+export { E2E_TEST_USER_ID, FIXED_NOW };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "precheck:full": "pnpm typecheck && pnpm lint && pnpm format:check && pnpm i18n:check && pnpm test"
   },
   "dependencies": {
+    "@better-auth/api-key": "^1.6.9",
     "@hono/trpc-server": "^0.4.2",
     "@lingui/core": "^5.9.3",
     "@lingui/react": "^5.9.3",
@@ -42,12 +43,12 @@
     "@techstark/opencv-js": "4.12.0-release.1",
     "@trpc/client": "^11.1.0",
     "@trpc/server": "^11.1.0",
-    "better-auth": "^1.2.8",
+    "better-auth": "^1.6.9",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "dexie": "^4.0.11",
     "dexie-react-hooks": "^1.1.7",
-    "drizzle-orm": "^0.45.1",
+    "drizzle-orm": "^0.45.2",
     "drizzle-zod": "^0.8.3",
     "esbuild": "^0.27.4",
     "hono": "^4.7.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@better-auth/api-key':
+        specifier: ^1.6.9
+        version: 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(better-auth@1.6.9(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17))(mongodb@7.1.0)(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2)))
       '@hono/trpc-server':
         specifier: ^0.4.2
         version: 0.4.2(@trpc/server@11.12.0(typescript@5.9.3))(hono@4.12.7)
@@ -36,8 +39,8 @@ importers:
         specifier: ^11.1.0
         version: 11.12.0(typescript@5.9.3)
       better-auth:
-        specifier: ^1.2.8
-        version: 1.5.5(@cloudflare/workers-types@4.20260312.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11))(mongodb@7.1.0)(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2))
+        specifier: ^1.6.9
+        version: 1.6.9(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17))(mongodb@7.1.0)(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -51,11 +54,11 @@ importers:
         specifier: ^1.1.7
         version: 1.1.7(@types/react@19.2.14)(dexie@4.3.0)(react@19.2.4)
       drizzle-orm:
-        specifier: ^0.45.1
-        version: 0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11)
+        specifier: ^0.45.2
+        version: 0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17)
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11))(zod@4.3.6)
+        version: 0.8.3(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17))(zod@4.3.6)
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
@@ -107,7 +110,7 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.12.21
-        version: 0.12.21(@cloudflare/workers-types@4.20260312.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2))
+        version: 0.12.21(@cloudflare/workers-types@4.20260312.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2))
       '@cloudflare/workers-types':
         specifier: ^4.20250410.0
         version: 4.20260312.1
@@ -158,10 +161,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitest/coverage-istanbul':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2))
+        version: 3.2.4(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2))
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2))
+        version: 3.2.4(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2))
       babel-plugin-macros:
         specifier: ^3.1.0
         version: 3.1.0
@@ -224,7 +227,7 @@ importers:
         version: 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.1.2
-        version: 3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)
+        version: 3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2)
       wrangler:
         specifier: ^4.65.0
         version: 4.72.0(@cloudflare/workers-types@4.20260312.1)
@@ -620,6 +623,10 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -636,55 +643,71 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@better-auth/core@1.5.5':
-    resolution: {integrity: sha512-1oR/2jAp821Dcf67kQYHUoyNcdc1TcShfw4QMK0YTVntuRES5mUOyvEJql5T6eIuLfaqaN4LOF78l0FtF66HXA==}
+  '@better-auth/api-key@1.6.9':
+    resolution: {integrity: sha512-MPDNmvcCwDpix911kFYRn9XCebJjaCNuj16OA//difNCJoPRn2kD6KQ/3+B3rlSWl46x098SgN7Y3e8kU8nIwg==}
     peerDependencies:
-      '@better-auth/utils': 0.3.1
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
+      better-auth: ^1.6.9
+
+  '@better-auth/core@1.6.9':
+    resolution: {integrity: sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w==}
+    peerDependencies:
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@cloudflare/workers-types': '>=4'
-      better-call: 1.3.2
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.5
       jose: ^6.1.0
       kysely: ^0.28.5
       nanostores: ^1.0.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
+      '@opentelemetry/api':
+        optional: true
 
-  '@better-auth/drizzle-adapter@1.5.5':
-    resolution: {integrity: sha512-HAi9xAP40oDt48QZeYBFTcmg3vt1Jik90GwoRIfangd7VGbxesIIDBJSnvwMbZ52GBIc6+V4FRw9lasNiNrPfw==}
+  '@better-auth/drizzle-adapter@1.6.9':
+    resolution: {integrity: sha512-Lcco5hOGrMgc4XKAkvB6x72eQm4wCcya8IevMg4wBHY9W9GVg8pu23rpRX6VsVQSO4Ux13S7lFwUWtF7/r9aKw==}
     peerDependencies:
-      '@better-auth/core': 1.5.5
-      '@better-auth/utils': ^0.3.0
-      drizzle-orm: '>=0.41.0'
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
+      drizzle-orm: ^0.45.2
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
 
-  '@better-auth/kysely-adapter@1.5.5':
-    resolution: {integrity: sha512-LmHffIVnqbfsxcxckMOoE8MwibWrbVFch+kwPKJ5OFDFv6lin75ufN7ZZ7twH0IMPLT/FcgzaRjP8jRrXRef9g==}
+  '@better-auth/kysely-adapter@1.6.9':
+    resolution: {integrity: sha512-gyjuuxJtZ4o9G9z9q4kqn24X2kvMSp7F+KHogYxF03SnXY/2WleAcuj57iC4wP3e9mGDbjPOrnM5K6Kr3Ktdpw==}
     peerDependencies:
-      '@better-auth/core': 1.5.5
-      '@better-auth/utils': ^0.3.0
-      kysely: ^0.27.0 || ^0.28.0
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
+      kysely: ^0.28.14
+    peerDependenciesMeta:
+      kysely:
+        optional: true
 
-  '@better-auth/memory-adapter@1.5.5':
-    resolution: {integrity: sha512-4X0j1/2L+nsgmObjmy9xEGUFWUv38Qjthp558fwS3DAp6ueWWyCaxaD6VJZ7m5qPNMrsBStO5WGP8CmJTEWm7g==}
+  '@better-auth/memory-adapter@1.6.9':
+    resolution: {integrity: sha512-XmIG4tUnOXZ+KEcWjHUjOI9Z5donD09dC2t/AQTXifAUIqx7cySg86w0KTM09ArzAxRx1fCqO36Wkt5nULnrkQ==}
     peerDependencies:
-      '@better-auth/core': 1.5.5
-      '@better-auth/utils': ^0.3.0
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
 
-  '@better-auth/mongo-adapter@1.5.5':
-    resolution: {integrity: sha512-P1J9ljL5X5k740I8Rx1esPWNgWYPdJR5hf2CY7BwDSrQFPUHuzeCg0YhtEEP55niNateTXhBqGAcy0fVOeamZg==}
+  '@better-auth/mongo-adapter@1.6.9':
+    resolution: {integrity: sha512-h+AiRJ/TsBSi+ZDjySASBpbJ/9QCXBre34PSKgCz7QmTHrFM9Cg2EM4AM7LjR5lPXipEE+2rWPBc9wfnUBjhcw==}
     peerDependencies:
-      '@better-auth/core': 1.5.5
-      '@better-auth/utils': ^0.3.0
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
       mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
 
-  '@better-auth/prisma-adapter@1.5.5':
-    resolution: {integrity: sha512-CliDd78CXHzzwQIXhCdwGr5Ml53i6JdCHWV7PYwTIJz9EAm6qb2RVBdpP3nqEfNjINGM22A6gfleCgCdZkTIZg==}
+  '@better-auth/prisma-adapter@1.6.9':
+    resolution: {integrity: sha512-XHks01ntK20orqK/jICq8wmEbJ/zT6dct49Fk8zTQKN9QNGDc+Ix5+7z/Kvui0DXGFf790GfvRozquzaLtXa8Q==}
     peerDependencies:
-      '@better-auth/core': 1.5.5
-      '@better-auth/utils': ^0.3.0
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
@@ -693,13 +716,15 @@ packages:
       prisma:
         optional: true
 
-  '@better-auth/telemetry@1.5.5':
-    resolution: {integrity: sha512-1+lklxArn4IMHuU503RcPdXrSG2tlXt4jnGG3omolmspQ7tktg/Y9XO/yAkYDurtvMn1xJ8X1Ov01Ji/r5s9BQ==}
+  '@better-auth/telemetry@1.6.9':
+    resolution: {integrity: sha512-0u5zkhSCAQFoN3DHvUkLHOF6MBbVTDAa6mU8mhPwiysdz1x21vMzhzfaAKN/ZGWaQ09v91/F+2qu42G/bhUV4A==}
     peerDependencies:
-      '@better-auth/core': 1.5.5
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
 
-  '@better-auth/utils@0.3.1':
-    resolution: {integrity: sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==}
+  '@better-auth/utils@0.4.0':
+    resolution: {integrity: sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==}
 
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
@@ -1769,8 +1794,8 @@ packages:
   '@messageformat/parser@5.1.1':
     resolution: {integrity: sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==}
 
-  '@mongodb-js/saslprep@1.4.6':
-    resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
+  '@mongodb-js/saslprep@1.4.11':
+    resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
 
   '@mswjs/data@0.16.2':
     resolution: {integrity: sha512-/C0d/PBcJyQJokUhcjO4HiZPc67hzllKlRtD1XELygl2t991/ATAAQJVcStn4YtVALsNodruzOHT0JIvgr0hnA==}
@@ -3228,6 +3253,9 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -3518,8 +3546,8 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -3632,13 +3660,18 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.10.27:
+    resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   baseline-browser-mapping@2.10.7:
     resolution: {integrity: sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  better-auth@1.5.5:
-    resolution: {integrity: sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==}
+  better-auth@1.6.9:
+    resolution: {integrity: sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -3647,7 +3680,7 @@ packages:
       '@tanstack/solid-start': ^1.0.0
       better-sqlite3: ^12.0.0
       drizzle-kit: '>=0.31.4'
-      drizzle-orm: '>=0.41.0'
+      drizzle-orm: ^0.45.2
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -3699,8 +3732,8 @@ packages:
       vue:
         optional: true
 
-  better-call@1.3.2:
-    resolution: {integrity: sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==}
+  better-call@1.3.5:
+    resolution: {integrity: sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -3740,6 +3773,11 @@ packages:
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3787,6 +3825,9 @@ packages:
 
   caniuse-lite@1.0.30001778:
     resolution: {integrity: sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==}
+
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -4069,8 +4110,8 @@ packages:
     resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
     hasBin: true
 
-  drizzle-orm@0.45.1:
-    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -4187,6 +4228,9 @@ packages:
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
+  electron-to-chromium@1.5.349:
+    resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -4202,6 +4246,10 @@ packages:
 
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.21.0:
+    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -4229,8 +4277,8 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -4487,8 +4535,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.1:
+    resolution: {integrity: sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==}
 
   fast-xml-builder@1.1.2:
     resolution: {integrity: sha512-NJAmiuVaJEjVa7TjLZKlYd7RqmzOC91EtPFXHvlTcqBVo50Qh7XV5IwvXi1c7NRz2Q/majGX9YLcwJtWgHjtkA==}
@@ -5081,8 +5129,8 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
-  kysely@0.28.11:
-    resolution: {integrity: sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==}
+  kysely@0.28.17:
+    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
 
   language-subtag-registry@0.3.23:
@@ -5177,8 +5225,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  loader-runner@4.3.1:
-    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
   locate-path@5.0.0:
@@ -5437,6 +5485,9 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -6068,8 +6119,12 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  terser-webpack-plugin@5.4.0:
-    resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  terser-webpack-plugin@5.5.0:
+    resolution: {integrity: sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -6089,8 +6144,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  terser@5.46.0:
-    resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
+  terser@5.46.2:
+    resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -6245,6 +6300,9 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   undici@7.18.2:
     resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
     engines: {node: '>=20.18.1'}
@@ -6380,8 +6438,8 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  webpack-sources@3.3.4:
-    resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
+  webpack-sources@3.4.1:
+    resolution: {integrity: sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==}
     engines: {node: '>=10.13.0'}
 
   webpack@5.105.4:
@@ -7448,6 +7506,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -7473,55 +7533,68 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)':
+  '@better-auth/api-key@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(better-auth@1.6.9(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17))(mongodb@7.1.0)(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2)))':
     dependencies:
-      '@better-auth/utils': 0.3.1
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.0
+      better-auth: 1.6.9(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17))(mongodb@7.1.0)(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2))
+      zod: 4.3.6
+
+  '@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1)':
+    dependencies:
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
+      '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.6)
+      better-call: 1.3.5(zod@4.3.6)
       jose: 6.2.1
-      kysely: 0.28.11
+      kysely: 0.28.17
       nanostores: 1.1.1
       zod: 4.3.6
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260312.1
+      '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11))':
+  '@better-auth/drizzle-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17))':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/utils': 0.3.1
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.0
     optionalDependencies:
-      drizzle-orm: 0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17)
 
-  '@better-auth/kysely-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)':
+  '@better-auth/kysely-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/utils': 0.3.1
-      kysely: 0.28.11
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.0
+    optionalDependencies:
+      kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
+  '@better-auth/memory-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/utils': 0.3.1
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.0
 
-  '@better-auth/mongo-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)':
+  '@better-auth/mongo-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(mongodb@7.1.0)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/utils': 0.3.1
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.0
+    optionalDependencies:
       mongodb: 7.1.0
 
-  '@better-auth/prisma-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
+  '@better-auth/prisma-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/utils': 0.3.1
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.0
 
-  '@better-auth/telemetry@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))':
+  '@better-auth/telemetry@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/utils': 0.3.1
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
-  '@better-auth/utils@0.3.1': {}
+  '@better-auth/utils@0.4.0':
+    dependencies:
+      '@noble/hashes': 2.0.1
 
   '@better-fetch/fetch@1.1.21': {}
 
@@ -7533,14 +7606,14 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260310.1
 
-  '@cloudflare/vitest-pool-workers@0.12.21(@cloudflare/workers-types@4.20260312.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2))':
+  '@cloudflare/vitest-pool-workers@0.12.21(@cloudflare/workers-types@4.20260312.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2))':
     dependencies:
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.3
       miniflare: 4.20260310.0
-      vitest: 3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2)
       wrangler: 4.72.0(@cloudflare/workers-types@4.20260312.1)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -8265,9 +8338,10 @@ snapshots:
     dependencies:
       moo: 0.5.3
 
-  '@mongodb-js/saslprep@1.4.6':
+  '@mongodb-js/saslprep@1.4.11':
     dependencies:
       sparse-bitfield: 3.0.3
+    optional: true
 
   '@mswjs/data@0.16.2(@types/node@25.5.0)(typescript@5.9.3)':
     dependencies:
@@ -9635,7 +9709,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -9737,6 +9811,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/parse-json@4.0.2': {}
 
   '@types/pg-pool@2.0.7':
@@ -9773,11 +9851,13 @@ snapshots:
 
   '@types/uuid@8.3.4': {}
 
-  '@types/webidl-conversions@7.0.3': {}
+  '@types/webidl-conversions@7.0.3':
+    optional: true
 
   '@types/whatwg-url@13.0.0':
     dependencies:
       '@types/webidl-conversions': 7.0.3
+    optional: true
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -9927,7 +10007,7 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2))':
+  '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2))':
     dependencies:
       '@istanbuljs/schema': 0.1.6
       debug: 4.4.3
@@ -9939,11 +10019,11 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -9958,7 +10038,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -9970,14 +10050,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.2)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@25.5.0)(typescript@5.9.3)
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.2)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10118,13 +10198,13 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ajv-formats@2.1.1(ajv@8.18.0):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
-  ajv-keywords@5.1.0(ajv@8.18.0):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
 
   ajv@6.14.0:
@@ -10134,10 +10214,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.18.0:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10256,41 +10336,44 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.27: {}
+
   baseline-browser-mapping@2.10.7: {}
 
-  better-auth@1.5.5(@cloudflare/workers-types@4.20260312.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11))(mongodb@7.1.0)(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)):
+  better-auth@1.6.9(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17))(mongodb@7.1.0)(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2)):
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11))
-      '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
-      '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/telemetry': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))
-      '@better-auth/utils': 0.3.1
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17))
+      '@better-auth/kysely-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(mongodb@7.1.0)
+      '@better-auth/prisma-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.6)
+      better-call: 1.3.5(zod@4.3.6)
       defu: 6.1.4
       jose: 6.2.1
-      kysely: 0.28.11
+      kysely: 0.28.17
       nanostores: 1.1.1
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17)
       mongodb: 7.1.0
       next: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
 
-  better-call@1.3.2(zod@4.3.6):
+  better-call@1.3.5(zod@4.3.6):
     dependencies:
-      '@better-auth/utils': 0.3.1
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
       set-cookie-parser: 3.0.1
@@ -10348,7 +10431,16 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  bson@7.2.0: {}
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.27
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.349
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bson@7.2.0:
+    optional: true
 
   buffer-from@1.1.2: {}
 
@@ -10385,6 +10477,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001778: {}
+
+  caniuse-lite@1.0.30001791: {}
 
   chai@5.3.3:
     dependencies:
@@ -10640,16 +10734,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260312.1
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.15.6
-      kysely: 0.28.11
+      kysely: 0.28.17
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11))(zod@4.3.6):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17))(zod@4.3.6):
     dependencies:
-      drizzle-orm: 0.45.1(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260312.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17)
       zod: 4.3.6
 
   dunder-proto@1.0.1:
@@ -10673,6 +10767,8 @@ snapshots:
 
   electron-to-chromium@1.5.313: {}
 
+  electron-to-chromium@1.5.349: {}
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -10685,6 +10781,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  enhanced-resolve@5.21.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   enquirer@2.4.1:
     dependencies:
@@ -10760,7 +10861,7 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
-  es-module-lexer@2.0.0: {}
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -11199,7 +11300,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.1: {}
 
   fast-xml-builder@1.1.2:
     dependencies:
@@ -11706,7 +11807,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -11778,7 +11879,7 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  kysely@0.28.11: {}
+  kysely@0.28.17: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -11844,7 +11945,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  loader-runner@4.3.1: {}
+  loader-runner@4.3.2: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -11905,7 +12006,8 @@ snapshots:
 
   media-typer@1.1.0: {}
 
-  memory-pager@1.5.0: {}
+  memory-pager@1.5.0:
+    optional: true
 
   merge-descriptors@2.0.0: {}
 
@@ -11990,12 +12092,14 @@ snapshots:
     dependencies:
       '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
+    optional: true
 
   mongodb@7.1.0:
     dependencies:
-      '@mongodb-js/saslprep': 1.4.6
+      '@mongodb-js/saslprep': 1.4.11
       bson: 7.2.0
       mongodb-connection-string-url: 7.0.1
+    optional: true
 
   moo@0.5.3: {}
 
@@ -12071,6 +12175,8 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-releases@2.0.36: {}
+
+  node-releases@2.0.38: {}
 
   normalize-path@3.0.0: {}
 
@@ -12520,9 +12626,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.18.0
-      ajv-formats: 2.1.1(ajv@8.18.0)
-      ajv-keywords: 5.1.0(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   semver@6.3.1: {}
 
@@ -12688,6 +12794,7 @@ snapshots:
   sparse-bitfield@3.0.3:
     dependencies:
       memory-pager: 1.5.0
+    optional: true
 
   stackback@0.0.2: {}
 
@@ -12807,12 +12914,14 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  terser-webpack-plugin@5.4.0(esbuild@0.27.4)(webpack@5.105.4(esbuild@0.27.4)):
+  tapable@2.3.3: {}
+
+  terser-webpack-plugin@5.5.0(esbuild@0.27.4)(webpack@5.105.4(esbuild@0.27.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.46.0
+      terser: 5.46.2
       webpack: 5.105.4(esbuild@0.27.4)
     optionalDependencies:
       esbuild: 0.27.4
@@ -12824,7 +12933,7 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  terser@5.46.0:
+  terser@5.46.2:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.16.0
@@ -12895,6 +13004,7 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+    optional: true
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -12997,6 +13107,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici-types@7.19.2: {}
+
   undici@7.18.2: {}
 
   unenv@2.0.0-rc.24:
@@ -13010,6 +13122,12 @@ snapshots:
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -13027,13 +13145,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.2)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13048,7 +13166,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.2)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13061,14 +13179,14 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.31.1
-      terser: 5.46.0
+      terser: 5.46.2
       yaml: 2.8.2
 
-  vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2):
+  vitest@3.2.4(@types/node@25.5.0)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.2)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13086,8 +13204,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.2)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.2)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
@@ -13123,7 +13241,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-sources@3.3.4: {}
+  webpack-sources@3.4.1: {}
 
   webpack@5.105.4(esbuild@0.27.4):
     dependencies:
@@ -13135,23 +13253,23 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.0
-      es-module-lexer: 2.0.0
+      enhanced-resolve: 5.21.0
+      es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
+      loader-runner: 4.3.2
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(esbuild@0.27.4)(webpack@5.105.4(esbuild@0.27.4))
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.5.0(esbuild@0.27.4)(webpack@5.105.4(esbuild@0.27.4))
       watchpack: 2.5.1
-      webpack-sources: 3.3.4
+      webpack-sources: 3.4.1
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -13163,6 +13281,7 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+    optional: true
 
   whatwg-url@5.0.0:
     dependencies:

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -13,6 +13,7 @@ import {
   deleteStorageCaseAtom,
 } from "@/stores/locationAtoms";
 import { garmentsAtom } from "@/stores/garmentAtoms";
+import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
 import type { StorageCase, StorageCaseType } from "@/types";
 import { STORAGE_CASE_TYPE } from "@/lib/constants";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
@@ -25,12 +26,11 @@ import EmptyState from "@/components/ui/EmptyState";
 import FAB from "@/components/ui/FAB";
 import Skeleton from "@/components/ui/Skeleton";
 
-const TEMP_USER_ID = "user-1";
-
 const LocationsContent = () => {
   const cases = useAtomValue(storageCasesAtom);
   const locations = useAtomValue(storageLocationsAtom);
   const garments = useAtomValue(garmentsAtom);
+  const session = useAtomValue(authSessionUnwrappedAtom);
   const addCase = useSetAtom(addStorageCaseWithLocationsAtom);
   const updateCase = useSetAtom(updateStorageCaseAtom);
   const deleteCase = useSetAtom(deleteStorageCaseAtom);
@@ -65,7 +65,8 @@ const LocationsContent = () => {
           readonly description: string | undefined;
         },
   ) => {
-    await addCase({ ...input, userId: TEMP_USER_ID });
+    const userId = session.user?.id ?? "local";
+    await addCase({ ...input, userId });
     setIsCreateOpen(false);
   };
 

--- a/workers/migrations/0012_api_key.sql
+++ b/workers/migrations/0012_api_key.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "apikey" (
+  id TEXT PRIMARY KEY,
+  configId TEXT NOT NULL DEFAULT 'default',
+  name TEXT,
+  start TEXT,
+  referenceId TEXT NOT NULL,
+  prefix TEXT,
+  key TEXT NOT NULL,
+  refillInterval INTEGER,
+  refillAmount INTEGER,
+  lastRefillAt INTEGER,
+  enabled INTEGER DEFAULT 1,
+  rateLimitEnabled INTEGER DEFAULT 1,
+  rateLimitTimeWindow INTEGER,
+  rateLimitMax INTEGER,
+  requestCount INTEGER DEFAULT 0,
+  remaining INTEGER,
+  lastRequest INTEGER,
+  expiresAt INTEGER,
+  createdAt INTEGER NOT NULL,
+  updatedAt INTEGER NOT NULL,
+  permissions TEXT,
+  metadata TEXT
+);
+
+CREATE INDEX idx_apikey_configId ON "apikey"(configId);
+CREATE INDEX idx_apikey_referenceId ON "apikey"(referenceId);
+CREATE INDEX idx_apikey_key ON "apikey"(key);

--- a/workers/src/auth.ts
+++ b/workers/src/auth.ts
@@ -1,4 +1,5 @@
 import { betterAuth } from "better-auth";
+import { apiKey } from "@better-auth/api-key";
 import type { Env } from "./types";
 
 export const createAuth = ({ env }: { readonly env: Env }) =>
@@ -17,6 +18,7 @@ export const createAuth = ({ env }: { readonly env: Env }) =>
         clientSecret: env.GOOGLE_CLIENT_SECRET,
       },
     },
+    plugins: [apiKey()],
     trustedOrigins: env.TRUSTED_ORIGINS.split(","),
   });
 

--- a/workers/src/lib/auth-resolver.ts
+++ b/workers/src/lib/auth-resolver.ts
@@ -39,13 +39,19 @@ export const resolveAuthenticatedUserId = async ({
   readonly auth: Auth;
   readonly headers: Headers;
 }): Promise<string | undefined> => {
+  const bearer = extractBearerKey(headers);
+  const hasCookie = headers.get("cookie") !== null;
+
+  if (bearer !== undefined && !hasCookie) {
+    return await verifyBearer({ auth, key: bearer });
+  }
+
   const session = await auth.api.getSession({ headers }).catch(() => undefined);
   const sessionUserId = session?.user.id;
   if (sessionUserId !== undefined && sessionUserId !== "") {
     return sessionUserId;
   }
 
-  const bearer = extractBearerKey(headers);
   if (bearer === undefined) {
     return undefined;
   }

--- a/workers/src/lib/auth-resolver.ts
+++ b/workers/src/lib/auth-resolver.ts
@@ -1,0 +1,53 @@
+import type { Auth } from "../auth";
+
+const BEARER_PREFIX = "bearer ";
+
+const extractBearerKey = (headers: Headers): string | undefined => {
+  const raw = headers.get("authorization");
+  if (raw == null) {
+    return undefined;
+  }
+  const lower = raw.toLowerCase();
+  if (!lower.startsWith(BEARER_PREFIX)) {
+    return undefined;
+  }
+  const key = raw.slice(BEARER_PREFIX.length).trim();
+  return key !== "" ? key : undefined;
+};
+
+const verifyBearer = async ({
+  auth,
+  key,
+}: {
+  readonly auth: Auth;
+  readonly key: string;
+}): Promise<string | undefined> => {
+  const result = await auth.api
+    .verifyApiKey({ body: { key } })
+    .catch(() => undefined);
+  if (result?.valid !== true) {
+    return undefined;
+  }
+  const userId = result.key?.referenceId;
+  return userId !== undefined && userId !== "" ? userId : undefined;
+};
+
+export const resolveAuthenticatedUserId = async ({
+  auth,
+  headers,
+}: {
+  readonly auth: Auth;
+  readonly headers: Headers;
+}): Promise<string | undefined> => {
+  const session = await auth.api.getSession({ headers }).catch(() => undefined);
+  const sessionUserId = session?.user.id;
+  if (sessionUserId !== undefined && sessionUserId !== "") {
+    return sessionUserId;
+  }
+
+  const bearer = extractBearerKey(headers);
+  if (bearer === undefined) {
+    return undefined;
+  }
+  return await verifyBearer({ auth, key: bearer });
+};

--- a/workers/src/repositories/location-repository.ts
+++ b/workers/src/repositories/location-repository.ts
@@ -105,11 +105,13 @@ export const findLocationsByCaseId = async ({
 export const findLocationByPosition = async ({
   drizzleDb,
   caseId,
+  userId,
   row,
   col,
 }: {
   readonly drizzleDb: DrizzleDB;
   readonly caseId: string;
+  readonly userId: string;
   readonly row: number;
   readonly col: number;
 }): Promise<StorageLocation | undefined> => {
@@ -119,6 +121,7 @@ export const findLocationByPosition = async ({
     .where(
       and(
         eq(storageLocations.caseId, caseId),
+        eq(storageLocations.userId, userId),
         eq(storageLocations.row, row),
         eq(storageLocations.col, col),
       ),

--- a/workers/src/routes/image.scenario.test.ts
+++ b/workers/src/routes/image.scenario.test.ts
@@ -5,7 +5,11 @@ import { z } from "zod";
 import type { Env } from "../types";
 import type { Auth } from "../auth";
 import type { Logger } from "../lib/logger";
-import { createTestLogger, TEST_USER_ID } from "../test/helpers";
+import {
+  createStubAuth,
+  createTestLogger,
+  TEST_USER_ID,
+} from "../test/helpers";
 import { imageRoutes } from "./image";
 import { createId } from "@paralleldrive/cuid2";
 
@@ -14,21 +18,6 @@ type Variables = {
   requestId: string;
   logger: Logger;
 };
-
-const createStubAuth = (userId: string | undefined): Auth =>
-  ({
-    api: {
-      getSession: async (_args: { headers: Headers }) =>
-        await Promise.resolve(
-          userId === undefined
-            ? null
-            : {
-                user: { id: userId },
-                session: { id: "stub-session", userId },
-              },
-        ),
-    },
-  }) as unknown as Auth;
 
 const errorSchema = z.object({ error: z.string() });
 const imageUrlSchema = z.object({ imageUrl: z.string() });

--- a/workers/src/routes/image.scenario.test.ts
+++ b/workers/src/routes/image.scenario.test.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import type { Env } from "../types";
 import type { Auth } from "../auth";
 import type { Logger } from "../lib/logger";
-import { createTestLogger } from "../test/helpers";
+import { createTestLogger, TEST_USER_ID } from "../test/helpers";
 import { imageRoutes } from "./image";
 import { createId } from "@paralleldrive/cuid2";
 
@@ -14,6 +14,21 @@ type Variables = {
   requestId: string;
   logger: Logger;
 };
+
+const createStubAuth = (userId: string | undefined): Auth =>
+  ({
+    api: {
+      getSession: async (_args: { headers: Headers }) =>
+        await Promise.resolve(
+          userId === undefined
+            ? null
+            : {
+                user: { id: userId },
+                session: { id: "stub-session", userId },
+              },
+        ),
+    },
+  }) as unknown as Auth;
 
 const errorSchema = z.object({ error: z.string() });
 const imageUrlSchema = z.object({ imageUrl: z.string() });
@@ -28,10 +43,13 @@ const parseImageUrl = async (res: Response): Promise<string> => {
   return imageUrlSchema.parse(data).imageUrl;
 };
 
-const buildApp = () => {
+const buildApp = ({
+  authenticated = true,
+}: { readonly authenticated?: boolean } = {}) => {
   const app = new Hono<{ Bindings: Env; Variables: Variables }>();
   app.use("*", async (c, next) => {
     c.set("logger", createTestLogger());
+    c.set("auth", createStubAuth(authenticated ? TEST_USER_ID : undefined));
     await next();
   });
   app.route("/api/images", imageRoutes);
@@ -62,6 +80,20 @@ describe("imageRoutes /upload/:garmentId", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("認証なしの場合 401 を返す", async () => {
+    const app = buildApp({ authenticated: false });
+    const garmentId = createId();
+    const file = new File([new Uint8Array([10, 20, 30])], "x.png", {
+      type: "image/png",
+    });
+    const req = buildMultipartRequest({ garmentId, file });
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(401);
+    const message = await parseError(res);
+    expect(message).toBe("Unauthorized");
   });
 
   it("garmentId が空文字の場合 (ルート不一致) 404 を返す", async () => {
@@ -150,13 +182,13 @@ describe("imageRoutes /upload/:garmentId", () => {
     expect(res.status).toBe(200);
     const url = await parseImageUrl(res);
     expect(url).toBe(
-      `${env.R2_PUBLIC_URL}/garments/temp-user-001/${garmentId}/1700000000000.png`,
+      `${env.R2_PUBLIC_URL}/garments/test-user-001/${garmentId}/1700000000000.png`,
     );
     expect(putSpy).toHaveBeenCalledTimes(1);
     const firstCall = putSpy.mock.calls[0];
     expect(firstCall).toBeDefined();
     expect(firstCall?.[0]).toBe(
-      `garments/temp-user-001/${garmentId}/1700000000000.png`,
+      `garments/test-user-001/${garmentId}/1700000000000.png`,
     );
     expect(firstCall?.[2]).toEqual({
       httpMetadata: { contentType: "image/png" },

--- a/workers/src/routes/image.ts
+++ b/workers/src/routes/image.ts
@@ -3,7 +3,7 @@ import type { Env } from "../types";
 import type { Logger } from "../lib/logger";
 import type { Auth } from "../auth";
 import * as imageService from "../services/image-service";
-import { TEMP_USER_ID } from "../trpc/lib/d1-helpers";
+import { resolveAuthenticatedUserId } from "../lib/auth-resolver";
 import { cuidSchema } from "../db/validation";
 
 type Variables = {
@@ -16,6 +16,15 @@ const imageRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 imageRoutes.post("/upload/:garmentId", async (c) => {
   const logger = c.get("logger").child({ route: "image/upload" });
+
+  const userId = await resolveAuthenticatedUserId({
+    auth: c.get("auth"),
+    headers: c.req.raw.headers,
+  });
+  if (userId === undefined) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
   const garmentId = c.req.param("garmentId");
 
   const parseResult = cuidSchema.safeParse(garmentId);
@@ -45,7 +54,7 @@ imageRoutes.post("/upload/:garmentId", async (c) => {
   }
 
   const key = imageService.buildR2Key({
-    userId: TEMP_USER_ID,
+    userId,
     garmentId,
     mimeType: validation.data.validMimeType,
   });

--- a/workers/src/services/location-service.ts
+++ b/workers/src/services/location-service.ts
@@ -165,6 +165,7 @@ export const createLocation = async ({
   const duplicate = await locationRepo.findLocationByPosition({
     drizzleDb,
     caseId: input.caseId,
+    userId,
     row: input.row,
     col: input.col,
   });

--- a/workers/src/test/helpers.ts
+++ b/workers/src/test/helpers.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import { createCallerFactory } from "../trpc/index";
 import { appRouter } from "../trpc/router";
 import type { TRPCContext } from "../trpc/index";
+import type { Auth } from "../auth";
 import type {
   CreateGarmentInput,
   CreateCoordinateInput,
@@ -12,15 +13,43 @@ import type { Logger } from "../lib/logger";
 
 const createCaller = createCallerFactory(appRouter);
 
+export const TEST_USER_ID = "test-user-001";
+
 export const getTestDb = () => env.DB;
 
 export const createTestLogger = (): Logger =>
   createLogger({ minLevel: "error" });
 
-export const createTestCaller = (logger: Logger = createTestLogger()) => {
+const createStubAuth = (userId: string): Auth => {
+  const stub = {
+    api: {
+      getSession: async (_args: { headers: Headers }) =>
+        await Promise.resolve({
+          user: { id: userId },
+          session: { id: "stub-session", userId },
+        }),
+    },
+  };
+  return stub as unknown as Auth;
+};
+
+const createStubHonoContext = () => {
+  const headers = new Headers();
+  return { req: { raw: { headers } } } as unknown as TRPCContext["honoContext"];
+};
+
+export const createTestCaller = ({
+  userId = TEST_USER_ID,
+  logger = createTestLogger(),
+}: {
+  readonly userId?: string;
+  readonly logger?: Logger;
+} = {}) => {
   const mockCtx: TRPCContext = {
     env,
     logger,
+    auth: createStubAuth(userId),
+    honoContext: createStubHonoContext(),
   };
   return createCaller(mockCtx);
 };

--- a/workers/src/test/helpers.ts
+++ b/workers/src/test/helpers.ts
@@ -20,14 +20,18 @@ export const getTestDb = () => env.DB;
 export const createTestLogger = (): Logger =>
   createLogger({ minLevel: "error" });
 
-const createStubAuth = (userId: string): Auth => {
+export const createStubAuth = (userId: string | undefined): Auth => {
   const stub = {
     api: {
       getSession: async (_args: { headers: Headers }) =>
-        await Promise.resolve({
-          user: { id: userId },
-          session: { id: "stub-session", userId },
-        }),
+        await Promise.resolve(
+          userId === undefined
+            ? null
+            : {
+                user: { id: userId },
+                session: { id: "stub-session", userId },
+              },
+        ),
     },
   };
   return stub as unknown as Auth;

--- a/workers/src/test/sync-confidence-override.scenario.test.ts
+++ b/workers/src/test/sync-confidence-override.scenario.test.ts
@@ -1,6 +1,10 @@
 import { createId } from "@paralleldrive/cuid2";
-import { TEMP_USER_ID } from "../trpc/lib/d1-helpers";
-import { createTestCaller, resetDatabase, getTestDb } from "./helpers";
+import {
+  createTestCaller,
+  resetDatabase,
+  getTestDb,
+  TEST_USER_ID,
+} from "./helpers";
 
 describe("sync で confidenceDecayDaysOverride を伝搬", () => {
   const caller = createTestCaller();
@@ -14,7 +18,7 @@ describe("sync で confidenceDecayDaysOverride を伝搬", () => {
     const id = createId();
     const basePayload = {
       id,
-      userId: TEMP_USER_ID,
+      userId: TEST_USER_ID,
       name: "テスト服",
       category: "dress",
       dollSizes: ["MSD"],

--- a/workers/src/test/sync-workflow.scenario.test.ts
+++ b/workers/src/test/sync-workflow.scenario.test.ts
@@ -1,10 +1,10 @@
 import { createId } from "@paralleldrive/cuid2";
-import { TEMP_USER_ID } from "../trpc/lib/d1-helpers";
 import {
   createTestCaller,
   resetDatabase,
   getTestDb,
   expectTRPCError,
+  TEST_USER_ID,
 } from "./helpers";
 import { insertGarment } from "../../test/helpers/factories";
 
@@ -12,7 +12,7 @@ const createGarmentPayload = (overrides: Record<string, unknown> = {}) => {
   const now = Date.now();
   return {
     id: createId(),
-    userId: TEMP_USER_ID,
+    userId: TEST_USER_ID,
     name: "テスト服",
     category: "dress",
     dollSizes: ["MSD"],
@@ -31,7 +31,7 @@ const createCasePayload = (overrides: Record<string, unknown> = {}) => {
   const now = Date.now();
   return {
     id: createId(),
-    userId: TEMP_USER_ID,
+    userId: TEST_USER_ID,
     name: "テストケース",
     rows: 3,
     cols: 2,
@@ -44,7 +44,7 @@ const createDollPayload = (overrides: Record<string, unknown> = {}) => {
   const now = Date.now();
   return {
     id: createId(),
-    userId: TEMP_USER_ID,
+    userId: TEST_USER_ID,
     name: "テストドール",
     bodySize: "MSD",
     createdAt: now,
@@ -58,7 +58,7 @@ const createLocationPayload = (
   overrides: Record<string, unknown> = {},
 ) => ({
   id: createId(),
-  userId: TEMP_USER_ID,
+  userId: TEST_USER_ID,
   caseId,
   label: "A-1",
   row: 0,

--- a/workers/src/trpc/index.ts
+++ b/workers/src/trpc/index.ts
@@ -53,7 +53,6 @@ const authMiddleware = t.middleware(async ({ ctx, next }) => {
 
 export const { router } = t;
 export const createCallerFactory = t.createCallerFactory;
-export const publicProcedure = t.procedure.use(loggingMiddleware);
 export const protectedProcedure = t.procedure
   .use(loggingMiddleware)
   .use(authMiddleware);

--- a/workers/src/trpc/index.ts
+++ b/workers/src/trpc/index.ts
@@ -3,6 +3,7 @@ import type { Context as HonoContext } from "hono";
 import type { Env } from "../types";
 import type { Auth } from "../auth";
 import type { Logger } from "../lib/logger";
+import { resolveAuthenticatedUserId } from "../lib/auth-resolver";
 
 export type TRPCContext = {
   readonly env: Env;
@@ -36,18 +37,17 @@ const authMiddleware = t.middleware(async ({ ctx, next }) => {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
 
-  const session = await ctx.auth.api
-    .getSession({
-      headers: ctx.honoContext.req.raw.headers,
-    })
-    .catch(() => undefined);
+  const userId = await resolveAuthenticatedUserId({
+    auth: ctx.auth,
+    headers: ctx.honoContext.req.raw.headers,
+  });
 
-  if (session == null) {
+  if (userId === undefined) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
 
   return await next({
-    ctx: { ...ctx, userId: session.user.id },
+    ctx: { ...ctx, userId },
   });
 });
 

--- a/workers/src/trpc/lib/d1-helpers.ts
+++ b/workers/src/trpc/lib/d1-helpers.ts
@@ -1,8 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import type { Logger } from "../../lib/logger";
 
-export const TEMP_USER_ID = "temp-user-001";
-
 export const wrapDbError =
   ({
     context,

--- a/workers/src/trpc/routers/coordinate.ts
+++ b/workers/src/trpc/routers/coordinate.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { createDrizzle } from "../../db/client";
-import { router, publicProcedure } from "../index";
+import { router, protectedProcedure } from "../index";
 import {
   listCoordinatesInputSchema,
   createCoordinateInputSchema,
@@ -9,69 +9,68 @@ import {
 } from "../lib/schemas";
 import * as coordinateService from "../../services/coordinate-service";
 import { throwIfError } from "../../services/types";
-import { TEMP_USER_ID } from "../lib/d1-helpers";
 
 export const coordinateRouter = router({
-  list: publicProcedure
+  list: protectedProcedure
     .input(listCoordinatesInputSchema)
     .query(async ({ ctx, input }) =>
       throwIfError(
         await coordinateService.listCoordinates({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           filters: input,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  get: publicProcedure
+  get: protectedProcedure
     .input(z.object({ id: cuidSchema }))
     .query(async ({ ctx, input }) =>
       throwIfError(
         await coordinateService.getCoordinate({
           drizzleDb: createDrizzle(ctx.env.DB),
           id: input.id,
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  create: publicProcedure
+  create: protectedProcedure
     .input(createCoordinateInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await coordinateService.createCoordinate({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           input,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  update: publicProcedure
+  update: protectedProcedure
     .input(updateCoordinateInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await coordinateService.updateCoordinate({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           input,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  delete: publicProcedure
+  delete: protectedProcedure
     .input(z.object({ id: cuidSchema }))
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await coordinateService.deleteCoordinate({
           drizzleDb: createDrizzle(ctx.env.DB),
           id: input.id,
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           logger: ctx.logger,
         }),
       ),

--- a/workers/src/trpc/routers/digest.ts
+++ b/workers/src/trpc/routers/digest.ts
@@ -1,65 +1,64 @@
 import { createDrizzle } from "../../db/client";
-import { router, publicProcedure } from "../index";
+import { router, protectedProcedure } from "../index";
 import {
   listDigestsInputSchema,
   markDigestReadInputSchema,
 } from "../lib/schemas";
-import { TEMP_USER_ID } from "../lib/d1-helpers";
 import * as digestService from "../../services/digest-service";
 import { throwIfError } from "../../services/types";
 
 export const digestRouter = router({
-  latest: publicProcedure.query(async ({ ctx }) =>
+  latest: protectedProcedure.query(async ({ ctx }) =>
     throwIfError(
       await digestService.getLatestDigest({
         drizzleDb: createDrizzle(ctx.env.DB),
-        userId: TEMP_USER_ID,
+        userId: ctx.userId,
         logger: ctx.logger,
       }),
     ),
   ),
 
-  list: publicProcedure
+  list: protectedProcedure
     .input(listDigestsInputSchema)
     .query(async ({ ctx, input }) =>
       throwIfError(
         await digestService.listDigests({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           limit: input.limit,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  markRead: publicProcedure
+  markRead: protectedProcedure
     .input(markDigestReadInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await digestService.markAsRead({
           drizzleDb: createDrizzle(ctx.env.DB),
           id: input.id,
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  hasUnread: publicProcedure.query(async ({ ctx }) =>
+  hasUnread: protectedProcedure.query(async ({ ctx }) =>
     throwIfError(
       await digestService.checkUnreadDigest({
         drizzleDb: createDrizzle(ctx.env.DB),
-        userId: TEMP_USER_ID,
+        userId: ctx.userId,
         logger: ctx.logger,
       }),
     ),
   ),
 
-  generate: publicProcedure.mutation(async ({ ctx }) =>
+  generate: protectedProcedure.mutation(async ({ ctx }) =>
     throwIfError(
       await digestService.generateDigestForUser({
         drizzleDb: createDrizzle(ctx.env.DB),
-        userId: TEMP_USER_ID,
+        userId: ctx.userId,
         logger: ctx.logger,
       }),
     ),

--- a/workers/src/trpc/routers/doll.ts
+++ b/workers/src/trpc/routers/doll.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { createDrizzle } from "../../db/client";
-import { router, publicProcedure } from "../index";
+import { router, protectedProcedure } from "../index";
 import {
   listDollsInputSchema,
   createDollInputSchema,
@@ -9,69 +9,68 @@ import {
 } from "../lib/schemas";
 import * as dollService from "../../services/doll-service";
 import { throwIfError } from "../../services/types";
-import { TEMP_USER_ID } from "../lib/d1-helpers";
 
 export const dollRouter = router({
-  list: publicProcedure
+  list: protectedProcedure
     .input(listDollsInputSchema)
     .query(async ({ ctx, input }) =>
       throwIfError(
         await dollService.listDolls({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           filters: input,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  get: publicProcedure
+  get: protectedProcedure
     .input(z.object({ id: cuidSchema }))
     .query(async ({ ctx, input }) =>
       throwIfError(
         await dollService.getDoll({
           drizzleDb: createDrizzle(ctx.env.DB),
           id: input.id,
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  create: publicProcedure
+  create: protectedProcedure
     .input(createDollInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await dollService.createDoll({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           input,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  update: publicProcedure
+  update: protectedProcedure
     .input(updateDollInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await dollService.updateDoll({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           input,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  delete: publicProcedure
+  delete: protectedProcedure
     .input(z.object({ id: cuidSchema }))
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await dollService.deleteDoll({
           drizzleDb: createDrizzle(ctx.env.DB),
           id: input.id,
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           bucket: ctx.env.BUCKET,
           r2PublicUrl: ctx.env.R2_PUBLIC_URL,
           logger: ctx.logger,

--- a/workers/src/trpc/routers/garment.ts
+++ b/workers/src/trpc/routers/garment.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { createDrizzle } from "../../db/client";
-import { router, publicProcedure } from "../index";
+import { router, protectedProcedure } from "../index";
 import {
   listGarmentsInputSchema,
   createGarmentInputSchema,
@@ -10,82 +10,81 @@ import {
 } from "../lib/schemas";
 import * as garmentService from "../../services/garment-service";
 import { throwIfError } from "../../services/types";
-import { TEMP_USER_ID } from "../lib/d1-helpers";
 
 export const garmentRouter = router({
-  list: publicProcedure
+  list: protectedProcedure
     .input(listGarmentsInputSchema)
     .query(async ({ ctx, input }) =>
       throwIfError(
         await garmentService.listGarments({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           filters: input,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  get: publicProcedure
+  get: protectedProcedure
     .input(z.object({ id: cuidSchema }))
     .query(async ({ ctx, input }) =>
       throwIfError(
         await garmentService.getGarment({
           drizzleDb: createDrizzle(ctx.env.DB),
           id: input.id,
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  create: publicProcedure
+  create: protectedProcedure
     .input(createGarmentInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await garmentService.createGarment({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           input,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  bulkCreate: publicProcedure
+  bulkCreate: protectedProcedure
     .input(bulkCreateGarmentInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await garmentService.bulkCreateGarments({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           items: input.items,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  update: publicProcedure
+  update: protectedProcedure
     .input(updateGarmentInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await garmentService.updateGarment({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           input,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  delete: publicProcedure
+  delete: protectedProcedure
     .input(z.object({ id: cuidSchema }))
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await garmentService.deleteGarment({
           drizzleDb: createDrizzle(ctx.env.DB),
           id: input.id,
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           bucket: ctx.env.BUCKET,
           r2PublicUrl: ctx.env.R2_PUBLIC_URL,
           logger: ctx.logger,

--- a/workers/src/trpc/routers/location.ts
+++ b/workers/src/trpc/routers/location.ts
@@ -1,8 +1,7 @@
 import { createDrizzle } from "../../db/client";
 import * as locationService from "../../services/location-service";
 import { throwIfError } from "../../services/types";
-import { router, publicProcedure } from "../index";
-import { TEMP_USER_ID } from "../lib/d1-helpers";
+import { router, protectedProcedure } from "../index";
 import {
   cuidSchema,
   createCaseInputSchema,
@@ -12,93 +11,95 @@ import {
 } from "../lib/schemas";
 
 export const locationRouter = router({
-  listCases: publicProcedure.query(async ({ ctx }) =>
+  listCases: protectedProcedure.query(async ({ ctx }) =>
     throwIfError(
       await locationService.listCases({
         drizzleDb: createDrizzle(ctx.env.DB),
-        userId: TEMP_USER_ID,
+        userId: ctx.userId,
       }),
     ),
   ),
 
-  getCase: publicProcedure.input(cuidSchema).query(async ({ ctx, input: id }) =>
-    throwIfError(
-      await locationService.getCase({
-        drizzleDb: createDrizzle(ctx.env.DB),
-        id,
-        userId: TEMP_USER_ID,
-      }),
+  getCase: protectedProcedure
+    .input(cuidSchema)
+    .query(async ({ ctx, input: id }) =>
+      throwIfError(
+        await locationService.getCase({
+          drizzleDb: createDrizzle(ctx.env.DB),
+          id,
+          userId: ctx.userId,
+        }),
+      ),
     ),
-  ),
 
-  createCase: publicProcedure
+  createCase: protectedProcedure
     .input(createCaseInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await locationService.createCase({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           input,
         }),
       ),
     ),
 
-  updateCase: publicProcedure
+  updateCase: protectedProcedure
     .input(updateCaseInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await locationService.updateCase({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           input,
         }),
       ),
     ),
 
-  deleteCase: publicProcedure
+  deleteCase: protectedProcedure
     .input(cuidSchema)
     .mutation(async ({ ctx, input: id }) =>
       throwIfError(
         await locationService.deleteCase({
           drizzleDb: createDrizzle(ctx.env.DB),
           id,
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
         }),
       ),
     ),
 
-  updateLocation: publicProcedure
+  updateLocation: protectedProcedure
     .input(updateLocationInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await locationService.updateLocation({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           input,
         }),
       ),
     ),
 
-  createLocation: publicProcedure
+  createLocation: protectedProcedure
     .input(createLocationInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await locationService.createLocation({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           input,
         }),
       ),
     ),
 
-  deleteLocation: publicProcedure
+  deleteLocation: protectedProcedure
     .input(cuidSchema)
     .mutation(async ({ ctx, input: id }) =>
       throwIfError(
         await locationService.deleteLocation({
           drizzleDb: createDrizzle(ctx.env.DB),
           id,
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
         }),
       ),
     ),

--- a/workers/src/trpc/routers/scan.ts
+++ b/workers/src/trpc/routers/scan.ts
@@ -1,4 +1,4 @@
-import { router, publicProcedure } from "../index";
+import { router, protectedProcedure } from "../index";
 import {
   checkinInputSchema,
   checkoutInputSchema,
@@ -6,69 +6,68 @@ import {
   confirmPartialInputSchema,
   orphanResolveInputSchema,
 } from "../lib/schemas";
-import { TEMP_USER_ID } from "../lib/d1-helpers";
 import { createDrizzle } from "../../db/client";
 import * as scanService from "../../services/scan-service";
 import { throwIfError } from "../../services/types";
 
 export const scanRouter = router({
-  checkin: publicProcedure
+  checkin: protectedProcedure
     .input(checkinInputSchema)
     .mutation(async ({ input, ctx }) =>
       throwIfError(
         await scanService.checkin({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           locationId: input.locationId,
           garmentIds: input.garmentIds,
         }),
       ),
     ),
 
-  checkout: publicProcedure
+  checkout: protectedProcedure
     .input(checkoutInputSchema)
     .mutation(async ({ input, ctx }) =>
       throwIfError(
         await scanService.checkout({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           garmentId: input.garmentId,
         }),
       ),
     ),
 
-  confirmAll: publicProcedure
+  confirmAll: protectedProcedure
     .input(confirmAllInputSchema)
     .mutation(async ({ input, ctx }) =>
       throwIfError(
         await scanService.confirmAll({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           locationId: input.locationId,
         }),
       ),
     ),
 
-  confirmPartial: publicProcedure
+  confirmPartial: protectedProcedure
     .input(confirmPartialInputSchema)
     .mutation(async ({ input, ctx }) =>
       throwIfError(
         await scanService.confirmPartial({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           locationId: input.locationId,
           confirmations: input.confirmations,
         }),
       ),
     ),
 
-  orphanResolve: publicProcedure
+  orphanResolve: protectedProcedure
     .input(orphanResolveInputSchema)
     .mutation(async ({ input, ctx }) =>
       throwIfError(
         await scanService.orphanResolve({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           garmentId: input.garmentId,
           resolution: input.resolution,
           locationId: input.locationId,

--- a/workers/src/trpc/routers/sync.test.ts
+++ b/workers/src/trpc/routers/sync.test.ts
@@ -1,10 +1,10 @@
 import { createId } from "@paralleldrive/cuid2";
-import { TEMP_USER_ID } from "../lib/d1-helpers";
 import {
   createTestCaller,
   resetDatabase,
   getTestDb,
   expectTRPCError,
+  TEST_USER_ID,
 } from "../../test/helpers";
 import {
   insertCoordinate,
@@ -32,7 +32,7 @@ describe("sync router", () => {
             type: "garment:create",
             payload: {
               id: createId(),
-              userId: TEMP_USER_ID,
+              userId: TEST_USER_ID,
               name: "テスト",
               category: "dress",
               dollSizes: ["MSD"],
@@ -88,7 +88,7 @@ describe("sync router", () => {
             type: "storageLocation:update",
             payload: {
               id: locationId,
-              userId: TEMP_USER_ID,
+              userId: TEST_USER_ID,
               caseId,
               label: "A-1",
               row: 0,
@@ -121,7 +121,7 @@ describe("sync router", () => {
             type: "coordinate:create",
             payload: {
               id,
-              userId: TEMP_USER_ID,
+              userId: TEST_USER_ID,
               name: "春コーデ",
               garmentIds: ["g1", "g2"],
               isAiGenerated: false,
@@ -160,7 +160,7 @@ describe("sync router", () => {
             type: "coordinate:update",
             payload: {
               id,
-              userId: TEMP_USER_ID,
+              userId: TEST_USER_ID,
               name: "古い更新",
               garmentIds: [],
               isAiGenerated: false,
@@ -182,7 +182,7 @@ describe("sync router", () => {
             type: "coordinate:update",
             payload: {
               id,
-              userId: TEMP_USER_ID,
+              userId: TEST_USER_ID,
               name: "新しい更新",
               garmentIds: ["g1"],
               isAiGenerated: true,
@@ -240,7 +240,7 @@ describe("sync router", () => {
             type: "storageLocation:update",
             payload: {
               id: locationId,
-              userId: TEMP_USER_ID,
+              userId: TEST_USER_ID,
               caseId,
               label: "A-1",
               row: 0,
@@ -262,7 +262,7 @@ describe("sync router", () => {
             type: "storageLocation:update",
             payload: {
               id: locationId,
-              userId: TEMP_USER_ID,
+              userId: TEST_USER_ID,
               caseId,
               label: "A-1",
               customName: "新しい名前",

--- a/workers/src/trpc/routers/sync.ts
+++ b/workers/src/trpc/routers/sync.ts
@@ -1,29 +1,28 @@
 import { createDrizzle } from "../../db/client";
 import * as syncService from "../../services/sync-service";
 import { throwIfError } from "../../services/types";
-import { TEMP_USER_ID } from "../lib/d1-helpers";
 import { syncPushInputSchema } from "../lib/schemas";
-import { router, publicProcedure } from "../index";
+import { router, protectedProcedure } from "../index";
 
 export const syncRouter = router({
-  push: publicProcedure
+  push: protectedProcedure
     .input(syncPushInputSchema)
     .mutation(async ({ ctx, input }) =>
       throwIfError(
         await syncService.push({
           drizzleDb: createDrizzle(ctx.env.DB),
-          userId: TEMP_USER_ID,
+          userId: ctx.userId,
           items: input.items,
           logger: ctx.logger,
         }),
       ),
     ),
 
-  pull: publicProcedure.query(async ({ ctx }) =>
+  pull: protectedProcedure.query(async ({ ctx }) =>
     throwIfError(
       await syncService.pull({
         drizzleDb: createDrizzle(ctx.env.DB),
-        userId: TEMP_USER_ID,
+        userId: ctx.userId,
         logger: ctx.logger,
       }),
     ),

--- a/workers/test/helpers/factories.ts
+++ b/workers/test/helpers/factories.ts
@@ -1,5 +1,6 @@
 import { createId } from "@paralleldrive/cuid2";
-import { TEMP_USER_ID } from "../../src/trpc/lib/d1-helpers";
+
+export const TEST_USER_ID = "test-user-001";
 
 type InsertGarmentParams = {
   readonly db: D1Database;
@@ -36,7 +37,7 @@ export const insertGarment = async ({
     )
     .bind(
       id,
-      TEMP_USER_ID,
+      TEST_USER_ID,
       overrides.name ?? "テストドレス",
       overrides.category ?? "dress",
       JSON.stringify(overrides.dollSizes ?? ["MSD"]),
@@ -83,7 +84,7 @@ export const insertStorageCase = async ({
     )
     .bind(
       id,
-      TEMP_USER_ID,
+      TEST_USER_ID,
       overrides.name ?? "テストケース",
       overrides.rows ?? 3,
       overrides.cols ?? 2,
@@ -119,7 +120,7 @@ export const insertStorageLocation = async ({
     )
     .bind(
       id,
-      TEMP_USER_ID,
+      TEST_USER_ID,
       caseId,
       overrides.label ?? "A-1",
       overrides.row ?? 0,
@@ -154,7 +155,7 @@ export const insertDoll = async ({ db, overrides = {} }: InsertDollParams) => {
     )
     .bind(
       id,
-      TEMP_USER_ID,
+      TEST_USER_ID,
       overrides.name ?? "テストドール",
       overrides.headModel ?? null,
       overrides.bodySize ?? "MSD",
@@ -193,7 +194,7 @@ export const insertCoordinate = async ({
     )
     .bind(
       id,
-      TEMP_USER_ID,
+      TEST_USER_ID,
       overrides.name ?? "テストコーデ",
       JSON.stringify(overrides.garmentIds ?? []),
       overrides.isAiGenerated === true ? 1 : 0,
@@ -234,7 +235,7 @@ export const insertDigest = async ({
     )
     .bind(
       id,
-      TEMP_USER_ID,
+      TEST_USER_ID,
       overrides.accuracyScore ?? 1,
       overrides.confirmedCount ?? 0,
       overrides.uncertainCount ?? 0,

--- a/workers/test/helpers/factories.ts
+++ b/workers/test/helpers/factories.ts
@@ -1,6 +1,5 @@
 import { createId } from "@paralleldrive/cuid2";
-
-export const TEST_USER_ID = "test-user-001";
+import { TEST_USER_ID } from "../../src/test/helpers";
 
 type InsertGarmentParams = {
   readonly db: D1Database;


### PR DESCRIPTION
## Summary

- `TEMP_USER_ID` 定数を撤廃し、tRPC の 7 ルーター・31 procedure を全て `protectedProcedure` に切替、`userId` を `ctx.session.user.id` 由来 (`ctx.userId`) で取得するよう修正。
- better-auth を 1.6.9 にアップデートし `@better-auth/api-key` plugin を導入。`Authorization: Bearer <key>` 経路を共通ユーティリティ `resolveAuthenticatedUserId` で session / apiKey 両対応にし、`authMiddleware` と画像アップロード `/api/images/upload/:garmentId` の双方を保護。
- `findLocationByPosition` の userId フィルタ漏れを修正し、他ユーザーの位置情報を引けない構造に。
- テスト基盤を `createTestCaller` での session stub 注入方式に変更、`TEMP_USER_ID` 依存を `TEST_USER_ID` に整理。`workers/migrations/0012_api_key.sql` で `apikey` テーブルを追加。
- フロント `src/app/locations/page.tsx` を `authSessionUnwrappedAtom` 経由に切替、IndexedDB 保存時 userId を実セッションから取得。

## Test plan

- [x] `pnpm typecheck` 通過 (5 tsconfig 全て)
- [x] `pnpm lint` エラーなし (warnings は既存)
- [x] `pnpm format:check` 通過
- [x] `pnpm i18n:check` 通過
- [x] `pnpm test` 1026 テスト全緑
- [x] `pnpm test:coverage` branches 85.28% (>= 80% 必達)
- [x] 画像アップロード認証なしで 401 を返す scenario test を追加
- [ ] OAuth ログイン済みセッション A / B でデータ分離を手動確認 (verification step in #122)
- [ ] cookie 削除状態で `/trpc/garment.list` が `UNAUTHORIZED` を返すことを手動確認
- [ ] `auth.api.createApiKey({ userId })` で 1 本発行し `Authorization: Bearer <key>` で `garment.list` が通ることを手動確認
- [ ] `pnpm test:e2e` ハッピーパスが緑であること

## Non-goals (per issue body)

- OAuth provider 化は Phase 2
- API キーの read-only / read-write スコープ制御は #123
- API キー発行 UI (DB + 検証経路まで本 PR でカバー、UI は別 PR)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)