### PR TITLE
feat(auth): API キー管理 UI（発行・一覧・失効）

### DIFF
--- a/src/app/settings/api-keys/page.test.tsx
+++ b/src/app/settings/api-keys/page.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupAuthClient } from "@/test/mocks/modules/authClient";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import { installClipboard } from "@/test/helpers/clipboard";
+import { API_KEY_SCOPE, type ApiKeySummary } from "@/lib/auth";
+import ApiKeysPage from "./page";
+
+const baseKey: ApiKeySummary = {
+  id: "key-existing",
+  name: "agent-existing",
+  scope: API_KEY_SCOPE.READ_ONLY,
+  createdAt: new Date("2026-01-01T00:00:00Z").getTime(),
+  lastRequestAt: undefined,
+  enabled: true,
+};
+
+describe("ApiKeysPage", () => {
+  beforeEach(() => {
+    setupNextNavigation();
+  });
+
+  it("既存の API キー一覧が表示される", async () => {
+    setupAuthClient({ apiKeys: [baseKey] });
+
+    await renderWithProviders(<ApiKeysPage />);
+
+    expect(await screen.findByText("agent-existing")).toBeInTheDocument();
+  });
+
+  it("発行 → 一覧に追加 → 失効 → 一覧から消える、の一気通貫フロー", async () => {
+    const { spies } = setupAuthClient({
+      apiKeys: [],
+      nextCreated: {
+        id: "key-new",
+        name: "agent-new",
+        scope: API_KEY_SCOPE.READ_WRITE,
+        createdAt: Date.now(),
+        lastRequestAt: undefined,
+        enabled: true,
+        key: "dwk_secret_value",
+      },
+    });
+    const user = userEvent.setup();
+    installClipboard();
+
+    await renderWithProviders(<ApiKeysPage />);
+
+    // 初期状態: EmptyState
+    expect(
+      await screen.findByText("まだ API キーがありません"),
+    ).toBeInTheDocument();
+
+    // 発行ダイアログを開く
+    await user.click(
+      screen.getByRole("button", { name: "新しい API キーを発行" }),
+    );
+
+    // 名前入力 + scope=read-write 選択 + 発行
+    await user.type(await screen.findByLabelText("名前"), "agent-new");
+    await user.selectOptions(
+      screen.getByLabelText("スコープ"),
+      API_KEY_SCOPE.READ_WRITE,
+    );
+    await user.click(screen.getByRole("button", { name: "発行" }));
+
+    // 生キー表示
+    expect(await screen.findByTestId("api-key-value")).toHaveTextContent(
+      "dwk_secret_value",
+    );
+    expect(spies.createApiKey).toHaveBeenCalledWith({
+      name: "agent-new",
+      scope: API_KEY_SCOPE.READ_WRITE,
+    });
+
+    // モーダルを閉じる → 一覧に出現
+    await user.click(screen.getByRole("button", { name: "完了" }));
+    expect(await screen.findByText("agent-new")).toBeInTheDocument();
+
+    // 失効
+    await user.click(screen.getByRole("button", { name: "失効" }));
+    const confirmButtons = screen.getAllByRole("button", { name: "失効" });
+    await user.click(confirmButtons[confirmButtons.length - 1]!);
+
+    expect(spies.revokeApiKey).toHaveBeenCalledWith("key-new");
+    await waitFor(() => {
+      expect(screen.queryByText("agent-new")).toBeNull();
+    });
+  });
+});

--- a/src/app/settings/api-keys/page.test.tsx
+++ b/src/app/settings/api-keys/page.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import { server } from "@/test/mocks/server";
+import { unauthenticatedHandler } from "@/test/mocks/handlers";
 import { renderWithProviders } from "@/test/testUtils";
 import { setupAuthClient } from "@/test/mocks/modules/authClient";
 import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
@@ -87,6 +89,17 @@ describe("ApiKeysPage", () => {
     expect(spies.revokeApiKey).toHaveBeenCalledWith("key-new");
     await waitFor(() => {
       expect(screen.queryByText("agent-new")).toBeNull();
+    });
+  });
+
+  it("未認証時は /signin へリダイレクトされる", async () => {
+    server.use(unauthenticatedHandler);
+    const { router } = setupNextNavigation();
+
+    await renderWithProviders(<ApiKeysPage />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/signin");
     });
   });
 });

--- a/src/app/settings/api-keys/page.tsx
+++ b/src/app/settings/api-keys/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { Plus } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import type { CreatedApiKey } from "@/lib/auth";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
+import ApiKeyList from "@/components/settings/api-key/ApiKeyList";
+import ApiKeyCreateSheet from "@/components/settings/api-key/ApiKeyCreateSheet";
+import ApiKeyRevealSheet from "@/components/settings/api-key/ApiKeyRevealSheet";
+import Button from "@/components/ui/Button";
+import PageHeader from "@/components/ui/PageHeader";
+import Skeleton from "@/components/ui/Skeleton";
+
+const ApiKeysPage = () => {
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [createdKey, setCreatedKey] = useState<CreatedApiKey | undefined>(
+    undefined,
+  );
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <PageHeader title={t`API キー`} backHref="/" backLabel={t`戻る`} />
+
+      <p className="text-sm text-text-secondary">
+        <Trans>
+          外部 AI エージェントから接続するための Personal Access Token
+          を発行・管理します。
+        </Trans>
+      </p>
+
+      <div className="flex justify-end">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => setIsCreateOpen(true)}
+          aria-label={t`新しい API キーを発行`}
+        >
+          <Plus className="size-4" />
+          <Trans>新しい API キー</Trans>
+        </Button>
+      </div>
+
+      <ErrorBoundary
+        fallback={
+          <p className="text-sm text-danger">
+            <Trans>API キーの読み込みに失敗しました</Trans>
+          </p>
+        }
+      >
+        <Suspense
+          fallback={
+            <div className="flex flex-col gap-3">
+              <Skeleton className="h-24 rounded-xl" />
+              <Skeleton className="h-24 rounded-xl" />
+            </div>
+          }
+        >
+          <ApiKeyList />
+        </Suspense>
+      </ErrorBoundary>
+
+      <ApiKeyCreateSheet
+        isOpen={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+        onCreated={(key) => {
+          setIsCreateOpen(false);
+          setCreatedKey(key);
+        }}
+      />
+
+      <ApiKeyRevealSheet
+        createdKey={createdKey}
+        onClose={() => setCreatedKey(undefined)}
+      />
+    </div>
+  );
+};
+
+export default ApiKeysPage;

--- a/src/app/settings/api-keys/page.tsx
+++ b/src/app/settings/api-keys/page.tsx
@@ -18,19 +18,19 @@ import Skeleton from "@/components/ui/Skeleton";
 
 const ApiKeysPage = () => {
   const router = useRouter();
-  const { isAuthenticated } = useAtomValue(authSessionUnwrappedAtom);
+  const { isAuthenticated, isLoading } = useAtomValue(authSessionUnwrappedAtom);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [createdKey, setCreatedKey] = useState<CreatedApiKey | undefined>(
     undefined,
   );
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (!isLoading && !isAuthenticated) {
       router.replace("/signin");
     }
-  }, [isAuthenticated, router]);
+  }, [isLoading, isAuthenticated, router]);
 
-  if (!isAuthenticated) {
+  if (isLoading || !isAuthenticated) {
     return undefined;
   }
 

--- a/src/app/settings/api-keys/page.tsx
+++ b/src/app/settings/api-keys/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAtomValue } from "jotai";
 import { Plus } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import type { CreatedApiKey } from "@/lib/auth";
+import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import ApiKeyList from "@/components/settings/api-key/ApiKeyList";
 import ApiKeyCreateSheet from "@/components/settings/api-key/ApiKeyCreateSheet";
@@ -14,10 +17,23 @@ import PageHeader from "@/components/ui/PageHeader";
 import Skeleton from "@/components/ui/Skeleton";
 
 const ApiKeysPage = () => {
+  const router = useRouter();
+  const authState = useAtomValue(authSessionUnwrappedAtom);
+  const isAuthenticated = authState.user !== undefined;
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [createdKey, setCreatedKey] = useState<CreatedApiKey | undefined>(
     undefined,
   );
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.replace("/signin");
+    }
+  }, [isAuthenticated, router]);
+
+  if (!isAuthenticated) {
+    return undefined;
+  }
 
   return (
     <div className="flex flex-col gap-6 p-4">

--- a/src/app/settings/api-keys/page.tsx
+++ b/src/app/settings/api-keys/page.tsx
@@ -18,8 +18,7 @@ import Skeleton from "@/components/ui/Skeleton";
 
 const ApiKeysPage = () => {
   const router = useRouter();
-  const authState = useAtomValue(authSessionUnwrappedAtom);
-  const isAuthenticated = authState.user !== undefined;
+  const { isAuthenticated } = useAtomValue(authSessionUnwrappedAtom);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [createdKey, setCreatedKey] = useState<CreatedApiKey | undefined>(
     undefined,

--- a/src/app/signin/page.test.tsx
+++ b/src/app/signin/page.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { server } from "@/test/mocks/server";
+import { unauthenticatedHandler } from "@/test/mocks/handlers";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import SignInPage from "./page";
+
+describe("SignInPage", () => {
+  beforeEach(() => {
+    setupNextNavigation();
+  });
+
+  it("未認証時に Twitter / Google のログインボタンが表示される", async () => {
+    server.use(unauthenticatedHandler);
+
+    await renderWithProviders(<SignInPage />);
+
+    expect(
+      await screen.findByRole("button", { name: "X (Twitter) でログイン" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Google でログイン" }),
+    ).toBeInTheDocument();
+  });
+
+  it("認証済みの場合はホームへリダイレクトされる", async () => {
+    const { router } = setupNextNavigation();
+
+    await renderWithProviders(<SignInPage />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/");
+    });
+  });
+});

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -11,8 +11,7 @@ import PageHeader from "@/components/ui/PageHeader";
 
 const SignInPage = () => {
   const router = useRouter();
-  const authState = useAtomValue(authSessionUnwrappedAtom);
-  const isAuthenticated = authState.user !== undefined;
+  const { isAuthenticated } = useAtomValue(authSessionUnwrappedAtom);
 
   useEffect(() => {
     if (isAuthenticated) {

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAtomValue } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
+import LoginButton from "@/components/auth/LoginButton";
+import PageHeader from "@/components/ui/PageHeader";
+
+const SignInPage = () => {
+  const router = useRouter();
+  const authState = useAtomValue(authSessionUnwrappedAtom);
+  const isAuthenticated = authState.user !== undefined;
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.replace("/");
+    }
+  }, [isAuthenticated, router]);
+
+  if (isAuthenticated) {
+    return undefined;
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <PageHeader title={t`ログイン`} backHref="/" backLabel={t`戻る`} />
+
+      <p className="text-sm text-text-secondary">
+        <Trans>
+          ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API
+          キーの発行など、すべての機能を利用できます。
+        </Trans>
+      </p>
+
+      <div className="flex flex-col gap-3">
+        <LoginButton provider="twitter" />
+        <LoginButton provider="google" />
+      </div>
+    </div>
+  );
+};
+
+export default SignInPage;

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -11,15 +11,15 @@ import PageHeader from "@/components/ui/PageHeader";
 
 const SignInPage = () => {
   const router = useRouter();
-  const { isAuthenticated } = useAtomValue(authSessionUnwrappedAtom);
+  const { isAuthenticated, isLoading } = useAtomValue(authSessionUnwrappedAtom);
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (!isLoading && isAuthenticated) {
       router.replace("/");
     }
-  }, [isAuthenticated, router]);
+  }, [isLoading, isAuthenticated, router]);
 
-  if (isAuthenticated) {
+  if (isLoading || isAuthenticated) {
     return undefined;
   }
 

--- a/src/components/auth/UserMenu.test.tsx
+++ b/src/components/auth/UserMenu.test.tsx
@@ -13,14 +13,15 @@ describe("UserMenu", () => {
     expect(screen.getByLabelText("ログアウト")).toBeInTheDocument();
   });
 
-  it("未認証時は何も表示されない", async () => {
+  it("未認証時はログインリンクが表示される", async () => {
     server.use(unauthenticatedHandler);
-    const { container } = await renderWithProviders(<UserMenu />);
+    await renderWithProviders(<UserMenu />);
 
     await waitFor(() => {
       expect(screen.queryByTestId("suspense-loading")).not.toBeInTheDocument();
     });
 
-    expect(container.innerHTML).toBe("");
+    const loginLink = await screen.findByRole("link", { name: "ログイン" });
+    expect(loginLink).toHaveAttribute("href", "/signin");
   });
 });

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useAtomValue, useSetAtom } from "jotai";
-import { LogOut } from "lucide-react";
+import { LogOut, Settings } from "lucide-react";
 import { t } from "@lingui/core/macro";
 import { authSessionUnwrappedAtom, signOutAtom } from "@/stores/authAtoms";
 
@@ -30,6 +31,13 @@ const UserMenu = () => {
           {user.name.charAt(0)}
         </div>
       )}
+      <Link
+        href="/settings/api-keys"
+        className="p-1 text-text-tertiary hover:text-text-primary"
+        aria-label={t`設定`}
+      >
+        <Settings className="size-4" />
+      </Link>
       <button
         type="button"
         onClick={() => {

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useAtomValue, useSetAtom } from "jotai";
 import { LogOut, Settings } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import { authSessionUnwrappedAtom, signOutAtom } from "@/stores/authAtoms";
 
@@ -16,8 +17,19 @@ const UserMenu = () => {
     setIsMounted(true);
   }, []);
 
-  if (!isMounted || authState.user === undefined) {
+  if (!isMounted) {
     return undefined;
+  }
+
+  if (authState.user === undefined) {
+    return (
+      <Link
+        href="/signin"
+        className="rounded-lg px-3 py-1.5 text-sm font-medium text-text-secondary hover:bg-primary-50 hover:text-text-primary"
+      >
+        <Trans>ログイン</Trans>
+      </Link>
+    );
   }
 
   const { user } = authState;

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -17,7 +17,7 @@ const UserMenu = () => {
     setIsMounted(true);
   }, []);
 
-  if (!isMounted) {
+  if (!isMounted || authState.isLoading) {
     return undefined;
   }
 

--- a/src/components/settings/api-key/ApiKeyCreateSheet.test.tsx
+++ b/src/components/settings/api-key/ApiKeyCreateSheet.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupAuthClient } from "@/test/mocks/modules/authClient";
+import { API_KEY_SCOPE, type CreatedApiKey } from "@/lib/auth";
+import ApiKeyCreateSheet from "./ApiKeyCreateSheet";
+
+const fixedCreated: CreatedApiKey = {
+  id: "key-new",
+  name: "agent-x",
+  scope: API_KEY_SCOPE.READ_ONLY,
+  createdAt: 1_700_000_000_000,
+  lastRequestAt: undefined,
+  enabled: true,
+  key: "dwk_test_abcdef",
+};
+
+describe("ApiKeyCreateSheet", () => {
+  beforeEach(() => {
+    setupAuthClient({ nextCreated: fixedCreated });
+  });
+
+  it("isOpen=false のとき発行ボタンは表示されない", async () => {
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    await renderWithProviders(
+      <ApiKeyCreateSheet
+        isOpen={false}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "発行" })).toBeNull();
+  });
+
+  it("名前が空欄のとき発行ボタンは disabled", async () => {
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    await renderWithProviders(
+      <ApiKeyCreateSheet
+        isOpen={true}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    );
+
+    const submitButton = await screen.findByRole("button", { name: "発行" });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("名前 + scope=read-write で発行 → createApiKey が呼ばれ onCreated が生キー付きで実行される", async () => {
+    const { spies } = setupAuthClient({
+      nextCreated: { ...fixedCreated, scope: API_KEY_SCOPE.READ_WRITE },
+    });
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    await renderWithProviders(
+      <ApiKeyCreateSheet
+        isOpen={true}
+        onClose={onClose}
+        onCreated={onCreated}
+      />,
+    );
+
+    await user.type(await screen.findByLabelText("名前"), "agent-x");
+    await user.selectOptions(
+      screen.getByLabelText("スコープ"),
+      API_KEY_SCOPE.READ_WRITE,
+    );
+    await user.click(screen.getByRole("button", { name: "発行" }));
+
+    expect(spies.createApiKey).toHaveBeenCalledWith({
+      name: "agent-x",
+      scope: API_KEY_SCOPE.READ_WRITE,
+    });
+    expect(onCreated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "dwk_test_abcdef",
+        scope: API_KEY_SCOPE.READ_WRITE,
+      }),
+    );
+  });
+});

--- a/src/components/settings/api-key/ApiKeyCreateSheet.tsx
+++ b/src/components/settings/api-key/ApiKeyCreateSheet.tsx
@@ -48,6 +48,11 @@ const ApiKeyCreateSheet = ({ isOpen, onClose, onCreated }: Props) => {
   const trimmedName = name.trim();
   const isDisabled = trimmedName === "" || isSubmitting;
 
+  const resetForm = () => {
+    setName("");
+    setScope(API_KEY_SCOPE.READ_ONLY);
+  };
+
   const handleSubmit = async () => {
     if (isDisabled) return;
     setIsSubmitting(true);
@@ -59,15 +64,13 @@ const ApiKeyCreateSheet = ({ isOpen, onClose, onCreated }: Props) => {
       addToast({ message: t`API キーの発行に失敗しました` });
       return;
     }
-    setName("");
-    setScope(API_KEY_SCOPE.READ_ONLY);
+    resetForm();
     onCreated(created);
   };
 
   const handleClose = () => {
     if (isSubmitting) return;
-    setName("");
-    setScope(API_KEY_SCOPE.READ_ONLY);
+    resetForm();
     onClose();
   };
 

--- a/src/components/settings/api-key/ApiKeyCreateSheet.tsx
+++ b/src/components/settings/api-key/ApiKeyCreateSheet.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { msg, t } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import { createApiKeyAtom } from "@/stores/apiKeyAtoms";
+import { addToastAtom } from "@/stores/toastAtoms";
+import {
+  API_KEY_SCOPE,
+  type ApiKeyScope,
+  type CreatedApiKey,
+} from "@/lib/auth";
+import BottomSheet from "@/components/ui/BottomSheet";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
+
+type Props = {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onCreated: (created: CreatedApiKey) => void;
+};
+
+const SCOPE_OPTIONS = [
+  { value: API_KEY_SCOPE.READ_ONLY, label: msg`read-only（読み取り専用）` },
+  {
+    value: API_KEY_SCOPE.READ_WRITE,
+    label: msg`read-write（読み取り＋書き込み）`,
+  },
+] as const;
+
+const toApiKeyScope = (value: string): ApiKeyScope =>
+  value === API_KEY_SCOPE.READ_WRITE
+    ? API_KEY_SCOPE.READ_WRITE
+    : API_KEY_SCOPE.READ_ONLY;
+
+const ApiKeyCreateSheet = ({ isOpen, onClose, onCreated }: Props) => {
+  const create = useSetAtom(createApiKeyAtom);
+  const addToast = useSetAtom(addToastAtom);
+  const { i18n } = useLingui();
+
+  const [name, setName] = useState("");
+  const [scope, setScope] = useState<ApiKeyScope>(API_KEY_SCOPE.READ_ONLY);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const trimmedName = name.trim();
+  const isDisabled = trimmedName === "" || isSubmitting;
+
+  const handleSubmit = async () => {
+    if (isDisabled) return;
+    setIsSubmitting(true);
+    const created = await create({ name: trimmedName, scope }).catch(
+      () => undefined,
+    );
+    setIsSubmitting(false);
+    if (created === undefined) {
+      addToast({ message: t`API キーの発行に失敗しました` });
+      return;
+    }
+    setName("");
+    setScope(API_KEY_SCOPE.READ_ONLY);
+    onCreated(created);
+  };
+
+  const handleClose = () => {
+    if (isSubmitting) return;
+    setName("");
+    setScope(API_KEY_SCOPE.READ_ONLY);
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={t`新しい API キーを発行`}
+    >
+      <div className="flex flex-col gap-4">
+        <Input
+          label={t`名前`}
+          placeholder={t`例: agent-1`}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={64}
+        />
+        <Select
+          label={t`スコープ`}
+          value={scope}
+          onChange={(e) => setScope(toApiKeyScope(e.target.value))}
+          options={SCOPE_OPTIONS.map((option) => ({
+            value: option.value,
+            label: i18n._(option.label),
+          }))}
+        />
+        <p className="text-xs text-text-tertiary">
+          <Trans>
+            生キーは発行直後の一度しか表示されません。安全な場所に保管してください。
+          </Trans>
+        </p>
+        <div className="flex gap-3">
+          <Button variant="ghost" fullWidth onClick={handleClose}>
+            <Trans>キャンセル</Trans>
+          </Button>
+          <Button
+            variant="primary"
+            fullWidth
+            disabled={isDisabled}
+            onClick={handleSubmit}
+          >
+            <Trans>発行</Trans>
+          </Button>
+        </div>
+      </div>
+    </BottomSheet>
+  );
+};
+
+export default ApiKeyCreateSheet;

--- a/src/components/settings/api-key/ApiKeyList.test.tsx
+++ b/src/components/settings/api-key/ApiKeyList.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupAuthClient } from "@/test/mocks/modules/authClient";
+import { API_KEY_SCOPE, type ApiKeySummary } from "@/lib/auth";
+import ApiKeyList from "./ApiKeyList";
+
+const baseKey: ApiKeySummary = {
+  id: "key-1",
+  name: "agent-1",
+  scope: API_KEY_SCOPE.READ_ONLY,
+  createdAt: new Date("2026-01-01T10:00:00Z").getTime(),
+  lastRequestAt: undefined,
+  enabled: true,
+};
+
+describe("ApiKeyList", () => {
+  beforeEach(() => {
+    setupAuthClient();
+  });
+
+  it("API キーが 0 件の場合は EmptyState が表示される", async () => {
+    setupAuthClient({ apiKeys: [] });
+    await renderWithProviders(<ApiKeyList />);
+
+    expect(
+      await screen.findByText("まだ API キーがありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("API キーの一覧（名前 / スコープ / 日時）が表示される", async () => {
+    setupAuthClient({
+      apiKeys: [
+        { ...baseKey, name: "agent-1", scope: API_KEY_SCOPE.READ_ONLY },
+        {
+          ...baseKey,
+          id: "key-2",
+          name: "agent-2",
+          scope: API_KEY_SCOPE.READ_WRITE,
+          lastRequestAt: new Date("2026-01-02T10:00:00Z").getTime(),
+        },
+      ],
+    });
+    await renderWithProviders(<ApiKeyList />);
+
+    expect(await screen.findByText("agent-1")).toBeInTheDocument();
+    expect(screen.getByText("agent-2")).toBeInTheDocument();
+    expect(screen.getByText("read-only")).toBeInTheDocument();
+    expect(screen.getByText("read-write")).toBeInTheDocument();
+    expect(screen.getByText("未使用")).toBeInTheDocument();
+  });
+
+  it("失効ボタン → 確認 → revokeApiKey が呼ばれる", async () => {
+    const { spies } = setupAuthClient({
+      apiKeys: [{ ...baseKey, name: "agent-1" }],
+    });
+    const user = userEvent.setup();
+    await renderWithProviders(<ApiKeyList />);
+
+    await user.click(await screen.findByRole("button", { name: "失効" }));
+
+    const confirmButtons = screen.getAllByRole("button", { name: "失効" });
+    await user.click(confirmButtons[confirmButtons.length - 1]!);
+
+    expect(spies.revokeApiKey).toHaveBeenCalledWith("key-1");
+  });
+});

--- a/src/components/settings/api-key/ApiKeyList.tsx
+++ b/src/components/settings/api-key/ApiKeyList.tsx
@@ -4,17 +4,28 @@ import { useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { KeyRound } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
-import { t } from "@lingui/core/macro";
+import { msg, t } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 import { apiKeysAtom, revokeApiKeyAtom } from "@/stores/apiKeyAtoms";
 import { addToastAtom } from "@/stores/toastAtoms";
-import { API_KEY_SCOPE, type ApiKeySummary } from "@/lib/auth";
+import type { ApiKeyScope, ApiKeySummary } from "@/lib/auth";
 import { formatDateTime } from "@/lib/formatDate";
 import { isSupportedLocale } from "@/i18n/types";
 import Badge from "@/components/ui/Badge";
 import Button from "@/components/ui/Button";
 import ConfirmSheet from "@/components/ui/ConfirmSheet";
 import EmptyState from "@/components/ui/EmptyState";
+
+const SCOPE_BADGE: Record<
+  ApiKeyScope,
+  {
+    readonly variant: "primary" | "default";
+    readonly label: ReturnType<typeof msg>;
+  }
+> = {
+  "read-write": { variant: "primary", label: msg`read-write` },
+  "read-only": { variant: "default", label: msg`read-only` },
+};
 
 const ApiKeyList = () => {
   const apiKeys = useAtomValue(apiKeysAtom);
@@ -31,9 +42,11 @@ const ApiKeyList = () => {
     if (revokingKey === undefined) return;
     const target = revokingKey;
     setRevokingKey(undefined);
-    await revoke(target.id).catch(() => {
+    const failure = await revoke(target.id).catch(() => "failed" as const);
+    if (failure === "failed") {
       addToast({ message: t`API キーの失効に失敗しました` });
-    });
+      return;
+    }
     addToast({ message: t`API キー「${target.name}」を失効しました` });
   };
 
@@ -50,65 +63,56 @@ const ApiKeyList = () => {
   return (
     <>
       <ul className="flex flex-col gap-3">
-        {apiKeys.map((apiKey) => (
-          <li
-            key={apiKey.id}
-            className="flex flex-col gap-2 rounded-xl border border-border-default bg-surface-overlay p-4"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex flex-col gap-1">
-                <span className="font-medium text-text-primary">
-                  {apiKey.name}
-                </span>
-                <Badge
-                  variant={
-                    apiKey.scope === API_KEY_SCOPE.READ_WRITE
-                      ? "primary"
-                      : "default"
-                  }
+        {apiKeys.map((apiKey) => {
+          const badge = SCOPE_BADGE[apiKey.scope];
+          return (
+            <li
+              key={apiKey.id}
+              className="flex flex-col gap-2 rounded-xl border border-border-default bg-surface-overlay p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex flex-col gap-1">
+                  <span className="font-medium text-text-primary">
+                    {apiKey.name}
+                  </span>
+                  <Badge variant={badge.variant}>{i18n._(badge.label)}</Badge>
+                </div>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => setRevokingKey(apiKey)}
                 >
-                  {apiKey.scope === API_KEY_SCOPE.READ_WRITE ? (
-                    <Trans>read-write</Trans>
-                  ) : (
-                    <Trans>read-only</Trans>
-                  )}
-                </Badge>
+                  <Trans>失効</Trans>
+                </Button>
               </div>
-              <Button
-                variant="danger"
-                size="sm"
-                onClick={() => setRevokingKey(apiKey)}
-              >
-                <Trans>失効</Trans>
-              </Button>
-            </div>
-            <dl className="grid grid-cols-2 gap-2 text-xs text-text-tertiary">
-              <div className="flex flex-col">
-                <dt>
-                  <Trans>作成日時</Trans>
-                </dt>
-                <dd className="text-text-secondary">
-                  {formatDateTime({ timestamp: apiKey.createdAt, locale })}
-                </dd>
+              <div className="grid grid-cols-2 gap-2 text-xs text-text-tertiary">
+                <div className="flex flex-col">
+                  <span>
+                    <Trans>作成日時</Trans>
+                  </span>
+                  <span className="text-text-secondary">
+                    {formatDateTime({ timestamp: apiKey.createdAt, locale })}
+                  </span>
+                </div>
+                <div className="flex flex-col">
+                  <span>
+                    <Trans>最終使用日時</Trans>
+                  </span>
+                  <span className="text-text-secondary">
+                    {apiKey.lastRequestAt === undefined ? (
+                      <Trans>未使用</Trans>
+                    ) : (
+                      formatDateTime({
+                        timestamp: apiKey.lastRequestAt,
+                        locale,
+                      })
+                    )}
+                  </span>
+                </div>
               </div>
-              <div className="flex flex-col">
-                <dt>
-                  <Trans>最終使用日時</Trans>
-                </dt>
-                <dd className="text-text-secondary">
-                  {apiKey.lastRequestAt === undefined ? (
-                    <Trans>未使用</Trans>
-                  ) : (
-                    formatDateTime({
-                      timestamp: apiKey.lastRequestAt,
-                      locale,
-                    })
-                  )}
-                </dd>
-              </div>
-            </dl>
-          </li>
-        ))}
+            </li>
+          );
+        })}
       </ul>
 
       <ConfirmSheet

--- a/src/components/settings/api-key/ApiKeyList.tsx
+++ b/src/components/settings/api-key/ApiKeyList.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { KeyRound } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import { apiKeysAtom, revokeApiKeyAtom } from "@/stores/apiKeyAtoms";
+import { addToastAtom } from "@/stores/toastAtoms";
+import { API_KEY_SCOPE, type ApiKeySummary } from "@/lib/auth";
+import { formatDateTime } from "@/lib/formatDate";
+import { isSupportedLocale } from "@/i18n/types";
+import Badge from "@/components/ui/Badge";
+import Button from "@/components/ui/Button";
+import ConfirmSheet from "@/components/ui/ConfirmSheet";
+import EmptyState from "@/components/ui/EmptyState";
+
+const ApiKeyList = () => {
+  const apiKeys = useAtomValue(apiKeysAtom);
+  const revoke = useSetAtom(revokeApiKeyAtom);
+  const addToast = useSetAtom(addToastAtom);
+  const { i18n } = useLingui();
+  const locale = isSupportedLocale(i18n.locale) ? i18n.locale : "ja";
+
+  const [revokingKey, setRevokingKey] = useState<ApiKeySummary | undefined>(
+    undefined,
+  );
+
+  const handleRevoke = async () => {
+    if (revokingKey === undefined) return;
+    const target = revokingKey;
+    setRevokingKey(undefined);
+    await revoke(target.id).catch(() => {
+      addToast({ message: t`API キーの失効に失敗しました` });
+    });
+    addToast({ message: t`API キー「${target.name}」を失効しました` });
+  };
+
+  if (apiKeys.length === 0) {
+    return (
+      <EmptyState
+        icon={KeyRound}
+        title={t`まだ API キーがありません`}
+        description={t`外部エージェントから接続するための API キーを発行できます`}
+      />
+    );
+  }
+
+  return (
+    <>
+      <ul className="flex flex-col gap-3">
+        {apiKeys.map((apiKey) => (
+          <li
+            key={apiKey.id}
+            className="flex flex-col gap-2 rounded-xl border border-border-default bg-surface-overlay p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex flex-col gap-1">
+                <span className="font-medium text-text-primary">
+                  {apiKey.name}
+                </span>
+                <Badge
+                  variant={
+                    apiKey.scope === API_KEY_SCOPE.READ_WRITE
+                      ? "primary"
+                      : "default"
+                  }
+                >
+                  {apiKey.scope === API_KEY_SCOPE.READ_WRITE ? (
+                    <Trans>read-write</Trans>
+                  ) : (
+                    <Trans>read-only</Trans>
+                  )}
+                </Badge>
+              </div>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => setRevokingKey(apiKey)}
+              >
+                <Trans>失効</Trans>
+              </Button>
+            </div>
+            <dl className="grid grid-cols-2 gap-2 text-xs text-text-tertiary">
+              <div className="flex flex-col">
+                <dt>
+                  <Trans>作成日時</Trans>
+                </dt>
+                <dd className="text-text-secondary">
+                  {formatDateTime({ timestamp: apiKey.createdAt, locale })}
+                </dd>
+              </div>
+              <div className="flex flex-col">
+                <dt>
+                  <Trans>最終使用日時</Trans>
+                </dt>
+                <dd className="text-text-secondary">
+                  {apiKey.lastRequestAt === undefined ? (
+                    <Trans>未使用</Trans>
+                  ) : (
+                    formatDateTime({
+                      timestamp: apiKey.lastRequestAt,
+                      locale,
+                    })
+                  )}
+                </dd>
+              </div>
+            </dl>
+          </li>
+        ))}
+      </ul>
+
+      <ConfirmSheet
+        isOpen={revokingKey !== undefined}
+        onClose={() => setRevokingKey(undefined)}
+        onConfirm={handleRevoke}
+        title={t`API キーを失効`}
+        message={
+          revokingKey !== undefined
+            ? t`「${revokingKey.name}」を失効します。失効したキーは復元できません。`
+            : ""
+        }
+        confirmLabel={t`失効`}
+        confirmVariant="danger"
+      />
+    </>
+  );
+};
+
+export default ApiKeyList;

--- a/src/components/settings/api-key/ApiKeyRevealSheet.test.tsx
+++ b/src/components/settings/api-key/ApiKeyRevealSheet.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/testUtils";
+import { installClipboard } from "@/test/helpers/clipboard";
+import { API_KEY_SCOPE, type CreatedApiKey } from "@/lib/auth";
+import ApiKeyRevealSheet from "./ApiKeyRevealSheet";
+
+const createdKey: CreatedApiKey = {
+  id: "key-new",
+  name: "agent-x",
+  scope: API_KEY_SCOPE.READ_ONLY,
+  createdAt: 1_700_000_000_000,
+  lastRequestAt: undefined,
+  enabled: true,
+  key: "dwk_test_abcdef123",
+};
+
+describe("ApiKeyRevealSheet", () => {
+  it("createdKey=undefined のときは何も表示されない", async () => {
+    const onClose = vi.fn();
+    await renderWithProviders(
+      <ApiKeyRevealSheet createdKey={undefined} onClose={onClose} />,
+    );
+
+    expect(screen.queryByTestId("api-key-value")).toBeNull();
+  });
+
+  it("生キーが画面に表示される", async () => {
+    const onClose = vi.fn();
+    await renderWithProviders(
+      <ApiKeyRevealSheet createdKey={createdKey} onClose={onClose} />,
+    );
+
+    const keyEl = await screen.findByTestId("api-key-value");
+    expect(keyEl.textContent).toBe("dwk_test_abcdef123");
+  });
+
+  it("コピーボタンで navigator.clipboard.writeText が生キーで呼ばれる", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    const { writeText } = installClipboard();
+
+    await renderWithProviders(
+      <ApiKeyRevealSheet createdKey={createdKey} onClose={onClose} />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "API キーをコピー" }),
+    );
+
+    expect(writeText).toHaveBeenCalledWith("dwk_test_abcdef123");
+    expect(await screen.findByText("コピー済み")).toBeInTheDocument();
+  });
+
+  it("「完了」ボタンで onClose が呼ばれる", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    await renderWithProviders(
+      <ApiKeyRevealSheet createdKey={createdKey} onClose={onClose} />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "完了" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("コピー失敗時は「コピー済み」状態にならない", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    const { writeText } = installClipboard({ shouldFail: true });
+
+    await renderWithProviders(
+      <ApiKeyRevealSheet createdKey={createdKey} onClose={onClose} />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "API キーをコピー" }),
+    );
+
+    expect(writeText).toHaveBeenCalledWith("dwk_test_abcdef123");
+    expect(screen.queryByText("コピー済み")).toBeNull();
+  });
+});

--- a/src/components/settings/api-key/ApiKeyRevealSheet.tsx
+++ b/src/components/settings/api-key/ApiKeyRevealSheet.tsx
@@ -19,10 +19,10 @@ const copyToClipboard = async (text: string): Promise<boolean> => {
   if (typeof navigator === "undefined" || navigator.clipboard === undefined) {
     return false;
   }
-  const failed = await navigator.clipboard
+  const result = await navigator.clipboard
     .writeText(text)
-    .catch(() => "failed" as const);
-  return failed !== "failed";
+    .catch((e: unknown) => e);
+  return !(result instanceof Error);
 };
 
 const ApiKeyRevealSheet = ({ createdKey, onClose }: Props) => {

--- a/src/components/settings/api-key/ApiKeyRevealSheet.tsx
+++ b/src/components/settings/api-key/ApiKeyRevealSheet.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Check, Copy } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { addToastAtom } from "@/stores/toastAtoms";
+import type { CreatedApiKey } from "@/lib/auth";
+import BottomSheet from "@/components/ui/BottomSheet";
+import Button from "@/components/ui/Button";
+
+type Props = {
+  readonly createdKey: CreatedApiKey | undefined;
+  readonly onClose: () => void;
+};
+
+const copyToClipboard = async (text: string): Promise<boolean> => {
+  if (typeof navigator === "undefined" || navigator.clipboard === undefined) {
+    return false;
+  }
+  const failed = await navigator.clipboard
+    .writeText(text)
+    .catch(() => "failed" as const);
+  return failed !== "failed";
+};
+
+const ApiKeyRevealSheet = ({ createdKey, onClose }: Props) => {
+  const addToast = useSetAtom(addToastAtom);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (createdKey === undefined) return;
+    const ok = await copyToClipboard(createdKey.key);
+    if (ok) {
+      setCopied(true);
+      addToast({ message: t`API キーをコピーしました` });
+    } else {
+      addToast({ message: t`コピーに失敗しました。手動でコピーしてください` });
+    }
+  };
+
+  const handleClose = () => {
+    setCopied(false);
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      isOpen={createdKey !== undefined}
+      onClose={handleClose}
+      title={t`API キーを発行しました`}
+    >
+      {createdKey !== undefined && (
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-text-secondary">
+            <Trans>
+              この API
+              キーは一度だけ表示されます。閉じる前に必ずコピーしてください。
+            </Trans>
+          </p>
+          <div className="flex flex-col gap-1">
+            <span className="text-xs font-medium text-text-tertiary">
+              {createdKey.name}
+            </span>
+            <code
+              data-testid="api-key-value"
+              className="break-all rounded-lg border border-border-default bg-primary-50 px-3 py-2 font-mono text-sm text-text-primary"
+            >
+              {createdKey.key}
+            </code>
+          </div>
+          <Button
+            variant="secondary"
+            fullWidth
+            onClick={handleCopy}
+            aria-label={t`API キーをコピー`}
+          >
+            {copied ? (
+              <>
+                <Check className="size-4" />
+                <Trans>コピー済み</Trans>
+              </>
+            ) : (
+              <>
+                <Copy className="size-4" />
+                <Trans>コピー</Trans>
+              </>
+            )}
+          </Button>
+          <Button variant="primary" fullWidth onClick={handleClose}>
+            <Trans>完了</Trans>
+          </Button>
+        </div>
+      )}
+    </BottomSheet>
+  );
+};
+
+export default ApiKeyRevealSheet;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,6 @@
 import { createAuthClient } from "better-auth/react";
+import { apiKeyClient } from "@better-auth/api-key/client";
+import { z } from "zod";
 import { WORKERS_URL_FOR_FETCH } from "@/lib/workersUrl";
 
 const AUTH_BASE_URL =
@@ -8,6 +10,7 @@ const AUTH_BASE_URL =
 
 const client = createAuthClient({
   baseURL: AUTH_BASE_URL,
+  plugins: [apiKeyClient()],
 });
 
 export type SessionUser = {
@@ -47,4 +50,110 @@ export const getSession = async (): Promise<SessionResponse> => {
             },
           },
   };
+};
+
+export const API_KEY_SCOPE = Object.freeze({
+  READ_ONLY: "read-only",
+  READ_WRITE: "read-write",
+});
+
+export type ApiKeyScope = (typeof API_KEY_SCOPE)[keyof typeof API_KEY_SCOPE];
+
+const SCOPE_PERMISSIONS: Record<ApiKeyScope, Record<string, string[]>> = {
+  "read-only": { all: ["read"] },
+  "read-write": { all: ["read", "write"] },
+};
+
+const permissionsSchema = z
+  .record(z.string(), z.array(z.string()))
+  .nullable()
+  .optional();
+
+const permissionsToScope = (raw: unknown): ApiKeyScope => {
+  const parsed = permissionsSchema.safeParse(raw);
+  const actions = parsed.success ? (parsed.data?.all ?? []) : [];
+  return actions.includes("write")
+    ? API_KEY_SCOPE.READ_WRITE
+    : API_KEY_SCOPE.READ_ONLY;
+};
+
+export type ApiKeySummary = {
+  readonly id: string;
+  readonly name: string;
+  readonly scope: ApiKeyScope;
+  readonly createdAt: number;
+  readonly lastRequestAt: number | undefined;
+  readonly enabled: boolean;
+};
+
+export type CreatedApiKey = ApiKeySummary & {
+  readonly key: string;
+};
+
+const dateLikeSchema = z
+  .union([z.date(), z.string(), z.number()])
+  .nullable()
+  .optional();
+
+const toMillis = (raw: unknown): number => {
+  const parsed = dateLikeSchema.safeParse(raw);
+  return !parsed.success || parsed.data == null
+    ? 0
+    : parsed.data instanceof Date
+      ? parsed.data.getTime()
+      : typeof parsed.data === "number"
+        ? parsed.data
+        : new Date(parsed.data).getTime();
+};
+
+const toLastRequest = (raw: unknown): number | undefined => {
+  const ms = toMillis(raw);
+  return ms === 0 ? undefined : ms;
+};
+
+const fail = (msg: string): never => {
+  // eslint-disable-next-line functional/no-throw-statements -- ErrorBoundary handles via Suspense
+  throw new Error(msg);
+};
+
+export const createApiKey = async (input: {
+  readonly name: string;
+  readonly scope: ApiKeyScope;
+}): Promise<CreatedApiKey> => {
+  const { data, error } = await client.apiKey.create({
+    name: input.name,
+    permissions: SCOPE_PERMISSIONS[input.scope],
+  });
+  return error === null
+    ? {
+        id: data.id,
+        name: data.name ?? input.name,
+        scope: input.scope,
+        createdAt: toMillis(data.createdAt),
+        lastRequestAt: undefined,
+        enabled: data.enabled,
+        key: data.key,
+      }
+    : fail(error.message ?? "Failed to create API key");
+};
+
+export const listApiKeys = async (): Promise<readonly ApiKeySummary[]> => {
+  const { data, error } = await client.apiKey.list();
+  return error === null
+    ? data.apiKeys.map((item) => ({
+        id: item.id,
+        name: item.name ?? "",
+        scope: permissionsToScope(item.permissions),
+        createdAt: toMillis(item.createdAt),
+        lastRequestAt: toLastRequest(item.lastRequest),
+        enabled: item.enabled,
+      }))
+    : fail(error.message ?? "Failed to list API keys");
+};
+
+export const revokeApiKey = async (keyId: string): Promise<void> => {
+  const { error } = await client.apiKey.delete({ keyId });
+  return error === null
+    ? undefined
+    : fail(error.message ?? "Failed to revoke API key");
 };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -55,7 +55,7 @@ export const getSession = async (): Promise<SessionResponse> => {
 export const API_KEY_SCOPE = Object.freeze({
   READ_ONLY: "read-only",
   READ_WRITE: "read-write",
-});
+} as const);
 
 export type ApiKeyScope = (typeof API_KEY_SCOPE)[keyof typeof API_KEY_SCOPE];
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -142,6 +142,11 @@ msgstr "Delete \"{0}\"? Garments in this case will be marked as \"checked out\".
 msgid "「{0}」を削除しますか？この操作は取り消せません。"
 msgstr "Delete \"{0}\"? This action cannot be undone."
 
+#. placeholder {0}: revokingKey.name
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "「{0}」を失効します。失効したキーは復元できません。"
+msgstr "Revoke \"{0}\". Revoked keys cannot be restored."
+
 #. placeholder {0}: doll.name
 #. placeholder {0}: garment.name
 #: src/components/doll/DollDetail.tsx
@@ -157,6 +162,43 @@ msgstr "Mark \"{0}\" as lost. Its location information will be cleared."
 #: src/components/coordinate/OriginBadge.tsx
 msgid "AI"
 msgstr "AI"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "API キー"
+msgstr "API keys"
+
+#. placeholder {0}: target.name
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キー「{0}」を失効しました"
+msgstr "Revoked API key \"{0}\""
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キーの失効に失敗しました"
+msgstr "Failed to revoke API key"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "API キーの発行に失敗しました"
+msgstr "Failed to issue API key"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "API キーの読み込みに失敗しました"
+msgstr "Failed to load API keys"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーをコピー"
+msgstr "Copy API key"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーをコピーしました"
+msgstr "API key copied"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キーを失効"
+msgstr "Revoke API key"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーを発行しました"
+msgstr "API key issued"
 
 #: src/app/garments/new/page.tsx
 #: src/app/garments/page.tsx
@@ -260,6 +302,22 @@ msgstr "Confidence is restored conservatively compared to QR scan (approx. 0.5)"
 #: src/components/garment/GarmentDetail.tsx
 msgid "QRを印刷"
 msgstr "Print QR"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "read-only"
+msgstr "read-only"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "read-only（読み取り専用）"
+msgstr "read-only (read access)"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "read-write"
+msgstr "read-write"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "read-write（読み取り＋書き込み）"
+msgstr "read-write (read & write)"
 
 #: src/lib/i18n-labels.ts
 msgid "SD (~57cm)"
@@ -402,6 +460,7 @@ msgstr "Color"
 #: src/components/location/StorageCaseEditForm.tsx
 #: src/components/location/StorageCaseForm.tsx
 #: src/components/location/StorageLocationEditForm.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 #: src/components/ui/ConfirmSheet.tsx
 msgid "キャンセル"
 msgstr "Cancel"
@@ -468,6 +527,10 @@ msgstr "Outfit name"
 msgid "コーデ詳細"
 msgstr "Outfit details"
 
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "この API キーは一度だけ表示されます。閉じる前に必ずコピーしてください。"
+msgstr "This API key is shown only once. Make sure to copy it before closing."
+
 #: src/app/nfc-write/page.tsx
 msgid "このデバイスは NFC 書き込みに対応していません。Android Chrome をご利用ください。"
 msgstr "This device does not support NFC writing. Please use Android Chrome."
@@ -487,6 +550,18 @@ msgstr "Mark all garments in this location as confirmed"
 #: src/components/scan/CheckoutConfirmSheet.tsx
 msgid "この引き出しの他の服、まだありますか？"
 msgstr "Are all the other clothes in this drawer still there?"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピー"
+msgstr "Copy"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピーに失敗しました。手動でコピーしてください"
+msgstr "Copy failed. Please copy manually"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピー済み"
+msgstr "Copied"
 
 #: src/app/garments/page.tsx
 #: src/components/dashboard/WardrobeAnalytics.tsx
@@ -538,6 +613,10 @@ msgstr "Scanned"
 #: src/components/scan/ScanSessionPanel.tsx
 msgid "スキャン中の場所"
 msgstr "Scanning location"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "スコープ"
+msgstr "Scope"
 
 #: src/components/dashboard/StatsOverview.tsx
 #: src/components/garment/GarmentDetail.tsx
@@ -743,6 +822,10 @@ msgstr "Body size"
 msgid "ボトムス"
 msgstr "Bottoms"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "まだ API キーがありません"
+msgstr "No API keys yet"
+
 #: src/app/coordinates/page.tsx
 msgid "まだコーデがありません"
 msgstr "No outfits yet"
@@ -863,8 +946,16 @@ msgid "一覧に戻る"
 msgstr "Back to list"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
-msgid "下のリストから服を選択してください"
-msgstr "Pick garments from the list below."
+msgid "上へ"
+msgstr "Move up"
+
+#: src/components/coordinate/CoordinateBuilder.tsx
+#~ msgid "下のリストから服を選択してください"
+#~ msgstr "Pick garments from the list below."
+
+#: src/components/coordinate/CoordinateBuilder.tsx
+msgid "下へ"
+msgstr "Move down"
 
 #: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
@@ -886,6 +977,10 @@ msgstr "Confirm without being here"
 msgid "作成"
 msgstr "Create"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "作成日時"
+msgstr "Created"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "使用する服"
 msgstr "Garments used"
@@ -893,6 +988,10 @@ msgstr "Garments used"
 #: src/components/dashboard/CheckedOutSection.tsx
 msgid "使用中"
 msgstr "In use"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "例: agent-1"
+msgstr "e.g. agent-1"
 
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "例: ワンピース用"
@@ -966,6 +1065,10 @@ msgstr "Register your first doll"
 msgid "最初のドール服を登録してみましょう"
 msgstr "Register your first doll garment"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "最終使用日時"
+msgstr "Last used"
+
 #: src/components/dashboard/RecentItems.tsx
 msgid "最近のアイテム"
 msgstr "Recent items"
@@ -997,7 +1100,6 @@ msgstr "Previous page"
 msgid "前の値を適用"
 msgstr "Apply previous values"
 
-#: src/components/coordinate/CoordinateBuilder.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/ui/Pagination.tsx
 msgid "前へ"
@@ -1062,6 +1164,7 @@ msgstr "Total"
 #: src/components/garment/bulk/BulkMetadataFormFields.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/garment/GarmentForm.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "名前"
 msgstr "Name"
 
@@ -1102,9 +1205,26 @@ msgstr "Location set"
 msgid "変更"
 msgstr "Change"
 
+#: src/app/settings/api-keys/page.tsx
+msgid "外部 AI エージェントから接続するための Personal Access Token を発行・管理します。"
+msgstr "Issue and manage Personal Access Tokens for external AI agents to connect."
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "外部エージェントから接続するための API キーを発行できます"
+msgstr "You can issue API keys for external agents to connect"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "失効"
+msgstr "Revoke"
+
 #: src/lib/i18n-labels.ts
 msgid "季節物 (90日)"
 msgstr "Seasonal (90 days)"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "完了"
+msgstr "Done"
 
 #: src/components/doll/DollDetail.tsx
 #: src/components/doll/DollDetail.tsx
@@ -1132,6 +1252,7 @@ msgstr "Restore"
 
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
+#: src/app/settings/api-keys/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
@@ -1141,6 +1262,15 @@ msgstr "Back"
 #: src/components/coordinate/OriginBadge.tsx
 msgid "手動"
 msgstr "Manual"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "新しい API キー"
+msgstr "New API key"
+
+#: src/app/settings/api-keys/page.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "新しい API キーを発行"
+msgstr "Issue a new API key"
 
 #: src/components/digest/DigestBanner.tsx
 msgid "新しい週間レポートが届いています"
@@ -1225,6 +1355,10 @@ msgstr "Edit garment"
 msgid "服を選ぶ"
 msgstr "Pick garments"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "未使用"
+msgstr "Not used"
+
 #: src/components/dashboard/StaleLocationItem.tsx
 msgid "未確認 {uncertainItemCount}着"
 msgstr "{uncertainItemCount} items unconfirmed"
@@ -1251,7 +1385,6 @@ msgid "次のページ"
 msgstr "Next page"
 
 #: src/app/nfc-write/page.tsx
-#: src/components/coordinate/CoordinateBuilder.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/bulk/CaptureCamera.tsx
 #: src/components/ui/Pagination.tsx
@@ -1266,11 +1399,19 @@ msgstr "Auto-generated every Monday"
 msgid "状態"
 msgstr "Status"
 
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "生キーは発行直後の一度しか表示されません。安全な場所に保管してください。"
+msgstr "The raw key is shown only once right after issuance. Keep it in a safe place."
+
 #. placeholder {0}: status.completed
 #. placeholder {1}: status.total
 #: src/components/garment/bulk/BulkRegistrationProgress.tsx
 msgid "画像をアップロードしています ({0}/{1})"
 msgstr "Uploading images ({0}/{1})"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "発行"
+msgstr "Issue"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "登録された服がありません"
@@ -1411,6 +1552,10 @@ msgstr "Items needing review ({0})"
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"
 msgstr "Language"
+
+#: src/components/auth/UserMenu.tsx
+msgid "設定"
+msgstr "Settings"
 
 #: src/components/garment/DollCombobox.tsx
 msgid "該当するドールがありません"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -652,6 +652,10 @@ msgstr "Set"
 msgid "セット内容"
 msgstr "Set Contents"
 
+#: src/app/signin/page.tsx
+msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+msgstr "Sign in with a social account to access all features, including QR/NFC scan tracking and API key issuance."
+
 #: src/lib/i18n-labels.ts
 msgid "ソックス/タイツ"
 msgstr "Socks/Tights"
@@ -900,6 +904,11 @@ msgstr "Reset"
 #: src/components/auth/UserMenu.tsx
 msgid "ログアウト"
 msgstr "Sign out"
+
+#: src/app/signin/page.tsx
+#: src/components/auth/UserMenu.tsx
+msgid "ログイン"
+msgstr "Sign in"
 
 #: src/app/garments/page.tsx
 #: src/lib/nav-items.ts
@@ -1253,6 +1262,7 @@ msgstr "Restore"
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
 #: src/app/settings/api-keys/page.tsx
+#: src/app/signin/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -652,6 +652,10 @@ msgstr "セット"
 msgid "セット内容"
 msgstr "セット内容"
 
+#: src/app/signin/page.tsx
+msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+msgstr "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+
 #: src/lib/i18n-labels.ts
 msgid "ソックス/タイツ"
 msgstr "ソックス/タイツ"
@@ -900,6 +904,11 @@ msgstr "リセット"
 #: src/components/auth/UserMenu.tsx
 msgid "ログアウト"
 msgstr "ログアウト"
+
+#: src/app/signin/page.tsx
+#: src/components/auth/UserMenu.tsx
+msgid "ログイン"
+msgstr "ログイン"
 
 #: src/app/garments/page.tsx
 #: src/lib/nav-items.ts
@@ -1253,6 +1262,7 @@ msgstr "復元"
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
 #: src/app/settings/api-keys/page.tsx
+#: src/app/signin/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -142,6 +142,11 @@ msgstr "「{0}」を削除しますか？ケース内の服は「取り出し中
 msgid "「{0}」を削除しますか？この操作は取り消せません。"
 msgstr "「{0}」を削除しますか？この操作は取り消せません。"
 
+#. placeholder {0}: revokingKey.name
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "「{0}」を失効します。失効したキーは復元できません。"
+msgstr "「{0}」を失効します。失効したキーは復元できません。"
+
 #. placeholder {0}: doll.name
 #. placeholder {0}: garment.name
 #: src/components/doll/DollDetail.tsx
@@ -157,6 +162,43 @@ msgstr "「{0}」を紛失としてマークします。収納場所の情報は
 #: src/components/coordinate/OriginBadge.tsx
 msgid "AI"
 msgstr "AI"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "API キー"
+msgstr "API キー"
+
+#. placeholder {0}: target.name
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キー「{0}」を失効しました"
+msgstr "API キー「{0}」を失効しました"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キーの失効に失敗しました"
+msgstr "API キーの失効に失敗しました"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "API キーの発行に失敗しました"
+msgstr "API キーの発行に失敗しました"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "API キーの読み込みに失敗しました"
+msgstr "API キーの読み込みに失敗しました"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーをコピー"
+msgstr "API キーをコピー"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーをコピーしました"
+msgstr "API キーをコピーしました"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キーを失効"
+msgstr "API キーを失効"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーを発行しました"
+msgstr "API キーを発行しました"
 
 #: src/app/garments/new/page.tsx
 #: src/app/garments/page.tsx
@@ -260,6 +302,22 @@ msgstr "QR 確認より信頼度は控えめに戻ります（約0.5）"
 #: src/components/garment/GarmentDetail.tsx
 msgid "QRを印刷"
 msgstr "QRを印刷"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "read-only"
+msgstr "read-only"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "read-only（読み取り専用）"
+msgstr "read-only（読み取り専用）"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "read-write"
+msgstr "read-write"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "read-write（読み取り＋書き込み）"
+msgstr "read-write（読み取り＋書き込み）"
 
 #: src/lib/i18n-labels.ts
 msgid "SD (~57cm)"
@@ -402,6 +460,7 @@ msgstr "カラー"
 #: src/components/location/StorageCaseEditForm.tsx
 #: src/components/location/StorageCaseForm.tsx
 #: src/components/location/StorageLocationEditForm.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 #: src/components/ui/ConfirmSheet.tsx
 msgid "キャンセル"
 msgstr "キャンセル"
@@ -468,6 +527,10 @@ msgstr "コーデ名"
 msgid "コーデ詳細"
 msgstr "コーデ詳細"
 
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "この API キーは一度だけ表示されます。閉じる前に必ずコピーしてください。"
+msgstr "この API キーは一度だけ表示されます。閉じる前に必ずコピーしてください。"
+
 #: src/app/nfc-write/page.tsx
 msgid "このデバイスは NFC 書き込みに対応していません。Android Chrome をご利用ください。"
 msgstr "このデバイスは NFC 書き込みに対応していません。Android Chrome をご利用ください。"
@@ -487,6 +550,18 @@ msgstr "この場所の全服を確認済みにする"
 #: src/components/scan/CheckoutConfirmSheet.tsx
 msgid "この引き出しの他の服、まだありますか？"
 msgstr "この引き出しの他の服、まだありますか？"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピー"
+msgstr "コピー"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピーに失敗しました。手動でコピーしてください"
+msgstr "コピーに失敗しました。手動でコピーしてください"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピー済み"
+msgstr "コピー済み"
 
 #: src/app/garments/page.tsx
 #: src/components/dashboard/WardrobeAnalytics.tsx
@@ -538,6 +613,10 @@ msgstr "スキャンしました"
 #: src/components/scan/ScanSessionPanel.tsx
 msgid "スキャン中の場所"
 msgstr "スキャン中の場所"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "スコープ"
+msgstr "スコープ"
 
 #: src/components/dashboard/StatsOverview.tsx
 #: src/components/garment/GarmentDetail.tsx
@@ -743,6 +822,10 @@ msgstr "ボディサイズ"
 msgid "ボトムス"
 msgstr "ボトムス"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "まだ API キーがありません"
+msgstr "まだ API キーがありません"
+
 #: src/app/coordinates/page.tsx
 msgid "まだコーデがありません"
 msgstr "まだコーデがありません"
@@ -863,8 +946,16 @@ msgid "一覧に戻る"
 msgstr "一覧に戻る"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
-msgid "下のリストから服を選択してください"
-msgstr "下のリストから服を選択してください"
+msgid "上へ"
+msgstr "上へ"
+
+#: src/components/coordinate/CoordinateBuilder.tsx
+#~ msgid "下のリストから服を選択してください"
+#~ msgstr "下のリストから服を選択してください"
+
+#: src/components/coordinate/CoordinateBuilder.tsx
+msgid "下へ"
+msgstr "下へ"
 
 #: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
@@ -886,6 +977,10 @@ msgstr "今ここにいなくても確認"
 msgid "作成"
 msgstr "作成"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "作成日時"
+msgstr "作成日時"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "使用する服"
 msgstr "使用する服"
@@ -893,6 +988,10 @@ msgstr "使用する服"
 #: src/components/dashboard/CheckedOutSection.tsx
 msgid "使用中"
 msgstr "使用中"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "例: agent-1"
+msgstr "例: agent-1"
 
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "例: ワンピース用"
@@ -966,6 +1065,10 @@ msgstr "最初のドールを登録してみましょう"
 msgid "最初のドール服を登録してみましょう"
 msgstr "最初のドール服を登録してみましょう"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "最終使用日時"
+msgstr "最終使用日時"
+
 #: src/components/dashboard/RecentItems.tsx
 msgid "最近のアイテム"
 msgstr "最近のアイテム"
@@ -997,7 +1100,6 @@ msgstr "前のページ"
 msgid "前の値を適用"
 msgstr "前の値を適用"
 
-#: src/components/coordinate/CoordinateBuilder.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/ui/Pagination.tsx
 msgid "前へ"
@@ -1062,6 +1164,7 @@ msgstr "合計"
 #: src/components/garment/bulk/BulkMetadataFormFields.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/garment/GarmentForm.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "名前"
 msgstr "名前"
 
@@ -1102,9 +1205,26 @@ msgstr "場所を設定しました"
 msgid "変更"
 msgstr "変更"
 
+#: src/app/settings/api-keys/page.tsx
+msgid "外部 AI エージェントから接続するための Personal Access Token を発行・管理します。"
+msgstr "外部 AI エージェントから接続するための Personal Access Token を発行・管理します。"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "外部エージェントから接続するための API キーを発行できます"
+msgstr "外部エージェントから接続するための API キーを発行できます"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "失効"
+msgstr "失効"
+
 #: src/lib/i18n-labels.ts
 msgid "季節物 (90日)"
 msgstr "季節物 (90日)"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "完了"
+msgstr "完了"
 
 #: src/components/doll/DollDetail.tsx
 #: src/components/doll/DollDetail.tsx
@@ -1132,6 +1252,7 @@ msgstr "復元"
 
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
+#: src/app/settings/api-keys/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
@@ -1141,6 +1262,15 @@ msgstr "戻る"
 #: src/components/coordinate/OriginBadge.tsx
 msgid "手動"
 msgstr "手動"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "新しい API キー"
+msgstr "新しい API キー"
+
+#: src/app/settings/api-keys/page.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "新しい API キーを発行"
+msgstr "新しい API キーを発行"
 
 #: src/components/digest/DigestBanner.tsx
 msgid "新しい週間レポートが届いています"
@@ -1225,6 +1355,10 @@ msgstr "服を編集"
 msgid "服を選ぶ"
 msgstr "服を選ぶ"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "未使用"
+msgstr "未使用"
+
 #: src/components/dashboard/StaleLocationItem.tsx
 msgid "未確認 {uncertainItemCount}着"
 msgstr "未確認 {uncertainItemCount}着"
@@ -1251,7 +1385,6 @@ msgid "次のページ"
 msgstr "次のページ"
 
 #: src/app/nfc-write/page.tsx
-#: src/components/coordinate/CoordinateBuilder.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/bulk/CaptureCamera.tsx
 #: src/components/ui/Pagination.tsx
@@ -1266,11 +1399,19 @@ msgstr "毎週月曜日に自動生成されます"
 msgid "状態"
 msgstr "状態"
 
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "生キーは発行直後の一度しか表示されません。安全な場所に保管してください。"
+msgstr "生キーは発行直後の一度しか表示されません。安全な場所に保管してください。"
+
 #. placeholder {0}: status.completed
 #. placeholder {1}: status.total
 #: src/components/garment/bulk/BulkRegistrationProgress.tsx
 msgid "画像をアップロードしています ({0}/{1})"
 msgstr "画像をアップロードしています ({0}/{1})"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "発行"
+msgstr "発行"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "登録された服がありません"
@@ -1411,6 +1552,10 @@ msgstr "要確認のアイテム（{0}件）"
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"
 msgstr "言語"
+
+#: src/components/auth/UserMenu.tsx
+msgid "設定"
+msgstr "設定"
 
 #: src/components/garment/DollCombobox.tsx
 msgid "該当するドールがありません"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -652,6 +652,10 @@ msgstr "세트"
 msgid "セット内容"
 msgstr "세트 구성"
 
+#: src/app/signin/page.tsx
+msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+msgstr "소셜 계정으로 로그인하면 QR/NFC 스캔 기록과 API 키 발급을 비롯한 모든 기능을 이용할 수 있습니다."
+
 #: src/lib/i18n-labels.ts
 msgid "ソックス/タイツ"
 msgstr "양말/타이츠"
@@ -900,6 +904,11 @@ msgstr "초기화"
 #: src/components/auth/UserMenu.tsx
 msgid "ログアウト"
 msgstr "로그아웃"
+
+#: src/app/signin/page.tsx
+#: src/components/auth/UserMenu.tsx
+msgid "ログイン"
+msgstr "로그인"
 
 #: src/app/garments/page.tsx
 #: src/lib/nav-items.ts
@@ -1253,6 +1262,7 @@ msgstr "복원"
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
 #: src/app/settings/api-keys/page.tsx
+#: src/app/signin/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -142,6 +142,11 @@ msgstr "\"{0}\"을(를) 삭제하시겠습니까? 케이스 안의 옷은 \"꺼�
 msgid "「{0}」を削除しますか？この操作は取り消せません。"
 msgstr "「{0}」을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
 
+#. placeholder {0}: revokingKey.name
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "「{0}」を失効します。失効したキーは復元できません。"
+msgstr "「{0}」를 폐기합니다. 폐기된 키는 복구할 수 없습니다."
+
 #. placeholder {0}: doll.name
 #. placeholder {0}: garment.name
 #: src/components/doll/DollDetail.tsx
@@ -157,6 +162,43 @@ msgstr "\"{0}\"을(를) 분실로 표시합니다. 수납 위치 정보는 지�
 #: src/components/coordinate/OriginBadge.tsx
 msgid "AI"
 msgstr "AI"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "API キー"
+msgstr "API 키"
+
+#. placeholder {0}: target.name
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キー「{0}」を失効しました"
+msgstr "API 키「{0}」를 폐기했습니다"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キーの失効に失敗しました"
+msgstr "API 키 폐기에 실패했습니다"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "API キーの発行に失敗しました"
+msgstr "API 키 발급에 실패했습니다"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "API キーの読み込みに失敗しました"
+msgstr "API 키를 불러오지 못했습니다"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーをコピー"
+msgstr "API 키 복사"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーをコピーしました"
+msgstr "API 키를 복사했습니다"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キーを失効"
+msgstr "API 키 폐기"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーを発行しました"
+msgstr "API 키를 발급했습니다"
 
 #: src/app/garments/new/page.tsx
 #: src/app/garments/page.tsx
@@ -260,6 +302,22 @@ msgstr "QR 확인보다 신뢰도가 조금 회복됩니다 (약 0.5)"
 #: src/components/garment/GarmentDetail.tsx
 msgid "QRを印刷"
 msgstr "QR 인쇄"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "read-only"
+msgstr "read-only"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "read-only（読み取り専用）"
+msgstr "read-only (읽기 전용)"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "read-write"
+msgstr "read-write"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "read-write（読み取り＋書き込み）"
+msgstr "read-write (읽기＋쓰기)"
 
 #: src/lib/i18n-labels.ts
 msgid "SD (~57cm)"
@@ -402,6 +460,7 @@ msgstr "컬러"
 #: src/components/location/StorageCaseEditForm.tsx
 #: src/components/location/StorageCaseForm.tsx
 #: src/components/location/StorageLocationEditForm.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 #: src/components/ui/ConfirmSheet.tsx
 msgid "キャンセル"
 msgstr "취소"
@@ -468,6 +527,10 @@ msgstr "코디 이름"
 msgid "コーデ詳細"
 msgstr "코디 상세"
 
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "この API キーは一度だけ表示されます。閉じる前に必ずコピーしてください。"
+msgstr "이 API 키는 한 번만 표시됩니다. 닫기 전에 반드시 복사해 주세요."
+
 #: src/app/nfc-write/page.tsx
 msgid "このデバイスは NFC 書き込みに対応していません。Android Chrome をご利用ください。"
 msgstr "이 기기는 NFC 쓰기를 지원하지 않습니다. Android Chrome을 이용해 주세요."
@@ -487,6 +550,18 @@ msgstr "이 장소의 모든 옷을 확인 완료로 표시"
 #: src/components/scan/CheckoutConfirmSheet.tsx
 msgid "この引き出しの他の服、まだありますか？"
 msgstr "이 서랍의 다른 옷들, 아직 있나요?"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピー"
+msgstr "복사"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピーに失敗しました。手動でコピーしてください"
+msgstr "복사에 실패했습니다. 직접 복사해 주세요"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピー済み"
+msgstr "복사 완료"
 
 #: src/app/garments/page.tsx
 #: src/components/dashboard/WardrobeAnalytics.tsx
@@ -538,6 +613,10 @@ msgstr "스캔 완료"
 #: src/components/scan/ScanSessionPanel.tsx
 msgid "スキャン中の場所"
 msgstr "스캔 중인 장소"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "スコープ"
+msgstr "스코프"
 
 #: src/components/dashboard/StatsOverview.tsx
 #: src/components/garment/GarmentDetail.tsx
@@ -743,6 +822,10 @@ msgstr "바디 사이즈"
 msgid "ボトムス"
 msgstr "하의"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "まだ API キーがありません"
+msgstr "아직 API 키가 없습니다"
+
 #: src/app/coordinates/page.tsx
 msgid "まだコーデがありません"
 msgstr "아직 코디가 없습니다"
@@ -863,8 +946,16 @@ msgid "一覧に戻る"
 msgstr "목록으로 돌아가기"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
-msgid "下のリストから服を選択してください"
-msgstr "아래 목록에서 옷을 선택해 주세요."
+msgid "上へ"
+msgstr "위로"
+
+#: src/components/coordinate/CoordinateBuilder.tsx
+#~ msgid "下のリストから服を選択してください"
+#~ msgstr "아래 목록에서 옷을 선택해 주세요."
+
+#: src/components/coordinate/CoordinateBuilder.tsx
+msgid "下へ"
+msgstr "아래로"
 
 #: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
@@ -886,6 +977,10 @@ msgstr "지금 여기 없어도 확인"
 msgid "作成"
 msgstr "생성"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "作成日時"
+msgstr "생성일시"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "使用する服"
 msgstr "사용하는 옷"
@@ -893,6 +988,10 @@ msgstr "사용하는 옷"
 #: src/components/dashboard/CheckedOutSection.tsx
 msgid "使用中"
 msgstr "사용 중"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "例: agent-1"
+msgstr "예: agent-1"
 
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "例: ワンピース用"
@@ -966,6 +1065,10 @@ msgstr "첫 번째 인형을 등록해 보세요"
 msgid "最初のドール服を登録してみましょう"
 msgstr "첫 번째 인형 옷을 등록해 보세요"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "最終使用日時"
+msgstr "마지막 사용"
+
 #: src/components/dashboard/RecentItems.tsx
 msgid "最近のアイテム"
 msgstr "최근 아이템"
@@ -997,7 +1100,6 @@ msgstr "이전 페이지"
 msgid "前の値を適用"
 msgstr "이전 값 적용"
 
-#: src/components/coordinate/CoordinateBuilder.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/ui/Pagination.tsx
 msgid "前へ"
@@ -1062,6 +1164,7 @@ msgstr "합계"
 #: src/components/garment/bulk/BulkMetadataFormFields.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/garment/GarmentForm.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "名前"
 msgstr "이름"
 
@@ -1102,9 +1205,26 @@ msgstr "장소가 설정되었습니다"
 msgid "変更"
 msgstr "변경"
 
+#: src/app/settings/api-keys/page.tsx
+msgid "外部 AI エージェントから接続するための Personal Access Token を発行・管理します。"
+msgstr "외부 AI 에이전트에서 연결하기 위한 Personal Access Token을 발급·관리합니다."
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "外部エージェントから接続するための API キーを発行できます"
+msgstr "외부 에이전트에서 연결하기 위한 API 키를 발급할 수 있습니다"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "失効"
+msgstr "폐기"
+
 #: src/lib/i18n-labels.ts
 msgid "季節物 (90日)"
 msgstr "계절 옷 (90일)"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "完了"
+msgstr "완료"
 
 #: src/components/doll/DollDetail.tsx
 #: src/components/doll/DollDetail.tsx
@@ -1132,6 +1252,7 @@ msgstr "복원"
 
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
+#: src/app/settings/api-keys/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
@@ -1141,6 +1262,15 @@ msgstr "뒤로"
 #: src/components/coordinate/OriginBadge.tsx
 msgid "手動"
 msgstr "수동"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "新しい API キー"
+msgstr "새 API 키"
+
+#: src/app/settings/api-keys/page.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "新しい API キーを発行"
+msgstr "새 API 키 발급"
 
 #: src/components/digest/DigestBanner.tsx
 msgid "新しい週間レポートが届いています"
@@ -1225,6 +1355,10 @@ msgstr "옷 편집"
 msgid "服を選ぶ"
 msgstr "옷 선택"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "未使用"
+msgstr "사용 전"
+
 #: src/components/dashboard/StaleLocationItem.tsx
 msgid "未確認 {uncertainItemCount}着"
 msgstr "미확인 {uncertainItemCount}벌"
@@ -1251,7 +1385,6 @@ msgid "次のページ"
 msgstr "다음 페이지"
 
 #: src/app/nfc-write/page.tsx
-#: src/components/coordinate/CoordinateBuilder.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/bulk/CaptureCamera.tsx
 #: src/components/ui/Pagination.tsx
@@ -1266,11 +1399,19 @@ msgstr "매주 월요일에 자동 생성됩니다"
 msgid "状態"
 msgstr "상태"
 
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "生キーは発行直後の一度しか表示されません。安全な場所に保管してください。"
+msgstr "원본 키는 발급 직후 한 번만 표시됩니다. 안전한 곳에 보관해 주세요."
+
 #. placeholder {0}: status.completed
 #. placeholder {1}: status.total
 #: src/components/garment/bulk/BulkRegistrationProgress.tsx
 msgid "画像をアップロードしています ({0}/{1})"
 msgstr "이미지를 업로드하고 있습니다 ({0}/{1})"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "発行"
+msgstr "발급"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "登録された服がありません"
@@ -1411,6 +1552,10 @@ msgstr "확인 필요 아이템 ({0}건)"
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"
 msgstr "언어"
+
+#: src/components/auth/UserMenu.tsx
+msgid "設定"
+msgstr "설정"
 
 #: src/components/garment/DollCombobox.tsx
 msgid "該当するドールがありません"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -652,6 +652,10 @@ msgstr "套装"
 msgid "セット内容"
 msgstr "套装内容"
 
+#: src/app/signin/page.tsx
+msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+msgstr "使用社交账号登录后，即可使用 QR/NFC 扫描记录和 API 密钥发行等全部功能。"
+
 #: src/lib/i18n-labels.ts
 msgid "ソックス/タイツ"
 msgstr "袜子/连裤袜"
@@ -900,6 +904,11 @@ msgstr "重置"
 #: src/components/auth/UserMenu.tsx
 msgid "ログアウト"
 msgstr "退出登录"
+
+#: src/app/signin/page.tsx
+#: src/components/auth/UserMenu.tsx
+msgid "ログイン"
+msgstr "登录"
 
 #: src/app/garments/page.tsx
 #: src/lib/nav-items.ts
@@ -1253,6 +1262,7 @@ msgstr "恢复"
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
 #: src/app/settings/api-keys/page.tsx
+#: src/app/signin/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -142,6 +142,11 @@ msgstr "确定删除\"{0}\"吗？箱内的衣服将变为\"取出中\"状态。"
 msgid "「{0}」を削除しますか？この操作は取り消せません。"
 msgstr "确定删除「{0}」吗？此操作无法撤销。"
 
+#. placeholder {0}: revokingKey.name
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "「{0}」を失効します。失効したキーは復元できません。"
+msgstr "撤销「{0}」。撤销后的密钥无法恢复。"
+
 #. placeholder {0}: doll.name
 #. placeholder {0}: garment.name
 #: src/components/doll/DollDetail.tsx
@@ -157,6 +162,43 @@ msgstr "将「{0}」标记为丢失。收纳位置信息将被清除。"
 #: src/components/coordinate/OriginBadge.tsx
 msgid "AI"
 msgstr "AI"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "API キー"
+msgstr "API 密钥"
+
+#. placeholder {0}: target.name
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キー「{0}」を失効しました"
+msgstr "已撤销 API 密钥「{0}」"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キーの失効に失敗しました"
+msgstr "撤销 API 密钥失败"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "API キーの発行に失敗しました"
+msgstr "签发 API 密钥失败"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "API キーの読み込みに失敗しました"
+msgstr "加载 API 密钥失败"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーをコピー"
+msgstr "复制 API 密钥"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーをコピーしました"
+msgstr "已复制 API 密钥"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "API キーを失効"
+msgstr "撤销 API 密钥"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "API キーを発行しました"
+msgstr "已签发 API 密钥"
 
 #: src/app/garments/new/page.tsx
 #: src/app/garments/page.tsx
@@ -260,6 +302,22 @@ msgstr "信任度比 QR 扫描恢复得更保守（约 0.5）"
 #: src/components/garment/GarmentDetail.tsx
 msgid "QRを印刷"
 msgstr "打印QR"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "read-only"
+msgstr "read-only"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "read-only（読み取り専用）"
+msgstr "read-only（只读）"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "read-write"
+msgstr "read-write"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "read-write（読み取り＋書き込み）"
+msgstr "read-write（读取＋写入）"
 
 #: src/lib/i18n-labels.ts
 msgid "SD (~57cm)"
@@ -402,6 +460,7 @@ msgstr "颜色"
 #: src/components/location/StorageCaseEditForm.tsx
 #: src/components/location/StorageCaseForm.tsx
 #: src/components/location/StorageLocationEditForm.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 #: src/components/ui/ConfirmSheet.tsx
 msgid "キャンセル"
 msgstr "取消"
@@ -468,6 +527,10 @@ msgstr "搭配名称"
 msgid "コーデ詳細"
 msgstr "搭配详情"
 
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "この API キーは一度だけ表示されます。閉じる前に必ずコピーしてください。"
+msgstr "此 API 密钥仅显示一次。请在关闭前务必复制。"
+
 #: src/app/nfc-write/page.tsx
 msgid "このデバイスは NFC 書き込みに対応していません。Android Chrome をご利用ください。"
 msgstr "此设备不支持NFC写入。请使用Android Chrome。"
@@ -487,6 +550,18 @@ msgstr "将此位置的所有衣服标记为已确认"
 #: src/components/scan/CheckoutConfirmSheet.tsx
 msgid "この引き出しの他の服、まだありますか？"
 msgstr "这个抽屉里的其他衣服都还在吗？"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピー"
+msgstr "复制"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピーに失敗しました。手動でコピーしてください"
+msgstr "复制失败,请手动复制"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "コピー済み"
+msgstr "已复制"
 
 #: src/app/garments/page.tsx
 #: src/components/dashboard/WardrobeAnalytics.tsx
@@ -538,6 +613,10 @@ msgstr "已扫描"
 #: src/components/scan/ScanSessionPanel.tsx
 msgid "スキャン中の場所"
 msgstr "正在扫描的位置"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "スコープ"
+msgstr "范围"
 
 #: src/components/dashboard/StatsOverview.tsx
 #: src/components/garment/GarmentDetail.tsx
@@ -743,6 +822,10 @@ msgstr "身体尺寸"
 msgid "ボトムス"
 msgstr "下装"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "まだ API キーがありません"
+msgstr "尚无 API 密钥"
+
 #: src/app/coordinates/page.tsx
 msgid "まだコーデがありません"
 msgstr "还没有搭配"
@@ -863,8 +946,16 @@ msgid "一覧に戻る"
 msgstr "返回列表"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
-msgid "下のリストから服を選択してください"
-msgstr "请从下面的列表中选择衣服。"
+msgid "上へ"
+msgstr "上移"
+
+#: src/components/coordinate/CoordinateBuilder.tsx
+#~ msgid "下のリストから服を選択してください"
+#~ msgstr "请从下面的列表中选择衣服。"
+
+#: src/components/coordinate/CoordinateBuilder.tsx
+msgid "下へ"
+msgstr "下移"
 
 #: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
@@ -886,6 +977,10 @@ msgstr "不在现场也可确认"
 msgid "作成"
 msgstr "创建"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "作成日時"
+msgstr "创建时间"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "使用する服"
 msgstr "使用的衣服"
@@ -893,6 +988,10 @@ msgstr "使用的衣服"
 #: src/components/dashboard/CheckedOutSection.tsx
 msgid "使用中"
 msgstr "使用中"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "例: agent-1"
+msgstr "例如: agent-1"
 
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "例: ワンピース用"
@@ -966,6 +1065,10 @@ msgstr "来登记你的第一个娃娃吧"
 msgid "最初のドール服を登録してみましょう"
 msgstr "来登记你的第一件娃衣吧"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "最終使用日時"
+msgstr "最后使用时间"
+
 #: src/components/dashboard/RecentItems.tsx
 msgid "最近のアイテム"
 msgstr "最近的物品"
@@ -997,7 +1100,6 @@ msgstr "上一页"
 msgid "前の値を適用"
 msgstr "应用上一个值"
 
-#: src/components/coordinate/CoordinateBuilder.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/ui/Pagination.tsx
 msgid "前へ"
@@ -1062,6 +1164,7 @@ msgstr "合计"
 #: src/components/garment/bulk/BulkMetadataFormFields.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/garment/GarmentForm.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "名前"
 msgstr "名称"
 
@@ -1102,9 +1205,26 @@ msgstr "位置已设置"
 msgid "変更"
 msgstr "更改"
 
+#: src/app/settings/api-keys/page.tsx
+msgid "外部 AI エージェントから接続するための Personal Access Token を発行・管理します。"
+msgstr "为外部 AI 代理连接签发和管理 Personal Access Token。"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "外部エージェントから接続するための API キーを発行できます"
+msgstr "可签发供外部代理连接的 API 密钥"
+
+#: src/components/settings/api-key/ApiKeyList.tsx
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "失効"
+msgstr "撤销"
+
 #: src/lib/i18n-labels.ts
 msgid "季節物 (90日)"
 msgstr "季节性衣物 (90天)"
+
+#: src/components/settings/api-key/ApiKeyRevealSheet.tsx
+msgid "完了"
+msgstr "完成"
 
 #: src/components/doll/DollDetail.tsx
 #: src/components/doll/DollDetail.tsx
@@ -1132,6 +1252,7 @@ msgstr "恢复"
 
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
+#: src/app/settings/api-keys/page.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
@@ -1141,6 +1262,15 @@ msgstr "返回"
 #: src/components/coordinate/OriginBadge.tsx
 msgid "手動"
 msgstr "手动"
+
+#: src/app/settings/api-keys/page.tsx
+msgid "新しい API キー"
+msgstr "新建 API 密钥"
+
+#: src/app/settings/api-keys/page.tsx
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "新しい API キーを発行"
+msgstr "签发新的 API 密钥"
 
 #: src/components/digest/DigestBanner.tsx
 msgid "新しい週間レポートが届いています"
@@ -1225,6 +1355,10 @@ msgstr "编辑衣服"
 msgid "服を選ぶ"
 msgstr "选择衣服"
 
+#: src/components/settings/api-key/ApiKeyList.tsx
+msgid "未使用"
+msgstr "未使用"
+
 #: src/components/dashboard/StaleLocationItem.tsx
 msgid "未確認 {uncertainItemCount}着"
 msgstr "未确认 {uncertainItemCount}件"
@@ -1251,7 +1385,6 @@ msgid "次のページ"
 msgstr "下一页"
 
 #: src/app/nfc-write/page.tsx
-#: src/components/coordinate/CoordinateBuilder.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/bulk/CaptureCamera.tsx
 #: src/components/ui/Pagination.tsx
@@ -1266,11 +1399,19 @@ msgstr "每周一自动生成"
 msgid "状態"
 msgstr "状态"
 
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "生キーは発行直後の一度しか表示されません。安全な場所に保管してください。"
+msgstr "原始密钥仅在签发后显示一次。请妥善保管。"
+
 #. placeholder {0}: status.completed
 #. placeholder {1}: status.total
 #: src/components/garment/bulk/BulkRegistrationProgress.tsx
 msgid "画像をアップロードしています ({0}/{1})"
 msgstr "正在上传图片 ({0}/{1})"
+
+#: src/components/settings/api-key/ApiKeyCreateSheet.tsx
+msgid "発行"
+msgstr "签发"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "登録された服がありません"
@@ -1411,6 +1552,10 @@ msgstr "待确认的物品（{0}件）"
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"
 msgstr "语言"
+
+#: src/components/auth/UserMenu.tsx
+msgid "設定"
+msgstr "设置"
 
 #: src/components/garment/DollCombobox.tsx
 msgid "該当するドールがありません"

--- a/src/stores/apiKeyAtoms.ts
+++ b/src/stores/apiKeyAtoms.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { atom } from "jotai";
-import { unwrap } from "jotai/utils";
 import {
   createApiKey,
   listApiKeys,
@@ -19,15 +18,6 @@ export const apiKeysAtom = atom(
     return await listApiKeys();
   },
 );
-
-export const apiKeysUnwrappedAtom = unwrap(
-  apiKeysAtom,
-  (prev): readonly ApiKeySummary[] => prev ?? [],
-);
-
-export const refreshApiKeysAtom = atom(undefined, (_get, set) => {
-  set(apiKeysRefreshTriggerAtom, (prev) => prev + 1);
-});
 
 export const createApiKeyAtom = atom(
   undefined,

--- a/src/stores/apiKeyAtoms.ts
+++ b/src/stores/apiKeyAtoms.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { atom } from "jotai";
+import { unwrap } from "jotai/utils";
+import {
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+  type ApiKeyScope,
+  type ApiKeySummary,
+  type CreatedApiKey,
+} from "@/lib/auth";
+
+const apiKeysRefreshTriggerAtom = atom(0);
+
+export const apiKeysAtom = atom(
+  async (get): Promise<readonly ApiKeySummary[]> => {
+    get(apiKeysRefreshTriggerAtom);
+    return await listApiKeys();
+  },
+);
+
+export const apiKeysUnwrappedAtom = unwrap(
+  apiKeysAtom,
+  (prev): readonly ApiKeySummary[] => prev ?? [],
+);
+
+export const refreshApiKeysAtom = atom(undefined, (_get, set) => {
+  set(apiKeysRefreshTriggerAtom, (prev) => prev + 1);
+});
+
+export const createApiKeyAtom = atom(
+  undefined,
+  async (
+    _get,
+    set,
+    input: { readonly name: string; readonly scope: ApiKeyScope },
+  ): Promise<CreatedApiKey> => {
+    const created = await createApiKey(input);
+    set(apiKeysRefreshTriggerAtom, (prev) => prev + 1);
+    return created;
+  },
+);
+
+export const revokeApiKeyAtom = atom(
+  undefined,
+  async (_get, set, keyId: string): Promise<void> => {
+    await revokeApiKey(keyId);
+    set(apiKeysRefreshTriggerAtom, (prev) => prev + 1);
+  },
+);

--- a/src/stores/authAtoms.ts
+++ b/src/stores/authAtoms.ts
@@ -15,6 +15,7 @@ type AuthUser = {
 type AuthState = {
   readonly user: AuthUser | undefined;
   readonly isAuthenticated: boolean;
+  readonly isLoading: boolean;
 };
 
 const extractUser = (
@@ -37,12 +38,13 @@ export const authSessionAtom = atom(async (get): Promise<AuthState> => {
   get(authRefreshTriggerAtom);
   const session = await getSession().catch(() => undefined);
   const user = extractUser(session);
-  return { user, isAuthenticated: user !== undefined };
+  return { user, isAuthenticated: user !== undefined, isLoading: false };
 });
 
 export const authSessionUnwrappedAtom = unwrap(
   authSessionAtom,
-  (prev): AuthState => prev ?? { user: undefined, isAuthenticated: false },
+  (prev): AuthState =>
+    prev ?? { user: undefined, isAuthenticated: false, isLoading: true },
 );
 
 export const signOutAtom = atom(undefined, async (_get, set) => {

--- a/src/test/helpers/canvas.ts
+++ b/src/test/helpers/canvas.ts
@@ -1,4 +1,8 @@
 import { vi } from "vitest";
+import {
+  installObjectProperty,
+  restoreInstalledProperties,
+} from "@/test/helpers/propertyMock";
 
 type Canvas2DContextLike = {
   readonly drawImage: ReturnType<typeof vi.fn>;
@@ -13,49 +17,7 @@ type InstallCanvas2DContextOptions = {
   };
 };
 
-const originalDescriptors = new WeakMap<
-  object,
-  Map<string, PropertyDescriptor | undefined>
->();
-const touchedPrototypes = new Set<object>();
-
-const installPrototypeProperty = (
-  proto: object,
-  key: string,
-  value: unknown,
-): void => {
-  const existing = originalDescriptors.get(proto);
-  const perProto =
-    existing ?? new Map<string, PropertyDescriptor | undefined>();
-  if (existing === undefined) {
-    originalDescriptors.set(proto, perProto);
-    touchedPrototypes.add(proto);
-  }
-  if (!perProto.has(key)) {
-    perProto.set(key, Object.getOwnPropertyDescriptor(proto, key));
-  }
-  Object.defineProperty(proto, key, {
-    value,
-    writable: true,
-    configurable: true,
-  });
-};
-
-export const restoreCanvasMocks = (): void => {
-  touchedPrototypes.forEach((proto) => {
-    const perProto = originalDescriptors.get(proto);
-    if (perProto === undefined) return;
-    perProto.forEach((original, key) => {
-      if (original === undefined) {
-        Reflect.deleteProperty(proto, key);
-        return;
-      }
-      Object.defineProperty(proto, key, original);
-    });
-    originalDescriptors.delete(proto);
-  });
-  touchedPrototypes.clear();
-};
+export const restoreCanvasMocks = restoreInstalledProperties;
 
 export const installCanvas2DContext = (
   options: InstallCanvas2DContextOptions = {},
@@ -75,11 +37,7 @@ export const installCanvas2DContext = (
   };
 
   const getContext = vi.fn(() => ctx);
-  installPrototypeProperty(
-    HTMLCanvasElement.prototype,
-    "getContext",
-    getContext,
-  );
+  installObjectProperty(HTMLCanvasElement.prototype, "getContext", getContext);
   return { ctx, getContext };
 };
 
@@ -87,11 +45,7 @@ export const installCanvas2DContextNull = (): {
   readonly getContext: ReturnType<typeof vi.fn>;
 } => {
   const getContext = vi.fn(() => null);
-  installPrototypeProperty(
-    HTMLCanvasElement.prototype,
-    "getContext",
-    getContext,
-  );
+  installObjectProperty(HTMLCanvasElement.prototype, "getContext", getContext);
   return { getContext };
 };
 
@@ -101,7 +55,7 @@ export const installCanvasToBlob = (
   const toBlob = vi.fn((callback: (b: Blob | null) => void) => {
     callback(blob);
   });
-  installPrototypeProperty(HTMLCanvasElement.prototype, "toBlob", toBlob);
+  installObjectProperty(HTMLCanvasElement.prototype, "toBlob", toBlob);
   return { toBlob };
 };
 
@@ -109,7 +63,7 @@ export const installCanvasToDataURL = (
   dataUrl: string,
 ): { readonly toDataURL: ReturnType<typeof vi.fn> } => {
   const toDataURL = vi.fn(() => dataUrl);
-  installPrototypeProperty(HTMLCanvasElement.prototype, "toDataURL", toDataURL);
+  installObjectProperty(HTMLCanvasElement.prototype, "toDataURL", toDataURL);
   return { toDataURL };
 };
 
@@ -117,8 +71,8 @@ export const installVideoReadyState = (
   state: number,
   haveEnoughData = 4,
 ): void => {
-  installPrototypeProperty(HTMLVideoElement.prototype, "readyState", state);
-  installPrototypeProperty(
+  installObjectProperty(HTMLVideoElement.prototype, "readyState", state);
+  installObjectProperty(
     HTMLVideoElement.prototype,
     "HAVE_ENOUGH_DATA",
     haveEnoughData,

--- a/src/test/helpers/clipboard.ts
+++ b/src/test/helpers/clipboard.ts
@@ -1,38 +1,13 @@
 import { vi, type MockInstance } from "vitest";
+import { installObjectProperty } from "@/test/helpers/propertyMock";
 
 type WriteTextSpy = MockInstance<(text: string) => Promise<void>>;
-
-type ClipboardSpyState = {
-  readonly writeText: WriteTextSpy;
-};
-
-type RestoreState = {
-  readonly mode: "spy" | "define" | "none";
-  readonly target: object | undefined;
-  readonly originalDescriptor: PropertyDescriptor | undefined;
-  readonly spy: WriteTextSpy | undefined;
-};
-
-const initialRestore: RestoreState = {
-  mode: "none",
-  target: undefined,
-  originalDescriptor: undefined,
-  spy: undefined,
-};
-
-const spyMap = new Map<"v", ClipboardSpyState>();
-const restoreMap = new Map<"v", RestoreState>([["v", initialRestore]]);
-
-const getRestore = (): RestoreState => restoreMap.get("v") ?? initialRestore;
-const setRestore = (next: RestoreState): void => {
-  restoreMap.set("v", next);
-};
 
 type InstallOptions = {
   readonly shouldFail?: boolean;
 };
 
-const createImpl = (shouldFail: boolean) =>
+const createImpl = (shouldFail: boolean): WriteTextSpy =>
   shouldFail
     ? vi
         .fn<(text: string) => Promise<void>>()
@@ -41,61 +16,10 @@ const createImpl = (shouldFail: boolean) =>
 
 export const installClipboard = (
   options: InstallOptions = {},
-): ClipboardSpyState => {
-  const shouldFail = options.shouldFail === true;
-  const writeText = createImpl(shouldFail);
-
-  if (
-    navigator.clipboard !== undefined &&
-    typeof navigator.clipboard.writeText === "function"
-  ) {
-    const spy = vi
-      .spyOn(navigator.clipboard, "writeText")
-      .mockImplementation(writeText);
-    spyMap.set("v", { writeText: spy });
-    setRestore({
-      mode: "spy",
-      target: undefined,
-      originalDescriptor: undefined,
-      spy,
-    });
-    return { writeText: spy };
-  }
-
-  const originalDescriptor = Object.getOwnPropertyDescriptor(
-    navigator,
-    "clipboard",
-  );
-  Object.defineProperty(navigator, "clipboard", {
-    value: { writeText },
-    configurable: true,
-    writable: true,
-  });
-  spyMap.set("v", { writeText });
-  setRestore({
-    mode: "define",
-    target: navigator,
-    originalDescriptor,
-    spy: undefined,
-  });
+): { readonly writeText: WriteTextSpy } => {
+  const writeText = createImpl(options.shouldFail === true);
+  installObjectProperty(navigator, "clipboard", { writeText });
   return { writeText };
 };
 
-export const restoreClipboard = (): void => {
-  const restore = getRestore();
-  if (restore.mode === "spy" && restore.spy !== undefined) {
-    restore.spy.mockRestore();
-  } else if (restore.mode === "define" && restore.target !== undefined) {
-    if (restore.originalDescriptor === undefined) {
-      Reflect.deleteProperty(restore.target, "clipboard");
-    } else {
-      Object.defineProperty(
-        restore.target,
-        "clipboard",
-        restore.originalDescriptor,
-      );
-    }
-  }
-  spyMap.delete("v");
-  setRestore(initialRestore);
-};
+export { restoreInstalledProperties as restoreClipboard } from "@/test/helpers/propertyMock";

--- a/src/test/helpers/clipboard.ts
+++ b/src/test/helpers/clipboard.ts
@@ -1,0 +1,101 @@
+import { vi, type MockInstance } from "vitest";
+
+type WriteTextSpy = MockInstance<(text: string) => Promise<void>>;
+
+type ClipboardSpyState = {
+  readonly writeText: WriteTextSpy;
+};
+
+type RestoreState = {
+  readonly mode: "spy" | "define" | "none";
+  readonly target: object | undefined;
+  readonly originalDescriptor: PropertyDescriptor | undefined;
+  readonly spy: WriteTextSpy | undefined;
+};
+
+const initialRestore: RestoreState = {
+  mode: "none",
+  target: undefined,
+  originalDescriptor: undefined,
+  spy: undefined,
+};
+
+const spyMap = new Map<"v", ClipboardSpyState>();
+const restoreMap = new Map<"v", RestoreState>([["v", initialRestore]]);
+
+const getRestore = (): RestoreState => restoreMap.get("v") ?? initialRestore;
+const setRestore = (next: RestoreState): void => {
+  restoreMap.set("v", next);
+};
+
+type InstallOptions = {
+  readonly shouldFail?: boolean;
+};
+
+const createImpl = (shouldFail: boolean) =>
+  shouldFail
+    ? vi
+        .fn<(text: string) => Promise<void>>()
+        .mockRejectedValue(new Error("Clipboard write failed"))
+    : vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+
+export const installClipboard = (
+  options: InstallOptions = {},
+): ClipboardSpyState => {
+  const shouldFail = options.shouldFail === true;
+  const writeText = createImpl(shouldFail);
+
+  if (
+    navigator.clipboard !== undefined &&
+    typeof navigator.clipboard.writeText === "function"
+  ) {
+    const spy = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockImplementation(writeText);
+    spyMap.set("v", { writeText: spy });
+    setRestore({
+      mode: "spy",
+      target: undefined,
+      originalDescriptor: undefined,
+      spy,
+    });
+    return { writeText: spy };
+  }
+
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    "clipboard",
+  );
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+  spyMap.set("v", { writeText });
+  setRestore({
+    mode: "define",
+    target: navigator,
+    originalDescriptor,
+    spy: undefined,
+  });
+  return { writeText };
+};
+
+export const restoreClipboard = (): void => {
+  const restore = getRestore();
+  if (restore.mode === "spy" && restore.spy !== undefined) {
+    restore.spy.mockRestore();
+  } else if (restore.mode === "define" && restore.target !== undefined) {
+    if (restore.originalDescriptor === undefined) {
+      Reflect.deleteProperty(restore.target, "clipboard");
+    } else {
+      Object.defineProperty(
+        restore.target,
+        "clipboard",
+        restore.originalDescriptor,
+      );
+    }
+  }
+  spyMap.delete("v");
+  setRestore(initialRestore);
+};

--- a/src/test/helpers/propertyMock.ts
+++ b/src/test/helpers/propertyMock.ts
@@ -1,0 +1,43 @@
+const originalDescriptors = new WeakMap<
+  object,
+  Map<string, PropertyDescriptor | undefined>
+>();
+const touchedTargets = new Set<object>();
+
+export const installObjectProperty = (
+  target: object,
+  key: string,
+  value: unknown,
+): void => {
+  const existing = originalDescriptors.get(target);
+  const perTarget =
+    existing ?? new Map<string, PropertyDescriptor | undefined>();
+  if (existing === undefined) {
+    originalDescriptors.set(target, perTarget);
+    touchedTargets.add(target);
+  }
+  if (!perTarget.has(key)) {
+    perTarget.set(key, Object.getOwnPropertyDescriptor(target, key));
+  }
+  Object.defineProperty(target, key, {
+    value,
+    writable: true,
+    configurable: true,
+  });
+};
+
+export const restoreInstalledProperties = (): void => {
+  touchedTargets.forEach((target) => {
+    const perTarget = originalDescriptors.get(target);
+    if (perTarget === undefined) return;
+    perTarget.forEach((original, key) => {
+      if (original === undefined) {
+        Reflect.deleteProperty(target, key);
+        return;
+      }
+      Object.defineProperty(target, key, original);
+    });
+    originalDescriptors.delete(target);
+  });
+  touchedTargets.clear();
+};

--- a/src/test/mocks/modules/authClient.ts
+++ b/src/test/mocks/modules/authClient.ts
@@ -1,0 +1,120 @@
+import { vi } from "vitest";
+import type { ApiKeyScope, ApiKeySummary, CreatedApiKey } from "@/lib/auth";
+
+type Spies = {
+  readonly createApiKey: ReturnType<typeof vi.fn>;
+  readonly listApiKeys: ReturnType<typeof vi.fn>;
+  readonly revokeApiKey: ReturnType<typeof vi.fn>;
+};
+
+type State = {
+  readonly apiKeys: readonly ApiKeySummary[];
+  readonly nextCreated: CreatedApiKey | undefined;
+  readonly createShouldFail: boolean;
+  readonly listShouldFail: boolean;
+  readonly revokeShouldFail: boolean;
+  readonly spies: Spies;
+};
+
+const createInitial = (): State => ({
+  apiKeys: [],
+  nextCreated: undefined,
+  createShouldFail: false,
+  listShouldFail: false,
+  revokeShouldFail: false,
+  spies: {
+    createApiKey: vi.fn(),
+    listApiKeys: vi.fn(),
+    revokeApiKey: vi.fn(),
+  },
+});
+
+const initialState = createInitial();
+const stateMap = new Map<"v", State>([["v", initialState]]);
+const getState = (): State => stateMap.get("v") ?? initialState;
+const setState = (next: State): void => {
+  stateMap.set("v", next);
+};
+
+export const authClientFactory = async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    createApiKey: async (input: {
+      readonly name: string;
+      readonly scope: ApiKeyScope;
+    }): Promise<CreatedApiKey> => {
+      const s = getState();
+      s.spies.createApiKey(input);
+      if (s.createShouldFail) {
+        return await Promise.reject(new Error("Failed to create API key"));
+      }
+      const created: CreatedApiKey = s.nextCreated ?? {
+        id: `api-key-${Date.now()}`,
+        name: input.name,
+        scope: input.scope,
+        createdAt: Date.now(),
+        lastRequestAt: undefined,
+        enabled: true,
+        key: `dwk_test_${Math.random().toString(36).slice(2)}`,
+      };
+      setState({ ...s, apiKeys: [...s.apiKeys, created] });
+      return created;
+    },
+    listApiKeys: async (): Promise<readonly ApiKeySummary[]> => {
+      const s = getState();
+      s.spies.listApiKeys();
+      if (s.listShouldFail) {
+        return await Promise.reject(new Error("Failed to list API keys"));
+      }
+      return s.apiKeys;
+    },
+    revokeApiKey: async (keyId: string): Promise<void> => {
+      const s = getState();
+      s.spies.revokeApiKey(keyId);
+      if (s.revokeShouldFail) {
+        await Promise.reject(new Error("Failed to revoke API key"));
+        return;
+      }
+      setState({
+        ...s,
+        apiKeys: s.apiKeys.filter((k) => k.id !== keyId),
+      });
+    },
+  };
+};
+
+type SetupOverrides = {
+  readonly apiKeys?: readonly ApiKeySummary[];
+  readonly nextCreated?: CreatedApiKey;
+  readonly createShouldFail?: boolean;
+  readonly listShouldFail?: boolean;
+  readonly revokeShouldFail?: boolean;
+};
+
+export const setupAuthClient = (overrides: SetupOverrides = {}) => {
+  const current = getState();
+  current.spies.createApiKey.mockClear();
+  current.spies.listApiKeys.mockClear();
+  current.spies.revokeApiKey.mockClear();
+
+  setState({
+    apiKeys: overrides.apiKeys ?? [],
+    nextCreated: overrides.nextCreated,
+    createShouldFail: overrides.createShouldFail ?? false,
+    listShouldFail: overrides.listShouldFail ?? false,
+    revokeShouldFail: overrides.revokeShouldFail ?? false,
+    spies: current.spies,
+  });
+
+  return {
+    spies: current.spies,
+    setApiKeys: (apiKeys: readonly ApiKeySummary[]) => {
+      setState({ ...getState(), apiKeys });
+    },
+    setNextCreated: (created: CreatedApiKey) => {
+      setState({ ...getState(), nextCreated: created });
+    },
+  };
+};

--- a/src/test/mocks/modules/authClient.ts
+++ b/src/test/mocks/modules/authClient.ts
@@ -108,13 +108,5 @@ export const setupAuthClient = (overrides: SetupOverrides = {}) => {
     spies: current.spies,
   });
 
-  return {
-    spies: current.spies,
-    setApiKeys: (apiKeys: readonly ApiKeySummary[]) => {
-      setState({ ...getState(), apiKeys });
-    },
-    setNextCreated: (created: CreatedApiKey) => {
-      setState({ ...getState(), nextCreated: created });
-    },
-  };
+  return { spies: current.spies };
 };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -6,6 +6,7 @@ import { server } from "./mocks/server";
 import { resetTestDb } from "./mocks/db";
 import { clearTrpcOverrides } from "./mocks/trpc/handlerFactory";
 import { restoreCanvasMocks } from "./helpers/canvas";
+import { restoreClipboard } from "./helpers/clipboard";
 
 const navMod = await vi.hoisted(
   async () => await import("./mocks/modules/nextNavigation"),
@@ -37,6 +38,9 @@ const onlineMod = await vi.hoisted(
 const jsqrMod = await vi.hoisted(
   async () => await import("./mocks/modules/jsqr"),
 );
+const authClientMod = await vi.hoisted(
+  async () => await import("./mocks/modules/authClient"),
+);
 
 vi.mock("next/navigation", navMod.nextNavigationFactory);
 vi.mock("next/link", linkMod.nextLinkFactory);
@@ -48,6 +52,7 @@ vi.mock("@/hooks/useColorExtraction", colorMod.useColorExtractionFactory);
 vi.mock("@/hooks/useBrandSuggestions", brandMod.useBrandSuggestionsFactory);
 vi.mock("@/hooks/useOnlineSync", onlineMod.useOnlineSyncFactory);
 vi.mock("jsqr", jsqrMod.jsqrFactory);
+vi.mock("@/lib/auth", authClientMod.authClientFactory);
 
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
@@ -58,6 +63,7 @@ afterEach(async () => {
   server.resetHandlers();
   clearTrpcOverrides();
   restoreCanvasMocks();
+  restoreClipboard();
 
   resetTestDb();
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -5,8 +5,7 @@ import { afterAll, afterEach, beforeAll, vi } from "vitest";
 import { server } from "./mocks/server";
 import { resetTestDb } from "./mocks/db";
 import { clearTrpcOverrides } from "./mocks/trpc/handlerFactory";
-import { restoreCanvasMocks } from "./helpers/canvas";
-import { restoreClipboard } from "./helpers/clipboard";
+import { restoreInstalledProperties } from "./helpers/propertyMock";
 
 const navMod = await vi.hoisted(
   async () => await import("./mocks/modules/nextNavigation"),
@@ -62,8 +61,7 @@ afterEach(async () => {
   cleanup();
   server.resetHandlers();
   clearTrpcOverrides();
-  restoreCanvasMocks();
-  restoreClipboard();
+  restoreInstalledProperties();
 
   resetTestDb();
 


### PR DESCRIPTION
## Summary

- 外部 AI エージェント連携用に、ユーザー自身で Personal Access Token を発行・一覧・失効できる UI を `/settings/api-keys` に追加
- better-auth の `apiKeyClient` プラグインを `src/lib/auth.ts` に登録し、`createApiKey` / `listApiKeys` / `revokeApiKey` をラップ export
- スコープ（`read-only` / `read-write`）は `permissions` フィールド（`{all:["read"]}` / `{all:["read","write"]}`）に格納

## 主な変更ファイル

- `src/lib/auth.ts` — apiKeyClient 登録 + 3 関数（create/list/revoke）export + スコープ⇄permissions 変換
- `src/stores/apiKeyAtoms.ts` — Suspense 対応 `apiKeysAtom` + 操作 atoms
- `src/app/settings/api-keys/page.tsx` — ErrorBoundary + Suspense でラップしたページ本体
- `src/components/settings/api-key/`
    - `ApiKeyList.tsx` — 一覧表示（名前 / 作成日時 / スコープバッジ / 最終使用日時 / 失効ボタン + ConfirmSheet）
    - `ApiKeyCreateSheet.tsx` — 名前入力 + スコープ選択 + 発行
    - `ApiKeyRevealSheet.tsx` — 生キー一度きり表示モーダル + クリップボードコピー
- `src/components/auth/UserMenu.tsx` — TopBar に設定（歯車）リンクを追加
- テスト基盤
    - `src/test/mocks/modules/authClient.ts` — `vi.mock("@/lib/auth")` の集約モック
    - `src/test/helpers/clipboard.ts` — `installClipboard` / `restoreClipboard` ヘルパー
    - `src/test/setup.ts` に上記の登録 + `restoreClipboard` を `afterEach` に追加

## スコープ強制について（Verification §2 の補足）

issue 末尾 Verification §2 に「`read-only` で書き込み procedure を呼ぶと 403 相当」とあるが、Non-goals では「スコープに紐づく tool-level 認可は #123 / MCP 側で実装」とされている。

→ **本 PR ではスコープ値を `permissions` に保存・表示するのみ**。`read-only` キーで mutation を 403 で弾く強制ロジックは **#123 / MCP 実装** の責務として未対応。

## Test plan

### 自動テスト
- [x] `pnpm precheck:full` パス（typecheck + lint + format + i18n + 1039 tests pass）
- [x] `pnpm test:coverage` の branches 83.84% (>= 80%)
- [x] 新規 RTL テスト 4 ファイル / 13 ケース全て pass
    - ApiKeyList: EmptyState / 一覧表示 / 失効フロー
    - ApiKeyCreateSheet: 空欄 disabled / 発行 → onCreated
    - ApiKeyRevealSheet: 生キー表示 / コピー / 完了 / コピー失敗
    - page: 既存表示 / 発行 → 一覧反映 → 失効 → 一覧から消える、の一気通貫

### 手動確認（要 reviewer）
- [ ] `pnpm dev` + `pnpm dev:workers` でサインイン後、TopBar の歯車から `/settings/api-keys` へ
- [ ] 「新しい API キー」発行 → 名前 / scope=read-write → 生キー表示モーダル → コピー → 完了
- [ ] 一覧に発行したキーが `read-write` バッジ付きで表示される
- [ ] `curl -H "Authorization: Bearer <copied-key>" .../api/trpc/garment.list?...` が 200 を返す
- [ ] UI で revoke 後、同じ curl が 401 を返す（既存の `verifyApiKey` 経路）

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)