### PR TITLE
feat(mcp): /api/mcp にリモート MCP サーバーを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@hono/trpc-server": "^0.4.2",
     "@lingui/core": "^5.9.3",
     "@lingui/react": "^5.9.3",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@paralleldrive/cuid2": "^2.2.2",
     "@sentry/nextjs": "^10.43.0",
     "@serwist/turbopack": "^9.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@lingui/react':
         specifier: ^5.9.3
         version: 5.9.3(@lingui/babel-plugin-lingui-macro@5.9.3(babel-plugin-macros@3.1.0)(typescript@5.9.3))(babel-plugin-macros@3.1.0)(react@19.2.4)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.3.1
@@ -1483,6 +1486,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hono/trpc-server@0.4.2':
     resolution: {integrity: sha512-3TDrc42CZLgcTFkXQba+y7JlRWRiyw1AqhLqztWyNS2IFT+3bHld0lxKdGBttCtGKHYx0505dM67RMazjhdZqw==}
     engines: {node: '>=16.0.0'}
@@ -1793,6 +1802,16 @@ packages:
 
   '@messageformat/parser@5.1.1':
     resolution: {integrity: sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mongodb-js/saslprep@1.4.11':
     resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
@@ -3538,6 +3557,14 @@ packages:
       ajv:
         optional: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
@@ -3965,6 +3992,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -4510,6 +4541,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -4517,6 +4556,12 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.0:
+    resolution: {integrity: sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -4831,6 +4876,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -5099,6 +5148,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -5497,6 +5549,10 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -5668,6 +5724,10 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
@@ -6615,6 +6675,11 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -8048,6 +8113,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@hono/node-server@1.19.14(hono@4.12.7)':
+    dependencies:
+      hono: 4.12.7
+
   '@hono/trpc-server@0.4.2(@trpc/server@11.12.0(typescript@5.9.3))(hono@4.12.7)':
     dependencies:
       '@trpc/server': 11.12.0(typescript@5.9.3)
@@ -8337,6 +8406,28 @@ snapshots:
   '@messageformat/parser@5.1.1':
     dependencies:
       moo: 0.5.3
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.7)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.0(express@5.2.1)
+      hono: 4.12.7
+      jose: 6.2.1
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mongodb-js/saslprep@1.4.11':
     dependencies:
@@ -10202,6 +10293,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.20.0
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
       ajv: 8.20.0
@@ -10605,6 +10700,11 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -11245,6 +11345,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -11258,6 +11364,11 @@ snapshots:
       strip-final-newline: 2.0.0
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.0(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
 
   express@5.2.1:
     dependencies:
@@ -11601,6 +11712,8 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  ip-address@10.1.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
@@ -11853,6 +11966,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -12184,6 +12299,8 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -12388,6 +12505,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.59.1: {}
 
@@ -13483,5 +13602,9 @@ snapshots:
       '@speed-highlight/core': 1.2.14
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@4.3.6: {}

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -15,6 +15,7 @@ import { imageRoutes } from "./routes/image";
 import * as imageService from "./services/image-service";
 import { handleDigestCron } from "./scheduled/digest-cron";
 import { handleDigestQueue } from "./queues/digest-consumer";
+import { mcpHandler, mcpMethodNotAllowed } from "./mcp/server";
 
 type Variables = {
   auth: Auth;
@@ -106,6 +107,10 @@ app.get("/api/images/serve/*", async (c) => {
 });
 
 app.route("/api/images", imageRoutes);
+
+app.post("/api/mcp", mcpHandler);
+app.get("/api/mcp", mcpMethodNotAllowed);
+app.delete("/api/mcp", mcpMethodNotAllowed);
 
 app.use(
   "/trpc/*",

--- a/workers/src/lib/auth-resolver.ts
+++ b/workers/src/lib/auth-resolver.ts
@@ -2,7 +2,7 @@ import type { Auth } from "../auth";
 
 const BEARER_PREFIX = "bearer ";
 
-const extractBearerKey = (headers: Headers): string | undefined => {
+export const extractBearerKey = (headers: Headers): string | undefined => {
   const raw = headers.get("authorization");
   if (raw == null) {
     return undefined;

--- a/workers/src/mcp/adapter.test.ts
+++ b/workers/src/mcp/adapter.test.ts
@@ -1,0 +1,136 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import type { Context as HonoContext } from "hono";
+import {
+  createMcpCaller,
+  okResult,
+  errorResult,
+  toErrorResult,
+} from "./adapter";
+import {
+  createStubAuth,
+  createTestGarmentInput,
+  createTestLogger,
+  getTestDb,
+  resetDatabase,
+} from "../test/helpers";
+
+const createStubHonoContext = (): HonoContext => {
+  const headers = new Headers();
+  const stub = { req: { raw: { headers } } };
+  return stub as unknown as HonoContext;
+};
+
+describe("createMcpCaller", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("calls tRPC procedures with the provided userId", async () => {
+    const caller = createMcpCaller({
+      env,
+      auth: createStubAuth("mcp-user-001"),
+      honoContext: createStubHonoContext(),
+      logger: createTestLogger(),
+    });
+
+    const created = await caller.garment.create(createTestGarmentInput());
+
+    expect(created.userId).toBe("mcp-user-001");
+
+    const list = await caller.garment.list({});
+    expect(list).toHaveLength(1);
+    expect(list[0]?.userId).toBe("mcp-user-001");
+  });
+
+  it("does not leak data between users", async () => {
+    const aliceCaller = createMcpCaller({
+      env,
+      auth: createStubAuth("alice"),
+      honoContext: createStubHonoContext(),
+      logger: createTestLogger(),
+    });
+    const bobCaller = createMcpCaller({
+      env,
+      auth: createStubAuth("bob"),
+      honoContext: createStubHonoContext(),
+      logger: createTestLogger(),
+    });
+
+    await aliceCaller.garment.create(
+      createTestGarmentInput({ name: "Alice's dress" }),
+    );
+
+    const bobList = await bobCaller.garment.list({});
+    expect(bobList).toHaveLength(0);
+  });
+});
+
+describe("okResult", () => {
+  it("serializes object data as text + structuredContent", () => {
+    const data = { id: "abc", tags: ["a", "b"] };
+    const result = okResult(data);
+    expect(result.content).toEqual([
+      { type: "text", text: JSON.stringify(data) },
+    ]);
+    expect(result.structuredContent).toEqual(data);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("omits structuredContent when data is an array (MCP requires object)", () => {
+    const data = [{ id: "1" }, { id: "2" }];
+    const result = okResult(data);
+    expect(result.content[0]?.text).toBe(JSON.stringify(data));
+    expect(result.structuredContent).toBeUndefined();
+  });
+
+  it("omits structuredContent when data is null/undefined", () => {
+    expect(okResult(null).structuredContent).toBeUndefined();
+    expect(okResult(undefined).structuredContent).toBeUndefined();
+  });
+});
+
+describe("errorResult", () => {
+  it("returns isError true with serialized message", () => {
+    const result = errorResult("Forbidden", "FORBIDDEN");
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe(
+      JSON.stringify({ error: "Forbidden", code: "FORBIDDEN" }),
+    );
+  });
+
+  it("omits code when not provided", () => {
+    const result = errorResult("Internal error");
+    expect(result.content[0]?.text).toBe(
+      JSON.stringify({ error: "Internal error" }),
+    );
+  });
+});
+
+describe("toErrorResult", () => {
+  it("preserves TRPCError code and message", () => {
+    const err = new TRPCError({
+      code: "NOT_FOUND",
+      message: "Garment missing",
+    });
+    const result = toErrorResult(err);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Garment missing");
+    expect(result.content[0]?.text).toContain("NOT_FOUND");
+  });
+
+  it("preserves plain Error message without code", () => {
+    const result = toErrorResult(new Error("boom"));
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe(JSON.stringify({ error: "boom" }));
+  });
+
+  it("falls back to 'Unknown error' for non-Error throws", () => {
+    const result = toErrorResult("string thrown");
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe(
+      JSON.stringify({ error: "Unknown error" }),
+    );
+  });
+});

--- a/workers/src/mcp/adapter.test.ts
+++ b/workers/src/mcp/adapter.test.ts
@@ -9,13 +9,11 @@ import {
   forbiddenResult,
 } from "./adapter";
 import {
-  createStubAuth,
   createTestGarmentInput,
   createTestLogger,
   getTestDb,
   resetDatabase,
 } from "../test/helpers";
-import { createStubHonoContext } from "../test/mcp-helpers";
 
 describe("createMcpCaller", () => {
   beforeEach(async () => {
@@ -25,8 +23,7 @@ describe("createMcpCaller", () => {
   it("calls tRPC procedures with the provided userId", async () => {
     const caller = createMcpCaller({
       env,
-      auth: createStubAuth("mcp-user-001"),
-      honoContext: createStubHonoContext(),
+      userId: "mcp-user-001",
       logger: createTestLogger(),
     });
 
@@ -42,14 +39,12 @@ describe("createMcpCaller", () => {
   it("does not leak data between users", async () => {
     const aliceCaller = createMcpCaller({
       env,
-      auth: createStubAuth("alice"),
-      honoContext: createStubHonoContext(),
+      userId: "alice",
       logger: createTestLogger(),
     });
     const bobCaller = createMcpCaller({
       env,
-      auth: createStubAuth("bob"),
-      honoContext: createStubHonoContext(),
+      userId: "bob",
       logger: createTestLogger(),
     });
 

--- a/workers/src/mcp/adapter.test.ts
+++ b/workers/src/mcp/adapter.test.ts
@@ -79,6 +79,18 @@ describe("okResult", () => {
     expect(okResult(null).structuredContent).toBeUndefined();
     expect(okResult(undefined).structuredContent).toBeUndefined();
   });
+
+  it("emits a string text field even when data is undefined (MCP TextContent contract)", () => {
+    // JSON.stringify(undefined) returns the value undefined (not a string),
+    // which would violate MCP TextContent.text: string. Must coerce.
+    const result = okResult(undefined);
+    expect(typeof result.content[0]?.text).toBe("string");
+    expect(result.content[0]?.text).toBe("null");
+  });
+
+  it("emits the JSON literal for null", () => {
+    expect(okResult(null).content[0]?.text).toBe("null");
+  });
 });
 
 describe("errorResult / forbiddenResult", () => {

--- a/workers/src/mcp/adapter.test.ts
+++ b/workers/src/mcp/adapter.test.ts
@@ -1,12 +1,12 @@
 import { env } from "cloudflare:test";
 import { describe, it, expect, beforeEach } from "vitest";
 import { TRPCError } from "@trpc/server";
-import type { Context as HonoContext } from "hono";
 import {
   createMcpCaller,
   okResult,
   errorResult,
   toErrorResult,
+  forbiddenResult,
 } from "./adapter";
 import {
   createStubAuth,
@@ -15,12 +15,7 @@ import {
   getTestDb,
   resetDatabase,
 } from "../test/helpers";
-
-const createStubHonoContext = (): HonoContext => {
-  const headers = new Headers();
-  const stub = { req: { raw: { headers } } };
-  return stub as unknown as HonoContext;
-};
+import { createStubHonoContext } from "../test/mcp-helpers";
 
 describe("createMcpCaller", () => {
   beforeEach(async () => {
@@ -91,7 +86,7 @@ describe("okResult", () => {
   });
 });
 
-describe("errorResult", () => {
+describe("errorResult / forbiddenResult", () => {
   it("returns isError true with serialized message", () => {
     const result = errorResult("Forbidden", "FORBIDDEN");
     expect(result.isError).toBe(true);
@@ -105,6 +100,13 @@ describe("errorResult", () => {
     expect(result.content[0]?.text).toBe(
       JSON.stringify({ error: "Internal error" }),
     );
+  });
+
+  it("forbiddenResult interpolates the required scope", () => {
+    const result = forbiddenResult("write");
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("write scope required");
+    expect(result.content[0]?.text).toContain("FORBIDDEN");
   });
 });
 

--- a/workers/src/mcp/adapter.ts
+++ b/workers/src/mcp/adapter.ts
@@ -53,6 +53,9 @@ export const errorResult = (
   isError: true,
 });
 
+export const forbiddenResult = (requiredScope: string): CallToolResult =>
+  errorResult(`Forbidden: ${requiredScope} scope required`, "FORBIDDEN");
+
 export const toErrorResult = (err: unknown): CallToolResult => {
   if (err instanceof TRPCError) {
     return errorResult(err.message, err.code);
@@ -90,9 +93,4 @@ export const safeCall = async <T>(
     return { ok: false, error: value.error };
   }
   return { ok: true, value };
-};
-
-export type McpToolHandlerContext = {
-  readonly caller: McpCaller;
-  readonly logger: Logger;
 };

--- a/workers/src/mcp/adapter.ts
+++ b/workers/src/mcp/adapter.ts
@@ -1,10 +1,8 @@
-import type { Context as HonoContext } from "hono";
 import { TRPCError } from "@trpc/server";
 import { createCallerFactory } from "../trpc/index";
 import type { TRPCContext } from "../trpc/index";
 import { appRouter } from "../trpc/router";
 import type { Env } from "../types";
-import type { Auth } from "../auth";
 import type { Logger } from "../lib/logger";
 
 const createCaller = createCallerFactory(appRouter);
@@ -13,19 +11,16 @@ export type McpCaller = ReturnType<typeof createCaller>;
 
 export const createMcpCaller = ({
   env,
-  auth,
-  honoContext,
+  userId,
   logger,
 }: {
   readonly env: Env;
-  readonly auth: Auth;
-  readonly honoContext: HonoContext;
+  readonly userId: string;
   readonly logger: Logger;
 }): McpCaller => {
   const ctx: TRPCContext = {
     env,
-    auth,
-    honoContext,
+    preAuthenticatedUserId: userId,
     logger: logger.child({ source: "mcp" }),
   };
   return createCaller(ctx);

--- a/workers/src/mcp/adapter.ts
+++ b/workers/src/mcp/adapter.ts
@@ -35,8 +35,13 @@ export type CallToolResult = {
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
+// JSON.stringify(undefined) returns undefined (not a string), which would
+// violate MCP TextContent's `text: string` contract; coerce to "null".
+const safeStringify = (data: unknown): string =>
+  data === undefined ? "null" : JSON.stringify(data);
+
 export const okResult = (data: unknown): CallToolResult => ({
-  content: [{ type: "text", text: JSON.stringify(data) }],
+  content: [{ type: "text", text: safeStringify(data) }],
   ...(isPlainRecord(data) && { structuredContent: data }),
 });
 

--- a/workers/src/mcp/adapter.ts
+++ b/workers/src/mcp/adapter.ts
@@ -1,0 +1,98 @@
+import type { Context as HonoContext } from "hono";
+import { TRPCError } from "@trpc/server";
+import { createCallerFactory } from "../trpc/index";
+import type { TRPCContext } from "../trpc/index";
+import { appRouter } from "../trpc/router";
+import type { Env } from "../types";
+import type { Auth } from "../auth";
+import type { Logger } from "../lib/logger";
+
+const createCaller = createCallerFactory(appRouter);
+
+export type McpCaller = ReturnType<typeof createCaller>;
+
+export const createMcpCaller = ({
+  env,
+  auth,
+  honoContext,
+  logger,
+}: {
+  readonly env: Env;
+  readonly auth: Auth;
+  readonly honoContext: HonoContext;
+  readonly logger: Logger;
+}): McpCaller => {
+  const ctx: TRPCContext = {
+    env,
+    auth,
+    honoContext,
+    logger: logger.child({ source: "mcp" }),
+  };
+  return createCaller(ctx);
+};
+
+export type CallToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+};
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+export const okResult = (data: unknown): CallToolResult => ({
+  content: [{ type: "text", text: JSON.stringify(data) }],
+  ...(isPlainRecord(data) && { structuredContent: data }),
+});
+
+export const errorResult = (
+  message: string,
+  code?: string,
+): CallToolResult => ({
+  content: [{ type: "text", text: JSON.stringify({ error: message, code }) }],
+  isError: true,
+});
+
+export const toErrorResult = (err: unknown): CallToolResult => {
+  if (err instanceof TRPCError) {
+    return errorResult(err.message, err.code);
+  }
+  if (err instanceof Error) {
+    return errorResult(err.message);
+  }
+  return errorResult("Unknown error");
+};
+
+export type SafeCallResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: unknown };
+
+const SAFE_CALL_FAILURE_KEY = "__mcpSafeCallFailure" as const;
+type FailureBox = {
+  readonly [SAFE_CALL_FAILURE_KEY]: true;
+  readonly error: unknown;
+};
+
+export const safeCall = async <T>(
+  promise: Promise<T>,
+): Promise<SafeCallResult<T>> => {
+  const value: T | FailureBox = await promise.catch(
+    (error: unknown): FailureBox => ({
+      [SAFE_CALL_FAILURE_KEY]: true,
+      error,
+    }),
+  );
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    SAFE_CALL_FAILURE_KEY in value
+  ) {
+    return { ok: false, error: value.error };
+  }
+  return { ok: true, value };
+};
+
+export type McpToolHandlerContext = {
+  readonly caller: McpCaller;
+  readonly logger: Logger;
+};

--- a/workers/src/mcp/auth.test.ts
+++ b/workers/src/mcp/auth.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Auth } from "../auth";
+import { resolveMcpAuth } from "./auth";
+
+type VerifyFn = (args: { body: { key: string } }) => Promise<unknown>;
+
+const createMockAuth = (verifyApiKey: VerifyFn): Auth => {
+  const stub = {
+    api: { verifyApiKey },
+  };
+  return stub as unknown as Auth;
+};
+
+const headersWith = (auth: string | undefined): Headers => {
+  const headers = new Headers();
+  if (auth !== undefined) {
+    headers.set("authorization", auth);
+  }
+  return headers;
+};
+
+describe("resolveMcpAuth", () => {
+  it("returns undefined when Authorization header is missing", async () => {
+    const verify = vi.fn();
+    const result = await resolveMcpAuth({
+      auth: createMockAuth(verify),
+      headers: headersWith(undefined),
+    });
+    expect(result).toBeUndefined();
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for non-Bearer authorization scheme", async () => {
+    const verify = vi.fn();
+    const result = await resolveMcpAuth({
+      auth: createMockAuth(verify),
+      headers: headersWith("Basic dXNlcjpwYXNz"),
+    });
+    expect(result).toBeUndefined();
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when Bearer key is empty", async () => {
+    const verify = vi.fn();
+    const result = await resolveMcpAuth({
+      auth: createMockAuth(verify),
+      headers: headersWith("Bearer "),
+    });
+    expect(result).toBeUndefined();
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when verifyApiKey reports invalid", async () => {
+    const verify = vi.fn().mockResolvedValue({ valid: false });
+    const result = await resolveMcpAuth({
+      auth: createMockAuth(verify),
+      headers: headersWith("Bearer abc123"),
+    });
+    expect(result).toBeUndefined();
+    expect(verify).toHaveBeenCalledWith({ body: { key: "abc123" } });
+  });
+
+  it("returns undefined when verifyApiKey throws", async () => {
+    const verify = vi.fn().mockRejectedValue(new Error("DB error"));
+    const result = await resolveMcpAuth({
+      auth: createMockAuth(verify),
+      headers: headersWith("Bearer abc123"),
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when referenceId is missing", async () => {
+    const verify = vi.fn().mockResolvedValue({
+      valid: true,
+      key: { permissions: { mcp: ["read"] } },
+    });
+    const result = await resolveMcpAuth({
+      auth: createMockAuth(verify),
+      headers: headersWith("Bearer abc123"),
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when permissions has no mcp scope", async () => {
+    const verify = vi.fn().mockResolvedValue({
+      valid: true,
+      key: { referenceId: "user-1", permissions: {} },
+    });
+    const result = await resolveMcpAuth({
+      auth: createMockAuth(verify),
+      headers: headersWith("Bearer abc123"),
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns read scope for { mcp: ['read'] }", async () => {
+    const verify = vi.fn().mockResolvedValue({
+      valid: true,
+      key: { referenceId: "user-1", permissions: { mcp: ["read"] } },
+    });
+    const result = await resolveMcpAuth({
+      auth: createMockAuth(verify),
+      headers: headersWith("Bearer key-read"),
+    });
+    expect(result).toEqual({ userId: "user-1", scope: "read" });
+  });
+
+  it("returns write scope for { mcp: ['read', 'write'] }", async () => {
+    const verify = vi.fn().mockResolvedValue({
+      valid: true,
+      key: {
+        referenceId: "user-2",
+        permissions: { mcp: ["read", "write"] },
+      },
+    });
+    const result = await resolveMcpAuth({
+      auth: createMockAuth(verify),
+      headers: headersWith("Bearer key-write"),
+    });
+    expect(result).toEqual({ userId: "user-2", scope: "write" });
+  });
+
+  it("accepts case-insensitive Bearer scheme", async () => {
+    const verify = vi.fn().mockResolvedValue({
+      valid: true,
+      key: { referenceId: "user-3", permissions: { mcp: ["read"] } },
+    });
+    const result = await resolveMcpAuth({
+      auth: createMockAuth(verify),
+      headers: headersWith("bearer xyz"),
+    });
+    expect(result).toEqual({ userId: "user-3", scope: "read" });
+  });
+});

--- a/workers/src/mcp/auth.test.ts
+++ b/workers/src/mcp/auth.test.ts
@@ -1,15 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import type { Auth } from "../auth";
 import { resolveMcpAuth } from "./auth";
-
-type VerifyFn = (args: { body: { key: string } }) => Promise<unknown>;
-
-const createMockAuth = (verifyApiKey: VerifyFn): Auth => {
-  const stub = {
-    api: { verifyApiKey },
-  };
-  return stub as unknown as Auth;
-};
+import { createApiKeyAuthStub } from "../test/mcp-helpers";
 
 const headersWith = (auth: string | undefined): Headers => {
   const headers = new Headers();
@@ -23,7 +14,7 @@ describe("resolveMcpAuth", () => {
   it("returns undefined when Authorization header is missing", async () => {
     const verify = vi.fn();
     const result = await resolveMcpAuth({
-      auth: createMockAuth(verify),
+      auth: createApiKeyAuthStub(verify),
       headers: headersWith(undefined),
     });
     expect(result).toBeUndefined();
@@ -33,7 +24,7 @@ describe("resolveMcpAuth", () => {
   it("returns undefined for non-Bearer authorization scheme", async () => {
     const verify = vi.fn();
     const result = await resolveMcpAuth({
-      auth: createMockAuth(verify),
+      auth: createApiKeyAuthStub(verify),
       headers: headersWith("Basic dXNlcjpwYXNz"),
     });
     expect(result).toBeUndefined();
@@ -43,7 +34,7 @@ describe("resolveMcpAuth", () => {
   it("returns undefined when Bearer key is empty", async () => {
     const verify = vi.fn();
     const result = await resolveMcpAuth({
-      auth: createMockAuth(verify),
+      auth: createApiKeyAuthStub(verify),
       headers: headersWith("Bearer "),
     });
     expect(result).toBeUndefined();
@@ -53,7 +44,7 @@ describe("resolveMcpAuth", () => {
   it("returns undefined when verifyApiKey reports invalid", async () => {
     const verify = vi.fn().mockResolvedValue({ valid: false });
     const result = await resolveMcpAuth({
-      auth: createMockAuth(verify),
+      auth: createApiKeyAuthStub(verify),
       headers: headersWith("Bearer abc123"),
     });
     expect(result).toBeUndefined();
@@ -63,7 +54,7 @@ describe("resolveMcpAuth", () => {
   it("returns undefined when verifyApiKey throws", async () => {
     const verify = vi.fn().mockRejectedValue(new Error("DB error"));
     const result = await resolveMcpAuth({
-      auth: createMockAuth(verify),
+      auth: createApiKeyAuthStub(verify),
       headers: headersWith("Bearer abc123"),
     });
     expect(result).toBeUndefined();
@@ -75,7 +66,7 @@ describe("resolveMcpAuth", () => {
       key: { permissions: { mcp: ["read"] } },
     });
     const result = await resolveMcpAuth({
-      auth: createMockAuth(verify),
+      auth: createApiKeyAuthStub(verify),
       headers: headersWith("Bearer abc123"),
     });
     expect(result).toBeUndefined();
@@ -87,7 +78,7 @@ describe("resolveMcpAuth", () => {
       key: { referenceId: "user-1", permissions: {} },
     });
     const result = await resolveMcpAuth({
-      auth: createMockAuth(verify),
+      auth: createApiKeyAuthStub(verify),
       headers: headersWith("Bearer abc123"),
     });
     expect(result).toBeUndefined();
@@ -99,7 +90,7 @@ describe("resolveMcpAuth", () => {
       key: { referenceId: "user-1", permissions: { mcp: ["read"] } },
     });
     const result = await resolveMcpAuth({
-      auth: createMockAuth(verify),
+      auth: createApiKeyAuthStub(verify),
       headers: headersWith("Bearer key-read"),
     });
     expect(result).toEqual({ userId: "user-1", scope: "read" });
@@ -114,7 +105,7 @@ describe("resolveMcpAuth", () => {
       },
     });
     const result = await resolveMcpAuth({
-      auth: createMockAuth(verify),
+      auth: createApiKeyAuthStub(verify),
       headers: headersWith("Bearer key-write"),
     });
     expect(result).toEqual({ userId: "user-2", scope: "write" });
@@ -126,7 +117,7 @@ describe("resolveMcpAuth", () => {
       key: { referenceId: "user-3", permissions: { mcp: ["read"] } },
     });
     const result = await resolveMcpAuth({
-      auth: createMockAuth(verify),
+      auth: createApiKeyAuthStub(verify),
       headers: headersWith("bearer xyz"),
     });
     expect(result).toEqual({ userId: "user-3", scope: "read" });

--- a/workers/src/mcp/auth.ts
+++ b/workers/src/mcp/auth.ts
@@ -1,0 +1,53 @@
+import type { Auth } from "../auth";
+import { parsePermissions, type McpScope } from "./scopes";
+
+export type McpAuth = {
+  readonly userId: string;
+  readonly scope: McpScope;
+};
+
+const BEARER_PREFIX = "bearer ";
+
+const extractBearer = (headers: Headers): string | undefined => {
+  const raw = headers.get("authorization");
+  if (raw == null) {
+    return undefined;
+  }
+  if (!raw.toLowerCase().startsWith(BEARER_PREFIX)) {
+    return undefined;
+  }
+  const key = raw.slice(BEARER_PREFIX.length).trim();
+  return key !== "" ? key : undefined;
+};
+
+export const resolveMcpAuth = async ({
+  auth,
+  headers,
+}: {
+  readonly auth: Auth;
+  readonly headers: Headers;
+}): Promise<McpAuth | undefined> => {
+  const key = extractBearer(headers);
+  if (key === undefined) {
+    return undefined;
+  }
+
+  const result = await auth.api
+    .verifyApiKey({ body: { key } })
+    .catch(() => undefined);
+  if (result?.valid !== true) {
+    return undefined;
+  }
+
+  const userId = result.key?.referenceId;
+  if (userId === undefined || userId === "") {
+    return undefined;
+  }
+
+  const scope = parsePermissions(result.key?.permissions);
+  if (scope === undefined) {
+    return undefined;
+  }
+
+  return { userId, scope };
+};

--- a/workers/src/mcp/auth.ts
+++ b/workers/src/mcp/auth.ts
@@ -1,23 +1,10 @@
 import type { Auth } from "../auth";
+import { extractBearerKey } from "../lib/auth-resolver";
 import { parsePermissions, type McpScope } from "./scopes";
 
 export type McpAuth = {
   readonly userId: string;
   readonly scope: McpScope;
-};
-
-const BEARER_PREFIX = "bearer ";
-
-const extractBearer = (headers: Headers): string | undefined => {
-  const raw = headers.get("authorization");
-  if (raw == null) {
-    return undefined;
-  }
-  if (!raw.toLowerCase().startsWith(BEARER_PREFIX)) {
-    return undefined;
-  }
-  const key = raw.slice(BEARER_PREFIX.length).trim();
-  return key !== "" ? key : undefined;
 };
 
 export const resolveMcpAuth = async ({
@@ -27,7 +14,7 @@ export const resolveMcpAuth = async ({
   readonly auth: Auth;
   readonly headers: Headers;
 }): Promise<McpAuth | undefined> => {
-  const key = extractBearer(headers);
+  const key = extractBearerKey(headers);
   if (key === undefined) {
     return undefined;
   }

--- a/workers/src/mcp/scopes.test.ts
+++ b/workers/src/mcp/scopes.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { parsePermissions, hasScope, TOOL_REQUIRED_SCOPE } from "./scopes";
+
+describe("parsePermissions", () => {
+  it("returns 'write' when mcp permissions include write", () => {
+    expect(parsePermissions({ mcp: ["read", "write"] })).toBe("write");
+  });
+
+  it("returns 'read' when mcp permissions only include read", () => {
+    expect(parsePermissions({ mcp: ["read"] })).toBe("read");
+  });
+
+  it("prefers write when both are present in any order", () => {
+    expect(parsePermissions({ mcp: ["write", "read"] })).toBe("write");
+    expect(parsePermissions({ mcp: ["write"] })).toBe("write");
+  });
+
+  it("returns undefined when mcp key is missing", () => {
+    expect(parsePermissions({})).toBeUndefined();
+    expect(parsePermissions({ other: ["read"] })).toBeUndefined();
+  });
+
+  it("returns undefined when mcp value is not an array", () => {
+    expect(parsePermissions({ mcp: "read" })).toBeUndefined();
+    expect(parsePermissions({ mcp: { read: true } })).toBeUndefined();
+  });
+
+  it("returns undefined when mcp array does not include read or write", () => {
+    expect(parsePermissions({ mcp: [] })).toBeUndefined();
+    expect(parsePermissions({ mcp: ["admin"] })).toBeUndefined();
+  });
+
+  it("returns undefined for null or non-object input", () => {
+    expect(parsePermissions(null)).toBeUndefined();
+    expect(parsePermissions(undefined)).toBeUndefined();
+    expect(parsePermissions("read")).toBeUndefined();
+    expect(parsePermissions(123)).toBeUndefined();
+  });
+});
+
+describe("hasScope", () => {
+  it("read scope can access read tools", () => {
+    expect(hasScope("read", "read")).toBe(true);
+  });
+
+  it("read scope cannot access write tools", () => {
+    expect(hasScope("read", "write")).toBe(false);
+  });
+
+  it("write scope can access read tools", () => {
+    expect(hasScope("write", "read")).toBe(true);
+  });
+
+  it("write scope can access write tools", () => {
+    expect(hasScope("write", "write")).toBe(true);
+  });
+});
+
+describe("TOOL_REQUIRED_SCOPE", () => {
+  it("only includes whitelisted tools", () => {
+    expect(Object.keys(TOOL_REQUIRED_SCOPE).sort()).toEqual([
+      "add_garment_tags",
+      "get_garment",
+      "get_organization_digest",
+      "get_storage_case",
+      "list_dolls",
+      "list_garments",
+      "list_storage_cases",
+    ]);
+  });
+
+  it("flags add_garment_tags as the only write tool", () => {
+    const writeOnly = Object.entries(TOOL_REQUIRED_SCOPE)
+      .filter(([, scope]) => scope === "write")
+      .map(([name]) => name);
+    expect(writeOnly).toEqual(["add_garment_tags"]);
+  });
+});

--- a/workers/src/mcp/scopes.ts
+++ b/workers/src/mcp/scopes.ts
@@ -1,0 +1,42 @@
+export type McpScope = "read" | "write";
+
+const SCOPE_KEY = "mcp" as const;
+const SCOPE_READ = "read" as const;
+const SCOPE_WRITE = "write" as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+export const parsePermissions = (
+  permissions: unknown,
+): McpScope | undefined => {
+  if (!isRecord(permissions)) {
+    return undefined;
+  }
+  const actions = permissions[SCOPE_KEY];
+  if (!Array.isArray(actions)) {
+    return undefined;
+  }
+  if (actions.includes(SCOPE_WRITE)) {
+    return SCOPE_WRITE;
+  }
+  if (actions.includes(SCOPE_READ)) {
+    return SCOPE_READ;
+  }
+  return undefined;
+};
+
+export const TOOL_REQUIRED_SCOPE = {
+  list_garments: SCOPE_READ,
+  get_garment: SCOPE_READ,
+  list_dolls: SCOPE_READ,
+  list_storage_cases: SCOPE_READ,
+  get_storage_case: SCOPE_READ,
+  get_organization_digest: SCOPE_READ,
+  add_garment_tags: SCOPE_WRITE,
+} as const satisfies Record<string, McpScope>;
+
+export type McpToolName = keyof typeof TOOL_REQUIRED_SCOPE;
+
+export const hasScope = (current: McpScope, required: McpScope): boolean =>
+  required === SCOPE_READ ? true : current === SCOPE_WRITE;

--- a/workers/src/mcp/server.test.ts
+++ b/workers/src/mcp/server.test.ts
@@ -1,0 +1,140 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { mcpHandler, mcpMethodNotAllowed } from "./server";
+import type { Auth } from "../auth";
+import { createLogger } from "../lib/logger";
+import type { Logger } from "../lib/logger";
+import type { Env } from "../types";
+import { resetDatabase, getTestDb } from "../test/helpers";
+
+type TestVariables = {
+  auth: Auth;
+  requestId: string;
+  logger: Logger;
+};
+
+const buildApp = (auth: Auth) => {
+  const app = new Hono<{ Bindings: Env; Variables: TestVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("requestId", "test-req-id");
+    c.set("logger", createLogger({ minLevel: "error" }));
+    c.set("auth", auth);
+    await next();
+  });
+  app.post("/api/mcp", mcpHandler);
+  app.get("/api/mcp", mcpMethodNotAllowed);
+  app.delete("/api/mcp", mcpMethodNotAllowed);
+  return app;
+};
+
+const buildAuth = (
+  verifyApiKey: (args: { body: { key: string } }) => Promise<unknown>,
+): Auth => {
+  const stub = { api: { verifyApiKey } };
+  return stub as unknown as Auth;
+};
+
+describe("/api/mcp Hono handler", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("rejects requests without Bearer token with 401 + JSON-RPC error", async () => {
+    const auth = buildAuth(vi.fn());
+    const app = buildApp(auth);
+    const res = await app.request(
+      "/api/mcp",
+      { method: "POST", body: JSON.stringify({}) },
+      env,
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      jsonrpc: "2.0",
+      error: { code: -32001, message: "Unauthorized" },
+      id: null,
+    });
+  });
+
+  it("rejects API keys without mcp scope with 401", async () => {
+    const auth = buildAuth(
+      vi.fn().mockResolvedValue({
+        valid: true,
+        key: { referenceId: "user-1", permissions: {} },
+      }),
+    );
+    const app = buildApp(auth);
+    const res = await app.request(
+      "/api/mcp",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer test-key" },
+        body: JSON.stringify({}),
+      },
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 405 with JSON-RPC error for GET requests", async () => {
+    const auth = buildAuth(vi.fn());
+    const app = buildApp(auth);
+    const res = await app.request("/api/mcp", { method: "GET" }, env);
+    expect(res.status).toBe(405);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Method not allowed" },
+    });
+  });
+
+  it("returns 405 for DELETE requests", async () => {
+    const auth = buildAuth(vi.fn());
+    const app = buildApp(auth);
+    const res = await app.request("/api/mcp", { method: "DELETE" }, env);
+    expect(res.status).toBe(405);
+  });
+
+  it("lists all 7 MCP tools for an authorized read API key", async () => {
+    const auth = buildAuth(
+      vi.fn().mockResolvedValue({
+        valid: true,
+        key: {
+          referenceId: "user-mcp-list",
+          permissions: { mcp: ["read"] },
+        },
+      }),
+    );
+    const app = buildApp(auth);
+    const res = await app.request(
+      "/api/mcp",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-key",
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "test-client", version: "0.0.1" },
+          },
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const initBody = await res.json();
+    expect(initBody).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { capabilities: { tools: {} } },
+    });
+  });
+});

--- a/workers/src/mcp/server.test.ts
+++ b/workers/src/mcp/server.test.ts
@@ -3,11 +3,17 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 import { mcpHandler, mcpMethodNotAllowed } from "./server";
 import type { Auth } from "../auth";
-import { createLogger } from "../lib/logger";
 import type { Logger } from "../lib/logger";
 import type { Env } from "../types";
-import { resetDatabase, getTestDb } from "../test/helpers";
+import {
+  createTestGarmentInput,
+  createTestLogger,
+  getTestDb,
+  resetDatabase,
+  TEST_USER_ID,
+} from "../test/helpers";
 import { createApiKeyAuthStub } from "../test/mcp-helpers";
+import { createMcpCaller } from "./adapter";
 
 type TestVariables = {
   auth: Auth;
@@ -19,7 +25,7 @@ const buildApp = (auth: Auth) => {
   const app = new Hono<{ Bindings: Env; Variables: TestVariables }>();
   app.use("*", async (c, next) => {
     c.set("requestId", "test-req-id");
-    c.set("logger", createLogger({ minLevel: "error" }));
+    c.set("logger", createTestLogger());
     c.set("auth", auth);
     await next();
   });
@@ -88,6 +94,68 @@ describe("/api/mcp Hono handler", () => {
     const app = buildApp(auth);
     const res = await app.request("/api/mcp", { method: "DELETE" }, env);
     expect(res.status).toBe(405);
+  });
+
+  it("uses the API key's userId even when a valid session cookie names a different user", async () => {
+    // Cross-account regression: a request that carries Authorization (userA's
+    // API key) AND a Cookie (userB's session) must run as userA — the holder
+    // of the API key whose scope was just verified. Pre-fix, tRPC's
+    // resolveAuthenticatedUserId preferred the cookie session.
+    const aliceCaller = createMcpCaller({
+      env,
+      userId: "alice",
+      logger: createTestLogger(),
+    });
+    await aliceCaller.garment.create(
+      createTestGarmentInput({ name: "Alice's secret dress" }),
+    );
+
+    // Auth stub that resolves the Bearer to TEST_USER_ID AND the cookie
+    // session to "alice". Without preAuthenticatedUserId in the tRPC ctx,
+    // resolveAuthenticatedUserId would prefer getSession → "alice".
+    const stub = {
+      api: {
+        verifyApiKey: vi.fn().mockResolvedValue({
+          valid: true,
+          key: { referenceId: TEST_USER_ID, permissions: { mcp: ["read"] } },
+        }),
+        getSession: vi.fn().mockResolvedValue({
+          user: { id: "alice" },
+          session: { id: "alice-session", userId: "alice" },
+        }),
+      },
+    };
+    const auth = stub as unknown as Auth;
+    const app = buildApp(auth);
+
+    const res = await app.request(
+      "/api/mcp",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-key",
+          Cookie: "better-auth.session_token=alice-forged",
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "list_garments",
+            arguments: {},
+          },
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+
+    // The MCP path must not consult getSession: it should never run since
+    // preAuthenticatedUserId short-circuits the auth middleware entirely.
+    expect(stub.api.getSession).not.toHaveBeenCalled();
+    expect(stub.api.verifyApiKey).toHaveBeenCalledTimes(1);
   });
 
   it("lists all 7 MCP tools for an authorized read API key", async () => {

--- a/workers/src/mcp/server.test.ts
+++ b/workers/src/mcp/server.test.ts
@@ -110,23 +110,15 @@ describe("/api/mcp Hono handler", () => {
       createTestGarmentInput({ name: "Alice's secret dress" }),
     );
 
-    // Auth stub that resolves the Bearer to TEST_USER_ID AND the cookie
-    // session to "alice". Without preAuthenticatedUserId in the tRPC ctx,
-    // resolveAuthenticatedUserId would prefer getSession → "alice".
-    const stub = {
-      api: {
-        verifyApiKey: vi.fn().mockResolvedValue({
-          valid: true,
-          key: { referenceId: TEST_USER_ID, permissions: { mcp: ["read"] } },
-        }),
-        getSession: vi.fn().mockResolvedValue({
-          user: { id: "alice" },
-          session: { id: "alice-session", userId: "alice" },
-        }),
-      },
-    };
-    const auth = stub as unknown as Auth;
-    const app = buildApp(auth);
+    const verifyApiKey = vi.fn().mockResolvedValue({
+      valid: true,
+      key: { referenceId: TEST_USER_ID, permissions: { mcp: ["read"] } },
+    });
+    const getSession = vi.fn().mockResolvedValue({
+      user: { id: "alice" },
+      session: { id: "alice-session", userId: "alice" },
+    });
+    const app = buildApp(createApiKeyAuthStub(verifyApiKey, getSession));
 
     const res = await app.request(
       "/api/mcp",
@@ -142,20 +134,52 @@ describe("/api/mcp Hono handler", () => {
           jsonrpc: "2.0",
           id: 1,
           method: "tools/call",
-          params: {
-            name: "list_garments",
-            arguments: {},
-          },
+          params: { name: "list_garments", arguments: {} },
         }),
       },
       env,
     );
     expect(res.status).toBe(200);
 
-    // The MCP path must not consult getSession: it should never run since
-    // preAuthenticatedUserId short-circuits the auth middleware entirely.
-    expect(stub.api.getSession).not.toHaveBeenCalled();
-    expect(stub.api.verifyApiKey).toHaveBeenCalledTimes(1);
+    // Implementation-level guarantee: preAuthenticatedUserId short-circuits
+    // the auth middleware so getSession is never consulted.
+    expect(getSession).not.toHaveBeenCalled();
+    expect(verifyApiKey).toHaveBeenCalledTimes(1);
+
+    // Observable guarantee: alice's data must be absent from the response.
+    // (TEST_USER_ID has no garments; alice has one named "Alice's secret dress".)
+    const body = (await res.json()) as {
+      result?: { content?: Array<{ text?: string }> };
+    };
+    const text = body.result?.content?.[0]?.text ?? "";
+    expect(text).not.toContain("Alice's secret dress");
+    expect(JSON.parse(text)).toEqual([]);
+  });
+
+  it("rejects cookie-only requests with 401 (MCP requires API key, not session)", async () => {
+    const verifyApiKey = vi.fn();
+    const getSession = vi.fn().mockResolvedValue({
+      user: { id: "alice" },
+      session: { id: "alice-session", userId: "alice" },
+    });
+    const app = buildApp(createApiKeyAuthStub(verifyApiKey, getSession));
+
+    const res = await app.request(
+      "/api/mcp",
+      {
+        method: "POST",
+        headers: {
+          Cookie: "better-auth.session_token=alice-session",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(401);
+    expect(verifyApiKey).not.toHaveBeenCalled();
+    expect(getSession).not.toHaveBeenCalled();
   });
 
   it("lists all 7 MCP tools for an authorized read API key", async () => {

--- a/workers/src/mcp/server.test.ts
+++ b/workers/src/mcp/server.test.ts
@@ -7,6 +7,7 @@ import { createLogger } from "../lib/logger";
 import type { Logger } from "../lib/logger";
 import type { Env } from "../types";
 import { resetDatabase, getTestDb } from "../test/helpers";
+import { createApiKeyAuthStub } from "../test/mcp-helpers";
 
 type TestVariables = {
   auth: Auth;
@@ -28,20 +29,13 @@ const buildApp = (auth: Auth) => {
   return app;
 };
 
-const buildAuth = (
-  verifyApiKey: (args: { body: { key: string } }) => Promise<unknown>,
-): Auth => {
-  const stub = { api: { verifyApiKey } };
-  return stub as unknown as Auth;
-};
-
 describe("/api/mcp Hono handler", () => {
   beforeEach(async () => {
     await resetDatabase(getTestDb());
   });
 
   it("rejects requests without Bearer token with 401 + JSON-RPC error", async () => {
-    const auth = buildAuth(vi.fn());
+    const auth = createApiKeyAuthStub(vi.fn());
     const app = buildApp(auth);
     const res = await app.request(
       "/api/mcp",
@@ -58,7 +52,7 @@ describe("/api/mcp Hono handler", () => {
   });
 
   it("rejects API keys without mcp scope with 401", async () => {
-    const auth = buildAuth(
+    const auth = createApiKeyAuthStub(
       vi.fn().mockResolvedValue({
         valid: true,
         key: { referenceId: "user-1", permissions: {} },
@@ -78,7 +72,7 @@ describe("/api/mcp Hono handler", () => {
   });
 
   it("returns 405 with JSON-RPC error for GET requests", async () => {
-    const auth = buildAuth(vi.fn());
+    const auth = createApiKeyAuthStub(vi.fn());
     const app = buildApp(auth);
     const res = await app.request("/api/mcp", { method: "GET" }, env);
     expect(res.status).toBe(405);
@@ -90,14 +84,14 @@ describe("/api/mcp Hono handler", () => {
   });
 
   it("returns 405 for DELETE requests", async () => {
-    const auth = buildAuth(vi.fn());
+    const auth = createApiKeyAuthStub(vi.fn());
     const app = buildApp(auth);
     const res = await app.request("/api/mcp", { method: "DELETE" }, env);
     expect(res.status).toBe(405);
   });
 
   it("lists all 7 MCP tools for an authorized read API key", async () => {
-    const auth = buildAuth(
+    const auth = createApiKeyAuthStub(
       vi.fn().mockResolvedValue({
         valid: true,
         key: {

--- a/workers/src/mcp/server.ts
+++ b/workers/src/mcp/server.ts
@@ -73,8 +73,7 @@ export const mcpHandler = async (c: McpHonoContext): Promise<Response> => {
 
   const caller = createMcpCaller({
     env: c.env,
-    auth,
-    honoContext: c,
+    userId: mcpAuth.userId,
     logger: requestLogger,
   });
 

--- a/workers/src/mcp/server.ts
+++ b/workers/src/mcp/server.ts
@@ -111,9 +111,8 @@ export const mcpHandler = async (c: McpHonoContext): Promise<Response> => {
       return internalError(c);
     });
 
-  // Cleanup transport / server in the background. Hono's executionCtx getter
-  // throws when no Workers ExecutionContext is attached (e.g. tests using
-  // app.request without a vexed context), so guard with a tolerant accessor.
+  // Hono's executionCtx getter throws when no Workers ExecutionContext is attached
+  // (e.g. tests using app.request); fall back to fire-and-forget in that case.
   const cleanup = Promise.allSettled([transport.close(), server.close()]);
   const execCtx = await readExecutionCtx(c);
   if (execCtx !== undefined) {

--- a/workers/src/mcp/server.ts
+++ b/workers/src/mcp/server.ts
@@ -1,0 +1,136 @@
+import type { Context } from "hono";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import type { Env } from "../types";
+import type { Auth } from "../auth";
+import type { Logger } from "../lib/logger";
+import { createMcpCaller } from "./adapter";
+import { resolveMcpAuth } from "./auth";
+import { registerAllTools } from "./tools/register-all";
+
+type McpVariables = {
+  readonly auth: Auth;
+  readonly requestId: string;
+  readonly logger: Logger;
+};
+type McpHonoContext = Context<{
+  Bindings: Env;
+  Variables: McpVariables;
+}>;
+
+const SERVER_NAME = "dollrobe-mcp";
+const SERVER_VERSION = "0.1.0";
+
+const HTTP_UNAUTHORIZED = 401;
+const HTTP_METHOD_NOT_ALLOWED = 405;
+const HTTP_INTERNAL_ERROR = 500;
+
+type WaitUntilCtx = { waitUntil: (promise: Promise<unknown>) => void };
+
+const readExecutionCtx = async (
+  c: McpHonoContext,
+): Promise<WaitUntilCtx | undefined> => {
+  const safeRead = async (): Promise<WaitUntilCtx | undefined> =>
+    await Promise.resolve(c.executionCtx);
+  return await safeRead().catch(() => undefined);
+};
+
+const unauthorized = (c: McpHonoContext): Response =>
+  c.json(
+    {
+      jsonrpc: "2.0",
+      error: { code: -32001, message: "Unauthorized" },
+      id: null,
+    },
+    HTTP_UNAUTHORIZED,
+  );
+
+const internalError = (c: McpHonoContext): Response =>
+  c.json(
+    {
+      jsonrpc: "2.0",
+      error: { code: -32603, message: "Internal error" },
+      id: null,
+    },
+    HTTP_INTERNAL_ERROR,
+  );
+
+export const mcpHandler = async (c: McpHonoContext): Promise<Response> => {
+  const baseLogger = c.get("logger").child({ route: "mcp" });
+  const auth = c.get("auth");
+
+  const mcpAuth = await resolveMcpAuth({ auth, headers: c.req.raw.headers });
+  if (mcpAuth === undefined) {
+    baseLogger.warn("mcp auth rejected");
+    return unauthorized(c);
+  }
+
+  const requestLogger = baseLogger.child({
+    userId: mcpAuth.userId,
+    scope: mcpAuth.scope,
+  });
+  requestLogger.info("mcp request authorized");
+
+  const caller = createMcpCaller({
+    env: c.env,
+    auth,
+    honoContext: c,
+    logger: requestLogger,
+  });
+
+  const server = new McpServer(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {} } },
+  );
+
+  registerAllTools(server, {
+    caller,
+    scope: mcpAuth.scope,
+    logger: requestLogger,
+  });
+
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  });
+
+  const connectError = await server
+    .connect(transport)
+    .catch((error: unknown) => error);
+  if (connectError !== undefined) {
+    requestLogger.error("mcp transport connect failed", {
+      error: connectError,
+    });
+    return internalError(c);
+  }
+
+  const response = await transport
+    .handleRequest(c.req.raw)
+    .catch((error: unknown) => {
+      requestLogger.error("mcp transport failed", { error });
+      return internalError(c);
+    });
+
+  // Cleanup transport / server in the background. Hono's executionCtx getter
+  // throws when no Workers ExecutionContext is attached (e.g. tests using
+  // app.request without a vexed context), so guard with a tolerant accessor.
+  const cleanup = Promise.allSettled([transport.close(), server.close()]);
+  const execCtx = await readExecutionCtx(c);
+  if (execCtx !== undefined) {
+    execCtx.waitUntil(cleanup);
+  } else {
+    void cleanup;
+  }
+
+  return response;
+};
+
+export const mcpMethodNotAllowed = (c: McpHonoContext): Response =>
+  c.json(
+    {
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Method not allowed" },
+      id: null,
+    },
+    HTTP_METHOD_NOT_ALLOWED,
+  );

--- a/workers/src/mcp/tools/add-garment-tags.test.ts
+++ b/workers/src/mcp/tools/add-garment-tags.test.ts
@@ -1,0 +1,96 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Context as HonoContext } from "hono";
+import { handleAddGarmentTags } from "./add-garment-tags";
+import { createMcpCaller } from "../adapter";
+import {
+  createStubAuth,
+  createTestGarmentInput,
+  createTestLogger,
+  getTestDb,
+  resetDatabase,
+} from "../../test/helpers";
+
+const createStubHonoContext = (): HonoContext => {
+  const headers = new Headers();
+  const stub = { req: { raw: { headers } } };
+  return stub as unknown as HonoContext;
+};
+
+const buildCtx = (scope: "read" | "write") => ({
+  caller: createMcpCaller({
+    env,
+    auth: createStubAuth("mcp-user"),
+    honoContext: createStubHonoContext(),
+    logger: createTestLogger(),
+  }),
+  scope,
+  logger: createTestLogger(),
+});
+
+describe("handleAddGarmentTags", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("rejects with FORBIDDEN when scope is read-only", async () => {
+    const ctx = buildCtx("read");
+    const created = await ctx.caller.garment.create(
+      createTestGarmentInput({ tags: ["a"] }),
+    );
+
+    const result = await handleAddGarmentTags(
+      { id: created.id, tags: ["b"] },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("FORBIDDEN");
+
+    // tags must not be modified
+    const reread = await ctx.caller.garment.get({ id: created.id });
+    expect([...reread.tags]).toEqual(["a"]);
+  });
+
+  it("merges new tags with existing tags and deduplicates", async () => {
+    const ctx = buildCtx("write");
+    const created = await ctx.caller.garment.create(
+      createTestGarmentInput({ tags: ["red", "summer"] }),
+    );
+
+    const result = await handleAddGarmentTags(
+      { id: created.id, tags: ["summer", "floral"] },
+      ctx,
+    );
+
+    expect(result.isError).toBeUndefined();
+    const updated = result.structuredContent as { tags: string[] };
+    expect([...updated.tags].sort()).toEqual(["floral", "red", "summer"]);
+  });
+
+  it("preserves non-tag fields (whitelist behaviour)", async () => {
+    const ctx = buildCtx("write");
+    const created = await ctx.caller.garment.create(
+      createTestGarmentInput({
+        name: "保護対象ドレス",
+        tags: ["original"],
+      }),
+    );
+
+    await handleAddGarmentTags({ id: created.id, tags: ["new"] }, ctx);
+
+    const reread = await ctx.caller.garment.get({ id: created.id });
+    expect(reread.name).toBe("保護対象ドレス");
+    expect(reread.category).toBe(created.category);
+    expect([...reread.tags].sort()).toEqual(["new", "original"]);
+  });
+
+  it("returns isError when garment does not exist", async () => {
+    const ctx = buildCtx("write");
+    const result = await handleAddGarmentTags(
+      { id: "nonexistent-id-12345", tags: ["x"] },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+  });
+});

--- a/workers/src/mcp/tools/add-garment-tags.test.ts
+++ b/workers/src/mcp/tools/add-garment-tags.test.ts
@@ -1,45 +1,24 @@
-import { env } from "cloudflare:test";
 import { describe, it, expect, beforeEach } from "vitest";
-import type { Context as HonoContext } from "hono";
-import { handleAddGarmentTags } from "./add-garment-tags";
-import { createMcpCaller } from "../adapter";
+import { addGarmentTagsTool } from "./add-garment-tags";
 import {
-  createStubAuth,
   createTestGarmentInput,
-  createTestLogger,
   getTestDb,
   resetDatabase,
 } from "../../test/helpers";
+import { buildMcpToolCtx } from "../../test/mcp-helpers";
 
-const createStubHonoContext = (): HonoContext => {
-  const headers = new Headers();
-  const stub = { req: { raw: { headers } } };
-  return stub as unknown as HonoContext;
-};
-
-const buildCtx = (scope: "read" | "write") => ({
-  caller: createMcpCaller({
-    env,
-    auth: createStubAuth("mcp-user"),
-    honoContext: createStubHonoContext(),
-    logger: createTestLogger(),
-  }),
-  scope,
-  logger: createTestLogger(),
-});
-
-describe("handleAddGarmentTags", () => {
+describe("addGarmentTagsTool", () => {
   beforeEach(async () => {
     await resetDatabase(getTestDb());
   });
 
   it("rejects with FORBIDDEN when scope is read-only", async () => {
-    const ctx = buildCtx("read");
+    const ctx = buildMcpToolCtx("read");
     const created = await ctx.caller.garment.create(
       createTestGarmentInput({ tags: ["a"] }),
     );
 
-    const result = await handleAddGarmentTags(
+    const result = await addGarmentTagsTool.handle(
       { id: created.id, tags: ["b"] },
       ctx,
     );
@@ -53,12 +32,12 @@ describe("handleAddGarmentTags", () => {
   });
 
   it("merges new tags with existing tags and deduplicates", async () => {
-    const ctx = buildCtx("write");
+    const ctx = buildMcpToolCtx("write");
     const created = await ctx.caller.garment.create(
       createTestGarmentInput({ tags: ["red", "summer"] }),
     );
 
-    const result = await handleAddGarmentTags(
+    const result = await addGarmentTagsTool.handle(
       { id: created.id, tags: ["summer", "floral"] },
       ctx,
     );
@@ -69,7 +48,7 @@ describe("handleAddGarmentTags", () => {
   });
 
   it("preserves non-tag fields (whitelist behaviour)", async () => {
-    const ctx = buildCtx("write");
+    const ctx = buildMcpToolCtx("write");
     const created = await ctx.caller.garment.create(
       createTestGarmentInput({
         name: "保護対象ドレス",
@@ -77,7 +56,7 @@ describe("handleAddGarmentTags", () => {
       }),
     );
 
-    await handleAddGarmentTags({ id: created.id, tags: ["new"] }, ctx);
+    await addGarmentTagsTool.handle({ id: created.id, tags: ["new"] }, ctx);
 
     const reread = await ctx.caller.garment.get({ id: created.id });
     expect(reread.name).toBe("保護対象ドレス");
@@ -86,8 +65,8 @@ describe("handleAddGarmentTags", () => {
   });
 
   it("returns isError when garment does not exist", async () => {
-    const ctx = buildCtx("write");
-    const result = await handleAddGarmentTags(
+    const ctx = buildMcpToolCtx("write");
+    const result = await addGarmentTagsTool.handle(
       { id: "nonexistent-id-12345", tags: ["x"] },
       ctx,
     );

--- a/workers/src/mcp/tools/add-garment-tags.ts
+++ b/workers/src/mcp/tools/add-garment-tags.ts
@@ -1,86 +1,27 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { cuidSchema } from "../../trpc/lib/schemas";
-import {
-  okResult,
-  toErrorResult,
-  errorResult,
-  safeCall,
-  type CallToolResult,
-  type McpCaller,
-} from "../adapter";
-import { hasScope, type McpScope } from "../scopes";
-import type { Logger } from "../../lib/logger";
-
-type ToolContext = {
-  readonly caller: McpCaller;
-  readonly scope: McpScope;
-  readonly logger: Logger;
-};
+import { defineTool } from "./define-tool";
 
 const TAG_MIN_LENGTH = 1;
 const TAG_MAX_LENGTH = 50;
 const TAGS_MIN_ITEMS = 1;
 const TAGS_MAX_ITEMS = 20;
 
-const inputSchema = z.object({
-  id: cuidSchema,
-  tags: z
-    .array(z.string().min(TAG_MIN_LENGTH).max(TAG_MAX_LENGTH))
-    .min(TAGS_MIN_ITEMS)
-    .max(TAGS_MAX_ITEMS),
+export const addGarmentTagsTool = defineTool({
+  name: "add_garment_tags",
+  title: "Add tags to garment",
+  description:
+    "服に追加タグを付与する（既存タグとマージ、重複は除去）。tags 以外のフィールドは変更しない。",
+  inputSchema: z.object({
+    id: cuidSchema,
+    tags: z
+      .array(z.string().min(TAG_MIN_LENGTH).max(TAG_MAX_LENGTH))
+      .min(TAGS_MIN_ITEMS)
+      .max(TAGS_MAX_ITEMS),
+  }),
+  call: async ({ id, tags }, ctx) => {
+    const existing = await ctx.caller.garment.get({ id });
+    const merged = Array.from(new Set([...existing.tags, ...tags]));
+    return await ctx.caller.garment.update({ id, tags: merged });
+  },
 });
-
-export const handleAddGarmentTags = async (
-  input: z.infer<typeof inputSchema>,
-  ctx: ToolContext,
-): Promise<CallToolResult> => {
-  const log = ctx.logger.child({
-    tool: "add_garment_tags",
-    garmentId: input.id,
-  });
-  if (!hasScope(ctx.scope, "write")) {
-    log.warn("scope denied (write required)");
-    return errorResult("Forbidden: write scope required", "FORBIDDEN");
-  }
-  log.info("tool invoked", { newTagCount: input.tags.length });
-
-  const fetched = await safeCall(ctx.caller.garment.get({ id: input.id }));
-  if (!fetched.ok) {
-    log.error("fetch failed", { error: fetched.error });
-    return toErrorResult(fetched.error);
-  }
-  const existing = fetched.value;
-
-  const merged = Array.from(new Set([...existing.tags, ...input.tags]));
-
-  const updated = await safeCall(
-    ctx.caller.garment.update({ id: input.id, tags: merged }),
-  );
-  if (!updated.ok) {
-    log.error("update failed", { error: updated.error });
-    return toErrorResult(updated.error);
-  }
-  log.info("tags merged", {
-    before: existing.tags.length,
-    added: input.tags.length,
-    after: merged.length,
-  });
-  return okResult(updated.value);
-};
-
-export const registerAddGarmentTags = (
-  server: McpServer,
-  ctx: ToolContext,
-): void => {
-  server.registerTool(
-    "add_garment_tags",
-    {
-      title: "Add tags to garment",
-      description:
-        "服に追加タグを付与する（既存タグとマージ、重複は除去）。tags 以外のフィールドは変更しない。",
-      inputSchema: inputSchema.shape,
-    },
-    async (input) => await handleAddGarmentTags(input, ctx),
-  );
-};

--- a/workers/src/mcp/tools/add-garment-tags.ts
+++ b/workers/src/mcp/tools/add-garment-tags.ts
@@ -1,0 +1,86 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { cuidSchema } from "../../trpc/lib/schemas";
+import {
+  okResult,
+  toErrorResult,
+  errorResult,
+  safeCall,
+  type CallToolResult,
+  type McpCaller,
+} from "../adapter";
+import { hasScope, type McpScope } from "../scopes";
+import type { Logger } from "../../lib/logger";
+
+type ToolContext = {
+  readonly caller: McpCaller;
+  readonly scope: McpScope;
+  readonly logger: Logger;
+};
+
+const TAG_MIN_LENGTH = 1;
+const TAG_MAX_LENGTH = 50;
+const TAGS_MIN_ITEMS = 1;
+const TAGS_MAX_ITEMS = 20;
+
+const inputSchema = z.object({
+  id: cuidSchema,
+  tags: z
+    .array(z.string().min(TAG_MIN_LENGTH).max(TAG_MAX_LENGTH))
+    .min(TAGS_MIN_ITEMS)
+    .max(TAGS_MAX_ITEMS),
+});
+
+export const handleAddGarmentTags = async (
+  input: z.infer<typeof inputSchema>,
+  ctx: ToolContext,
+): Promise<CallToolResult> => {
+  const log = ctx.logger.child({
+    tool: "add_garment_tags",
+    garmentId: input.id,
+  });
+  if (!hasScope(ctx.scope, "write")) {
+    log.warn("scope denied (write required)");
+    return errorResult("Forbidden: write scope required", "FORBIDDEN");
+  }
+  log.info("tool invoked", { newTagCount: input.tags.length });
+
+  const fetched = await safeCall(ctx.caller.garment.get({ id: input.id }));
+  if (!fetched.ok) {
+    log.error("fetch failed", { error: fetched.error });
+    return toErrorResult(fetched.error);
+  }
+  const existing = fetched.value;
+
+  const merged = Array.from(new Set([...existing.tags, ...input.tags]));
+
+  const updated = await safeCall(
+    ctx.caller.garment.update({ id: input.id, tags: merged }),
+  );
+  if (!updated.ok) {
+    log.error("update failed", { error: updated.error });
+    return toErrorResult(updated.error);
+  }
+  log.info("tags merged", {
+    before: existing.tags.length,
+    added: input.tags.length,
+    after: merged.length,
+  });
+  return okResult(updated.value);
+};
+
+export const registerAddGarmentTags = (
+  server: McpServer,
+  ctx: ToolContext,
+): void => {
+  server.registerTool(
+    "add_garment_tags",
+    {
+      title: "Add tags to garment",
+      description:
+        "服に追加タグを付与する（既存タグとマージ、重複は除去）。tags 以外のフィールドは変更しない。",
+      inputSchema: inputSchema.shape,
+    },
+    async (input) => await handleAddGarmentTags(input, ctx),
+  );
+};

--- a/workers/src/mcp/tools/define-tool.ts
+++ b/workers/src/mcp/tools/define-tool.ts
@@ -50,7 +50,9 @@ export const defineTool = <S extends ZodObjectAny>(spec: {
       log.warn("scope denied", { required });
       return forbiddenResult(required);
     }
-    const parsed = spec.inputSchema.safeParse(input);
+    // MCP allows clients to omit `params.arguments`; normalize to {} so that
+    // tools with no arguments or only optional fields don't fail validation.
+    const parsed = spec.inputSchema.safeParse(input ?? {});
     if (!parsed.success) {
       log.warn("invalid input", { issues: parsed.error.issues });
       return toErrorResult(parsed.error);

--- a/workers/src/mcp/tools/define-tool.ts
+++ b/workers/src/mcp/tools/define-tool.ts
@@ -1,0 +1,82 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { z } from "zod";
+import {
+  okResult,
+  toErrorResult,
+  forbiddenResult,
+  safeCall,
+  type CallToolResult,
+  type McpCaller,
+} from "../adapter";
+import {
+  hasScope,
+  TOOL_REQUIRED_SCOPE,
+  type McpScope,
+  type McpToolName,
+} from "../scopes";
+import type { Logger } from "../../lib/logger";
+
+export type ToolContext = {
+  readonly caller: McpCaller;
+  readonly scope: McpScope;
+  readonly logger: Logger;
+};
+
+type ZodObjectAny = z.ZodObject<z.ZodRawShape>;
+
+export type DefinedTool = {
+  readonly handle: (
+    input: unknown,
+    ctx: ToolContext,
+  ) => Promise<CallToolResult>;
+  readonly register: (server: McpServer, ctx: ToolContext) => void;
+};
+
+export const defineTool = <S extends ZodObjectAny>(spec: {
+  readonly name: McpToolName;
+  readonly title: string;
+  readonly description: string;
+  readonly inputSchema: S;
+  readonly call: (input: z.infer<S>, ctx: ToolContext) => Promise<unknown>;
+}): DefinedTool => {
+  const required = TOOL_REQUIRED_SCOPE[spec.name];
+
+  const handle = async (
+    input: unknown,
+    ctx: ToolContext,
+  ): Promise<CallToolResult> => {
+    const log = ctx.logger.child({ tool: spec.name });
+    if (!hasScope(ctx.scope, required)) {
+      log.warn("scope denied", { required });
+      return forbiddenResult(required);
+    }
+    const parsed = spec.inputSchema.safeParse(input);
+    if (!parsed.success) {
+      log.warn("invalid input", { issues: parsed.error.issues });
+      return toErrorResult(parsed.error);
+    }
+    log.info("tool invoked");
+    const result = await safeCall(spec.call(parsed.data, ctx));
+    if (!result.ok) {
+      log.error("tool failed", { error: result.error });
+      return toErrorResult(result.error);
+    }
+    log.info("tool completed");
+    return okResult(result.value);
+  };
+
+  const register = (server: McpServer, ctx: ToolContext): void => {
+    const shape: z.ZodRawShape = spec.inputSchema.shape;
+    server.registerTool(
+      spec.name,
+      {
+        title: spec.title,
+        description: spec.description,
+        inputSchema: shape,
+      },
+      async (input) => await handle(input, ctx),
+    );
+  };
+
+  return { handle, register };
+};

--- a/workers/src/mcp/tools/get-garment.test.ts
+++ b/workers/src/mcp/tools/get-garment.test.ts
@@ -1,0 +1,56 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Context as HonoContext } from "hono";
+import { handleGetGarment } from "./get-garment";
+import { createMcpCaller } from "../adapter";
+import {
+  createStubAuth,
+  createTestGarmentInput,
+  createTestLogger,
+  getTestDb,
+  resetDatabase,
+} from "../../test/helpers";
+
+const createStubHonoContext = (): HonoContext => {
+  const headers = new Headers();
+  const stub = { req: { raw: { headers } } };
+  return stub as unknown as HonoContext;
+};
+
+const buildCtx = (scope: "read" | "write") => ({
+  caller: createMcpCaller({
+    env,
+    auth: createStubAuth("mcp-user"),
+    honoContext: createStubHonoContext(),
+    logger: createTestLogger(),
+  }),
+  scope,
+  logger: createTestLogger(),
+});
+
+describe("handleGetGarment", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("returns the garment when it exists", async () => {
+    const ctx = buildCtx("read");
+    const created = await ctx.caller.garment.create(
+      createTestGarmentInput({ name: "ターゲット" }),
+    );
+
+    const result = await handleGetGarment({ id: created.id }, ctx);
+
+    expect(result.isError).toBeUndefined();
+    const garment = result.structuredContent as { name: string };
+    expect(garment.name).toBe("ターゲット");
+  });
+
+  it("returns isError when scope lacks read permission", async () => {
+    const ctx = { ...buildCtx("write"), scope: "write" as const };
+    const created = await ctx.caller.garment.create(createTestGarmentInput());
+    const result = await handleGetGarment({ id: created.id }, ctx);
+    // write scope has read access → succeeds
+    expect(result.isError).toBeUndefined();
+  });
+});

--- a/workers/src/mcp/tools/get-garment.test.ts
+++ b/workers/src/mcp/tools/get-garment.test.ts
@@ -1,56 +1,34 @@
-import { env } from "cloudflare:test";
 import { describe, it, expect, beforeEach } from "vitest";
-import type { Context as HonoContext } from "hono";
-import { handleGetGarment } from "./get-garment";
-import { createMcpCaller } from "../adapter";
+import { getGarmentTool } from "./get-garment";
 import {
-  createStubAuth,
   createTestGarmentInput,
-  createTestLogger,
   getTestDb,
   resetDatabase,
 } from "../../test/helpers";
+import { buildMcpToolCtx } from "../../test/mcp-helpers";
 
-const createStubHonoContext = (): HonoContext => {
-  const headers = new Headers();
-  const stub = { req: { raw: { headers } } };
-  return stub as unknown as HonoContext;
-};
-
-const buildCtx = (scope: "read" | "write") => ({
-  caller: createMcpCaller({
-    env,
-    auth: createStubAuth("mcp-user"),
-    honoContext: createStubHonoContext(),
-    logger: createTestLogger(),
-  }),
-  scope,
-  logger: createTestLogger(),
-});
-
-describe("handleGetGarment", () => {
+describe("getGarmentTool", () => {
   beforeEach(async () => {
     await resetDatabase(getTestDb());
   });
 
   it("returns the garment when it exists", async () => {
-    const ctx = buildCtx("read");
+    const ctx = buildMcpToolCtx("read");
     const created = await ctx.caller.garment.create(
       createTestGarmentInput({ name: "ターゲット" }),
     );
 
-    const result = await handleGetGarment({ id: created.id }, ctx);
+    const result = await getGarmentTool.handle({ id: created.id }, ctx);
 
     expect(result.isError).toBeUndefined();
     const garment = result.structuredContent as { name: string };
     expect(garment.name).toBe("ターゲット");
   });
 
-  it("returns isError when scope lacks read permission", async () => {
-    const ctx = { ...buildCtx("write"), scope: "write" as const };
+  it("write scope can also call read tools", async () => {
+    const ctx = buildMcpToolCtx("write");
     const created = await ctx.caller.garment.create(createTestGarmentInput());
-    const result = await handleGetGarment({ id: created.id }, ctx);
-    // write scope has read access → succeeds
+    const result = await getGarmentTool.handle({ id: created.id }, ctx);
     expect(result.isError).toBeUndefined();
   });
 });

--- a/workers/src/mcp/tools/get-garment.ts
+++ b/workers/src/mcp/tools/get-garment.ts
@@ -1,55 +1,11 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { cuidSchema } from "../../trpc/lib/schemas";
-import {
-  okResult,
-  toErrorResult,
-  errorResult,
-  safeCall,
-  type CallToolResult,
-  type McpCaller,
-} from "../adapter";
-import { hasScope, type McpScope } from "../scopes";
-import type { Logger } from "../../lib/logger";
+import { defineTool } from "./define-tool";
 
-type ToolContext = {
-  readonly caller: McpCaller;
-  readonly scope: McpScope;
-  readonly logger: Logger;
-};
-
-const inputSchema = z.object({ id: cuidSchema });
-
-export const handleGetGarment = async (
-  input: z.infer<typeof inputSchema>,
-  ctx: ToolContext,
-): Promise<CallToolResult> => {
-  const log = ctx.logger.child({ tool: "get_garment", garmentId: input.id });
-  if (!hasScope(ctx.scope, "read")) {
-    log.warn("scope denied");
-    return errorResult("Forbidden", "FORBIDDEN");
-  }
-  log.info("tool invoked");
-  const result = await safeCall(ctx.caller.garment.get(input));
-  if (!result.ok) {
-    log.error("tool failed", { error: result.error });
-    return toErrorResult(result.error);
-  }
-  log.info("tool completed");
-  return okResult(result.value);
-};
-
-export const registerGetGarment = (
-  server: McpServer,
-  ctx: ToolContext,
-): void => {
-  server.registerTool(
-    "get_garment",
-    {
-      title: "Get garment",
-      description: "ID で 1 件の服詳細を取得する。",
-      inputSchema: inputSchema.shape,
-    },
-    async (input) => await handleGetGarment(input, ctx),
-  );
-};
+export const getGarmentTool = defineTool({
+  name: "get_garment",
+  title: "Get garment",
+  description: "ID で 1 件の服詳細を取得する。",
+  inputSchema: z.object({ id: cuidSchema }),
+  call: async (input, ctx) => await ctx.caller.garment.get(input),
+});

--- a/workers/src/mcp/tools/get-garment.ts
+++ b/workers/src/mcp/tools/get-garment.ts
@@ -1,0 +1,55 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { cuidSchema } from "../../trpc/lib/schemas";
+import {
+  okResult,
+  toErrorResult,
+  errorResult,
+  safeCall,
+  type CallToolResult,
+  type McpCaller,
+} from "../adapter";
+import { hasScope, type McpScope } from "../scopes";
+import type { Logger } from "../../lib/logger";
+
+type ToolContext = {
+  readonly caller: McpCaller;
+  readonly scope: McpScope;
+  readonly logger: Logger;
+};
+
+const inputSchema = z.object({ id: cuidSchema });
+
+export const handleGetGarment = async (
+  input: z.infer<typeof inputSchema>,
+  ctx: ToolContext,
+): Promise<CallToolResult> => {
+  const log = ctx.logger.child({ tool: "get_garment", garmentId: input.id });
+  if (!hasScope(ctx.scope, "read")) {
+    log.warn("scope denied");
+    return errorResult("Forbidden", "FORBIDDEN");
+  }
+  log.info("tool invoked");
+  const result = await safeCall(ctx.caller.garment.get(input));
+  if (!result.ok) {
+    log.error("tool failed", { error: result.error });
+    return toErrorResult(result.error);
+  }
+  log.info("tool completed");
+  return okResult(result.value);
+};
+
+export const registerGetGarment = (
+  server: McpServer,
+  ctx: ToolContext,
+): void => {
+  server.registerTool(
+    "get_garment",
+    {
+      title: "Get garment",
+      description: "ID で 1 件の服詳細を取得する。",
+      inputSchema: inputSchema.shape,
+    },
+    async (input) => await handleGetGarment(input, ctx),
+  );
+};

--- a/workers/src/mcp/tools/get-organization-digest.test.ts
+++ b/workers/src/mcp/tools/get-organization-digest.test.ts
@@ -1,40 +1,16 @@
-import { env } from "cloudflare:test";
 import { describe, it, expect, beforeEach } from "vitest";
-import type { Context as HonoContext } from "hono";
-import { handleGetOrganizationDigest } from "./get-organization-digest";
-import { createMcpCaller } from "../adapter";
-import {
-  createStubAuth,
-  createTestLogger,
-  getTestDb,
-  resetDatabase,
-} from "../../test/helpers";
+import { getOrganizationDigestTool } from "./get-organization-digest";
+import { getTestDb, resetDatabase } from "../../test/helpers";
+import { buildMcpToolCtx } from "../../test/mcp-helpers";
 
-const createStubHonoContext = (): HonoContext => {
-  const headers = new Headers();
-  const stub = { req: { raw: { headers } } };
-  return stub as unknown as HonoContext;
-};
-
-const buildCtx = (scope: "read" | "write") => ({
-  caller: createMcpCaller({
-    env,
-    auth: createStubAuth("mcp-user"),
-    honoContext: createStubHonoContext(),
-    logger: createTestLogger(),
-  }),
-  scope,
-  logger: createTestLogger(),
-});
-
-describe("handleGetOrganizationDigest", () => {
+describe("getOrganizationDigestTool", () => {
   beforeEach(async () => {
     await resetDatabase(getTestDb());
   });
 
   it("returns undefined when no digest exists yet", async () => {
-    const ctx = buildCtx("read");
-    const result = await handleGetOrganizationDigest({}, ctx);
+    const ctx = buildMcpToolCtx("read");
+    const result = await getOrganizationDigestTool.handle({}, ctx);
 
     expect(result.isError).toBeUndefined();
     expect(result.structuredContent).toBeUndefined();

--- a/workers/src/mcp/tools/get-organization-digest.test.ts
+++ b/workers/src/mcp/tools/get-organization-digest.test.ts
@@ -14,5 +14,15 @@ describe("getOrganizationDigestTool", () => {
 
     expect(result.isError).toBeUndefined();
     expect(result.structuredContent).toBeUndefined();
+    // text must remain a string ("null") even though the underlying value is undefined.
+    expect(typeof result.content[0]?.text).toBe("string");
+    expect(result.content[0]?.text).toBe("null");
+  });
+
+  it("accepts omitted arguments (MCP allows undefined params.arguments)", async () => {
+    const ctx = buildMcpToolCtx("read");
+    const result = await getOrganizationDigestTool.handle(undefined, ctx);
+
+    expect(result.isError).toBeUndefined();
   });
 });

--- a/workers/src/mcp/tools/get-organization-digest.test.ts
+++ b/workers/src/mcp/tools/get-organization-digest.test.ts
@@ -1,0 +1,42 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Context as HonoContext } from "hono";
+import { handleGetOrganizationDigest } from "./get-organization-digest";
+import { createMcpCaller } from "../adapter";
+import {
+  createStubAuth,
+  createTestLogger,
+  getTestDb,
+  resetDatabase,
+} from "../../test/helpers";
+
+const createStubHonoContext = (): HonoContext => {
+  const headers = new Headers();
+  const stub = { req: { raw: { headers } } };
+  return stub as unknown as HonoContext;
+};
+
+const buildCtx = (scope: "read" | "write") => ({
+  caller: createMcpCaller({
+    env,
+    auth: createStubAuth("mcp-user"),
+    honoContext: createStubHonoContext(),
+    logger: createTestLogger(),
+  }),
+  scope,
+  logger: createTestLogger(),
+});
+
+describe("handleGetOrganizationDigest", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("returns undefined when no digest exists yet", async () => {
+    const ctx = buildCtx("read");
+    const result = await handleGetOrganizationDigest({}, ctx);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toBeUndefined();
+  });
+});

--- a/workers/src/mcp/tools/get-organization-digest.ts
+++ b/workers/src/mcp/tools/get-organization-digest.ts
@@ -1,55 +1,11 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import {
-  okResult,
-  toErrorResult,
-  errorResult,
-  safeCall,
-  type CallToolResult,
-  type McpCaller,
-} from "../adapter";
-import { hasScope, type McpScope } from "../scopes";
-import type { Logger } from "../../lib/logger";
+import { defineTool } from "./define-tool";
 
-type ToolContext = {
-  readonly caller: McpCaller;
-  readonly scope: McpScope;
-  readonly logger: Logger;
-};
-
-const inputSchema = z.object({});
-
-export const handleGetOrganizationDigest = async (
-  _input: z.infer<typeof inputSchema>,
-  ctx: ToolContext,
-): Promise<CallToolResult> => {
-  const log = ctx.logger.child({ tool: "get_organization_digest" });
-  if (!hasScope(ctx.scope, "read")) {
-    log.warn("scope denied");
-    return errorResult("Forbidden", "FORBIDDEN");
-  }
-  log.info("tool invoked");
-  const result = await safeCall(ctx.caller.digest.latest());
-  if (!result.ok) {
-    log.error("tool failed", { error: result.error });
-    return toErrorResult(result.error);
-  }
-  log.info("tool completed");
-  return okResult(result.value);
-};
-
-export const registerGetOrganizationDigest = (
-  server: McpServer,
-  ctx: ToolContext,
-): void => {
-  server.registerTool(
-    "get_organization_digest",
-    {
-      title: "Get organization digest",
-      description:
-        "週次ダイジェスト（在庫整理の最新サマリ）を取得する。digest.latest と同等。",
-      inputSchema: inputSchema.shape,
-    },
-    async (input) => await handleGetOrganizationDigest(input, ctx),
-  );
-};
+export const getOrganizationDigestTool = defineTool({
+  name: "get_organization_digest",
+  title: "Get organization digest",
+  description:
+    "週次ダイジェスト（在庫整理の最新サマリ）を取得する。digest.latest と同等。",
+  inputSchema: z.object({}),
+  call: async (_input, ctx) => await ctx.caller.digest.latest(),
+});

--- a/workers/src/mcp/tools/get-organization-digest.ts
+++ b/workers/src/mcp/tools/get-organization-digest.ts
@@ -1,0 +1,55 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  okResult,
+  toErrorResult,
+  errorResult,
+  safeCall,
+  type CallToolResult,
+  type McpCaller,
+} from "../adapter";
+import { hasScope, type McpScope } from "../scopes";
+import type { Logger } from "../../lib/logger";
+
+type ToolContext = {
+  readonly caller: McpCaller;
+  readonly scope: McpScope;
+  readonly logger: Logger;
+};
+
+const inputSchema = z.object({});
+
+export const handleGetOrganizationDigest = async (
+  _input: z.infer<typeof inputSchema>,
+  ctx: ToolContext,
+): Promise<CallToolResult> => {
+  const log = ctx.logger.child({ tool: "get_organization_digest" });
+  if (!hasScope(ctx.scope, "read")) {
+    log.warn("scope denied");
+    return errorResult("Forbidden", "FORBIDDEN");
+  }
+  log.info("tool invoked");
+  const result = await safeCall(ctx.caller.digest.latest());
+  if (!result.ok) {
+    log.error("tool failed", { error: result.error });
+    return toErrorResult(result.error);
+  }
+  log.info("tool completed");
+  return okResult(result.value);
+};
+
+export const registerGetOrganizationDigest = (
+  server: McpServer,
+  ctx: ToolContext,
+): void => {
+  server.registerTool(
+    "get_organization_digest",
+    {
+      title: "Get organization digest",
+      description:
+        "週次ダイジェスト（在庫整理の最新サマリ）を取得する。digest.latest と同等。",
+      inputSchema: inputSchema.shape,
+    },
+    async (input) => await handleGetOrganizationDigest(input, ctx),
+  );
+};

--- a/workers/src/mcp/tools/get-storage-case.test.ts
+++ b/workers/src/mcp/tools/get-storage-case.test.ts
@@ -1,43 +1,22 @@
-import { env } from "cloudflare:test";
 import { describe, it, expect, beforeEach } from "vitest";
-import type { Context as HonoContext } from "hono";
-import { handleGetStorageCase } from "./get-storage-case";
-import { createMcpCaller } from "../adapter";
+import { getStorageCaseTool } from "./get-storage-case";
 import {
-  createStubAuth,
   createTestCaseInput,
-  createTestLogger,
   getTestDb,
   resetDatabase,
 } from "../../test/helpers";
+import { buildMcpToolCtx } from "../../test/mcp-helpers";
 
-const createStubHonoContext = (): HonoContext => {
-  const headers = new Headers();
-  const stub = { req: { raw: { headers } } };
-  return stub as unknown as HonoContext;
-};
-
-const buildCtx = (scope: "read" | "write") => ({
-  caller: createMcpCaller({
-    env,
-    auth: createStubAuth("mcp-user"),
-    honoContext: createStubHonoContext(),
-    logger: createTestLogger(),
-  }),
-  scope,
-  logger: createTestLogger(),
-});
-
-describe("handleGetStorageCase", () => {
+describe("getStorageCaseTool", () => {
   beforeEach(async () => {
     await resetDatabase(getTestDb());
   });
 
   it("returns the storage case with its locations", async () => {
-    const ctx = buildCtx("read");
+    const ctx = buildMcpToolCtx("read");
     const created = await ctx.caller.location.createCase(createTestCaseInput());
 
-    const result = await handleGetStorageCase({ id: created.id }, ctx);
+    const result = await getStorageCaseTool.handle({ id: created.id }, ctx);
 
     expect(result.isError).toBeUndefined();
     const detail = result.structuredContent as {

--- a/workers/src/mcp/tools/get-storage-case.test.ts
+++ b/workers/src/mcp/tools/get-storage-case.test.ts
@@ -1,0 +1,50 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Context as HonoContext } from "hono";
+import { handleGetStorageCase } from "./get-storage-case";
+import { createMcpCaller } from "../adapter";
+import {
+  createStubAuth,
+  createTestCaseInput,
+  createTestLogger,
+  getTestDb,
+  resetDatabase,
+} from "../../test/helpers";
+
+const createStubHonoContext = (): HonoContext => {
+  const headers = new Headers();
+  const stub = { req: { raw: { headers } } };
+  return stub as unknown as HonoContext;
+};
+
+const buildCtx = (scope: "read" | "write") => ({
+  caller: createMcpCaller({
+    env,
+    auth: createStubAuth("mcp-user"),
+    honoContext: createStubHonoContext(),
+    logger: createTestLogger(),
+  }),
+  scope,
+  logger: createTestLogger(),
+});
+
+describe("handleGetStorageCase", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("returns the storage case with its locations", async () => {
+    const ctx = buildCtx("read");
+    const created = await ctx.caller.location.createCase(createTestCaseInput());
+
+    const result = await handleGetStorageCase({ id: created.id }, ctx);
+
+    expect(result.isError).toBeUndefined();
+    const detail = result.structuredContent as {
+      readonly storageCase: { readonly id: string };
+      readonly locations: readonly unknown[];
+    };
+    expect(detail.storageCase.id).toBe(created.id);
+    expect(detail.locations.length).toBeGreaterThan(0);
+  });
+});

--- a/workers/src/mcp/tools/get-storage-case.ts
+++ b/workers/src/mcp/tools/get-storage-case.ts
@@ -1,0 +1,59 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { cuidSchema } from "../../trpc/lib/schemas";
+import {
+  okResult,
+  toErrorResult,
+  errorResult,
+  safeCall,
+  type CallToolResult,
+  type McpCaller,
+} from "../adapter";
+import { hasScope, type McpScope } from "../scopes";
+import type { Logger } from "../../lib/logger";
+
+type ToolContext = {
+  readonly caller: McpCaller;
+  readonly scope: McpScope;
+  readonly logger: Logger;
+};
+
+const inputSchema = z.object({ id: cuidSchema });
+
+export const handleGetStorageCase = async (
+  input: z.infer<typeof inputSchema>,
+  ctx: ToolContext,
+): Promise<CallToolResult> => {
+  const log = ctx.logger.child({
+    tool: "get_storage_case",
+    caseId: input.id,
+  });
+  if (!hasScope(ctx.scope, "read")) {
+    log.warn("scope denied");
+    return errorResult("Forbidden", "FORBIDDEN");
+  }
+  log.info("tool invoked");
+  const result = await safeCall(ctx.caller.location.getCase(input.id));
+  if (!result.ok) {
+    log.error("tool failed", { error: result.error });
+    return toErrorResult(result.error);
+  }
+  log.info("tool completed");
+  return okResult(result.value);
+};
+
+export const registerGetStorageCase = (
+  server: McpServer,
+  ctx: ToolContext,
+): void => {
+  server.registerTool(
+    "get_storage_case",
+    {
+      title: "Get storage case",
+      description:
+        "ID で 1 件の収納ケース詳細（含む locations 一覧）を取得する。",
+      inputSchema: inputSchema.shape,
+    },
+    async (input) => await handleGetStorageCase(input, ctx),
+  );
+};

--- a/workers/src/mcp/tools/get-storage-case.ts
+++ b/workers/src/mcp/tools/get-storage-case.ts
@@ -1,59 +1,11 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { cuidSchema } from "../../trpc/lib/schemas";
-import {
-  okResult,
-  toErrorResult,
-  errorResult,
-  safeCall,
-  type CallToolResult,
-  type McpCaller,
-} from "../adapter";
-import { hasScope, type McpScope } from "../scopes";
-import type { Logger } from "../../lib/logger";
+import { defineTool } from "./define-tool";
 
-type ToolContext = {
-  readonly caller: McpCaller;
-  readonly scope: McpScope;
-  readonly logger: Logger;
-};
-
-const inputSchema = z.object({ id: cuidSchema });
-
-export const handleGetStorageCase = async (
-  input: z.infer<typeof inputSchema>,
-  ctx: ToolContext,
-): Promise<CallToolResult> => {
-  const log = ctx.logger.child({
-    tool: "get_storage_case",
-    caseId: input.id,
-  });
-  if (!hasScope(ctx.scope, "read")) {
-    log.warn("scope denied");
-    return errorResult("Forbidden", "FORBIDDEN");
-  }
-  log.info("tool invoked");
-  const result = await safeCall(ctx.caller.location.getCase(input.id));
-  if (!result.ok) {
-    log.error("tool failed", { error: result.error });
-    return toErrorResult(result.error);
-  }
-  log.info("tool completed");
-  return okResult(result.value);
-};
-
-export const registerGetStorageCase = (
-  server: McpServer,
-  ctx: ToolContext,
-): void => {
-  server.registerTool(
-    "get_storage_case",
-    {
-      title: "Get storage case",
-      description:
-        "ID で 1 件の収納ケース詳細（含む locations 一覧）を取得する。",
-      inputSchema: inputSchema.shape,
-    },
-    async (input) => await handleGetStorageCase(input, ctx),
-  );
-};
+export const getStorageCaseTool = defineTool({
+  name: "get_storage_case",
+  title: "Get storage case",
+  description: "ID で 1 件の収納ケース詳細（含む locations 一覧）を取得する。",
+  inputSchema: z.object({ id: cuidSchema }),
+  call: async ({ id }, ctx) => await ctx.caller.location.getCase(id),
+});

--- a/workers/src/mcp/tools/list-dolls.test.ts
+++ b/workers/src/mcp/tools/list-dolls.test.ts
@@ -1,45 +1,21 @@
-import { env } from "cloudflare:test";
 import { describe, it, expect, beforeEach } from "vitest";
-import type { Context as HonoContext } from "hono";
-import { handleListDolls } from "./list-dolls";
-import { createMcpCaller } from "../adapter";
-import {
-  createStubAuth,
-  createTestLogger,
-  getTestDb,
-  resetDatabase,
-} from "../../test/helpers";
+import { listDollsTool } from "./list-dolls";
+import { getTestDb, resetDatabase } from "../../test/helpers";
+import { buildMcpToolCtx } from "../../test/mcp-helpers";
 
-const createStubHonoContext = (): HonoContext => {
-  const headers = new Headers();
-  const stub = { req: { raw: { headers } } };
-  return stub as unknown as HonoContext;
-};
-
-const buildCtx = (scope: "read" | "write") => ({
-  caller: createMcpCaller({
-    env,
-    auth: createStubAuth("mcp-user"),
-    honoContext: createStubHonoContext(),
-    logger: createTestLogger(),
-  }),
-  scope,
-  logger: createTestLogger(),
-});
-
-describe("handleListDolls", () => {
+describe("listDollsTool", () => {
   beforeEach(async () => {
     await resetDatabase(getTestDb());
   });
 
   it("returns the user's dolls", async () => {
-    const ctx = buildCtx("read");
+    const ctx = buildMcpToolCtx("read");
     await ctx.caller.doll.create({
       name: "テスト DD",
       bodySize: "DD_S",
     });
 
-    const result = await handleListDolls({}, ctx);
+    const result = await listDollsTool.handle({}, ctx);
 
     expect(result.isError).toBeUndefined();
     const list = JSON.parse(result.content[0]!.text) as Array<{
@@ -50,8 +26,8 @@ describe("handleListDolls", () => {
   });
 
   it("returns empty list when user has no dolls", async () => {
-    const ctx = buildCtx("read");
-    const result = await handleListDolls({}, ctx);
+    const ctx = buildMcpToolCtx("read");
+    const result = await listDollsTool.handle({}, ctx);
     expect(JSON.parse(result.content[0]!.text)).toEqual([]);
   });
 });

--- a/workers/src/mcp/tools/list-dolls.test.ts
+++ b/workers/src/mcp/tools/list-dolls.test.ts
@@ -1,0 +1,57 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Context as HonoContext } from "hono";
+import { handleListDolls } from "./list-dolls";
+import { createMcpCaller } from "../adapter";
+import {
+  createStubAuth,
+  createTestLogger,
+  getTestDb,
+  resetDatabase,
+} from "../../test/helpers";
+
+const createStubHonoContext = (): HonoContext => {
+  const headers = new Headers();
+  const stub = { req: { raw: { headers } } };
+  return stub as unknown as HonoContext;
+};
+
+const buildCtx = (scope: "read" | "write") => ({
+  caller: createMcpCaller({
+    env,
+    auth: createStubAuth("mcp-user"),
+    honoContext: createStubHonoContext(),
+    logger: createTestLogger(),
+  }),
+  scope,
+  logger: createTestLogger(),
+});
+
+describe("handleListDolls", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("returns the user's dolls", async () => {
+    const ctx = buildCtx("read");
+    await ctx.caller.doll.create({
+      name: "テスト DD",
+      bodySize: "DD_S",
+    });
+
+    const result = await handleListDolls({}, ctx);
+
+    expect(result.isError).toBeUndefined();
+    const list = JSON.parse(result.content[0]!.text) as Array<{
+      name: string;
+    }>;
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe("テスト DD");
+  });
+
+  it("returns empty list when user has no dolls", async () => {
+    const ctx = buildCtx("read");
+    const result = await handleListDolls({}, ctx);
+    expect(JSON.parse(result.content[0]!.text)).toEqual([]);
+  });
+});

--- a/workers/src/mcp/tools/list-dolls.ts
+++ b/workers/src/mcp/tools/list-dolls.ts
@@ -1,0 +1,53 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { z } from "zod";
+import { listDollsInputSchema } from "../../trpc/lib/schemas";
+import {
+  okResult,
+  toErrorResult,
+  errorResult,
+  safeCall,
+  type CallToolResult,
+  type McpCaller,
+} from "../adapter";
+import { hasScope, type McpScope } from "../scopes";
+import type { Logger } from "../../lib/logger";
+
+type ToolContext = {
+  readonly caller: McpCaller;
+  readonly scope: McpScope;
+  readonly logger: Logger;
+};
+
+export const handleListDolls = async (
+  input: z.infer<typeof listDollsInputSchema>,
+  ctx: ToolContext,
+): Promise<CallToolResult> => {
+  const log = ctx.logger.child({ tool: "list_dolls" });
+  if (!hasScope(ctx.scope, "read")) {
+    log.warn("scope denied");
+    return errorResult("Forbidden", "FORBIDDEN");
+  }
+  log.info("tool invoked", { input });
+  const result = await safeCall(ctx.caller.doll.list(input));
+  if (!result.ok) {
+    log.error("tool failed", { error: result.error });
+    return toErrorResult(result.error);
+  }
+  log.info("tool completed", { count: result.value.length });
+  return okResult(result.value);
+};
+
+export const registerListDolls = (
+  server: McpServer,
+  ctx: ToolContext,
+): void => {
+  server.registerTool(
+    "list_dolls",
+    {
+      title: "List dolls",
+      description: "ユーザーのドール一覧を取得する。bodySize でフィルタ可能。",
+      inputSchema: listDollsInputSchema.shape,
+    },
+    async (input) => await handleListDolls(input, ctx),
+  );
+};

--- a/workers/src/mcp/tools/list-dolls.ts
+++ b/workers/src/mcp/tools/list-dolls.ts
@@ -1,53 +1,10 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { z } from "zod";
 import { listDollsInputSchema } from "../../trpc/lib/schemas";
-import {
-  okResult,
-  toErrorResult,
-  errorResult,
-  safeCall,
-  type CallToolResult,
-  type McpCaller,
-} from "../adapter";
-import { hasScope, type McpScope } from "../scopes";
-import type { Logger } from "../../lib/logger";
+import { defineTool } from "./define-tool";
 
-type ToolContext = {
-  readonly caller: McpCaller;
-  readonly scope: McpScope;
-  readonly logger: Logger;
-};
-
-export const handleListDolls = async (
-  input: z.infer<typeof listDollsInputSchema>,
-  ctx: ToolContext,
-): Promise<CallToolResult> => {
-  const log = ctx.logger.child({ tool: "list_dolls" });
-  if (!hasScope(ctx.scope, "read")) {
-    log.warn("scope denied");
-    return errorResult("Forbidden", "FORBIDDEN");
-  }
-  log.info("tool invoked", { input });
-  const result = await safeCall(ctx.caller.doll.list(input));
-  if (!result.ok) {
-    log.error("tool failed", { error: result.error });
-    return toErrorResult(result.error);
-  }
-  log.info("tool completed", { count: result.value.length });
-  return okResult(result.value);
-};
-
-export const registerListDolls = (
-  server: McpServer,
-  ctx: ToolContext,
-): void => {
-  server.registerTool(
-    "list_dolls",
-    {
-      title: "List dolls",
-      description: "ユーザーのドール一覧を取得する。bodySize でフィルタ可能。",
-      inputSchema: listDollsInputSchema.shape,
-    },
-    async (input) => await handleListDolls(input, ctx),
-  );
-};
+export const listDollsTool = defineTool({
+  name: "list_dolls",
+  title: "List dolls",
+  description: "ユーザーのドール一覧を取得する。bodySize でフィルタ可能。",
+  inputSchema: listDollsInputSchema,
+  call: async (input, ctx) => await ctx.caller.doll.list(input),
+});

--- a/workers/src/mcp/tools/list-garments.test.ts
+++ b/workers/src/mcp/tools/list-garments.test.ts
@@ -1,0 +1,80 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import { handleListGarments } from "./list-garments";
+import { createMcpCaller } from "../adapter";
+import {
+  createStubAuth,
+  createTestGarmentInput,
+  createTestLogger,
+  getTestDb,
+  resetDatabase,
+} from "../../test/helpers";
+import type { Context as HonoContext } from "hono";
+
+const createStubHonoContext = (): HonoContext => {
+  const headers = new Headers();
+  const stub = { req: { raw: { headers } } };
+  return stub as unknown as HonoContext;
+};
+
+const buildCtx = (scope: "read" | "write") => ({
+  caller: createMcpCaller({
+    env,
+    auth: createStubAuth("mcp-user"),
+    honoContext: createStubHonoContext(),
+    logger: createTestLogger(),
+  }),
+  scope,
+  logger: createTestLogger(),
+});
+
+describe("handleListGarments", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("returns the user's garments as structured content", async () => {
+    const ctx = buildCtx("read");
+    await ctx.caller.garment.create(
+      createTestGarmentInput({ name: "ドレス A" }),
+    );
+    await ctx.caller.garment.create(
+      createTestGarmentInput({ name: "ドレス B" }),
+    );
+
+    const result = await handleListGarments({}, ctx);
+
+    expect(result.isError).toBeUndefined();
+    const list = JSON.parse(result.content[0]!.text) as Array<{
+      name: string;
+    }>;
+    expect(list.map((g) => g.name).sort()).toEqual(["ドレス A", "ドレス B"]);
+  });
+
+  it("filters garments by category", async () => {
+    const ctx = buildCtx("read");
+    await ctx.caller.garment.create(
+      createTestGarmentInput({ name: "ドレス", category: "dress" }),
+    );
+    await ctx.caller.garment.create(
+      createTestGarmentInput({ name: "シャツ", category: "tops" }),
+    );
+
+    const result = await handleListGarments({ category: "dress" }, ctx);
+
+    const list = JSON.parse(result.content[0]!.text) as Array<{
+      name: string;
+      category: string;
+    }>;
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe("ドレス");
+  });
+
+  it("returns empty list when no garments exist", async () => {
+    const ctx = buildCtx("read");
+    const result = await handleListGarments({}, ctx);
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0]!.text)).toEqual([]);
+  });
+});

--- a/workers/src/mcp/tools/list-garments.test.ts
+++ b/workers/src/mcp/tools/list-garments.test.ts
@@ -56,4 +56,18 @@ describe("listGarmentsTool", () => {
     expect(result.isError).toBeUndefined();
     expect(JSON.parse(result.content[0]!.text)).toEqual([]);
   });
+
+  it("treats omitted arguments as no-filter (MCP allows undefined params.arguments)", async () => {
+    const ctx = buildMcpToolCtx("read");
+    await ctx.caller.garment.create(
+      createTestGarmentInput({ name: "no-args" }),
+    );
+
+    const result = await listGarmentsTool.handle(undefined, ctx);
+
+    expect(result.isError).toBeUndefined();
+    const list = JSON.parse(result.content[0]!.text) as Array<{ name: string }>;
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe("no-args");
+  });
 });

--- a/workers/src/mcp/tools/list-garments.test.ts
+++ b/workers/src/mcp/tools/list-garments.test.ts
@@ -1,40 +1,19 @@
-import { env } from "cloudflare:test";
 import { describe, it, expect, beforeEach } from "vitest";
-import { handleListGarments } from "./list-garments";
-import { createMcpCaller } from "../adapter";
+import { listGarmentsTool } from "./list-garments";
 import {
-  createStubAuth,
   createTestGarmentInput,
-  createTestLogger,
   getTestDb,
   resetDatabase,
 } from "../../test/helpers";
-import type { Context as HonoContext } from "hono";
+import { buildMcpToolCtx } from "../../test/mcp-helpers";
 
-const createStubHonoContext = (): HonoContext => {
-  const headers = new Headers();
-  const stub = { req: { raw: { headers } } };
-  return stub as unknown as HonoContext;
-};
-
-const buildCtx = (scope: "read" | "write") => ({
-  caller: createMcpCaller({
-    env,
-    auth: createStubAuth("mcp-user"),
-    honoContext: createStubHonoContext(),
-    logger: createTestLogger(),
-  }),
-  scope,
-  logger: createTestLogger(),
-});
-
-describe("handleListGarments", () => {
+describe("listGarmentsTool", () => {
   beforeEach(async () => {
     await resetDatabase(getTestDb());
   });
 
-  it("returns the user's garments as structured content", async () => {
-    const ctx = buildCtx("read");
+  it("returns the user's garments as text content (parseable JSON)", async () => {
+    const ctx = buildMcpToolCtx("read");
     await ctx.caller.garment.create(
       createTestGarmentInput({ name: "ドレス A" }),
     );
@@ -42,7 +21,7 @@ describe("handleListGarments", () => {
       createTestGarmentInput({ name: "ドレス B" }),
     );
 
-    const result = await handleListGarments({}, ctx);
+    const result = await listGarmentsTool.handle({}, ctx);
 
     expect(result.isError).toBeUndefined();
     const list = JSON.parse(result.content[0]!.text) as Array<{
@@ -52,7 +31,7 @@ describe("handleListGarments", () => {
   });
 
   it("filters garments by category", async () => {
-    const ctx = buildCtx("read");
+    const ctx = buildMcpToolCtx("read");
     await ctx.caller.garment.create(
       createTestGarmentInput({ name: "ドレス", category: "dress" }),
     );
@@ -60,7 +39,7 @@ describe("handleListGarments", () => {
       createTestGarmentInput({ name: "シャツ", category: "tops" }),
     );
 
-    const result = await handleListGarments({ category: "dress" }, ctx);
+    const result = await listGarmentsTool.handle({ category: "dress" }, ctx);
 
     const list = JSON.parse(result.content[0]!.text) as Array<{
       name: string;
@@ -71,8 +50,8 @@ describe("handleListGarments", () => {
   });
 
   it("returns empty list when no garments exist", async () => {
-    const ctx = buildCtx("read");
-    const result = await handleListGarments({}, ctx);
+    const ctx = buildMcpToolCtx("read");
+    const result = await listGarmentsTool.handle({}, ctx);
 
     expect(result.isError).toBeUndefined();
     expect(JSON.parse(result.content[0]!.text)).toEqual([]);

--- a/workers/src/mcp/tools/list-garments.ts
+++ b/workers/src/mcp/tools/list-garments.ts
@@ -1,0 +1,54 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { z } from "zod";
+import { listGarmentsInputSchema } from "../../trpc/lib/schemas";
+import {
+  okResult,
+  toErrorResult,
+  errorResult,
+  safeCall,
+  type CallToolResult,
+  type McpCaller,
+} from "../adapter";
+import { hasScope, type McpScope } from "../scopes";
+import type { Logger } from "../../lib/logger";
+
+type ToolContext = {
+  readonly caller: McpCaller;
+  readonly scope: McpScope;
+  readonly logger: Logger;
+};
+
+export const handleListGarments = async (
+  input: z.infer<typeof listGarmentsInputSchema>,
+  ctx: ToolContext,
+): Promise<CallToolResult> => {
+  const log = ctx.logger.child({ tool: "list_garments" });
+  if (!hasScope(ctx.scope, "read")) {
+    log.warn("scope denied");
+    return errorResult("Forbidden", "FORBIDDEN");
+  }
+  log.info("tool invoked", { input });
+  const result = await safeCall(ctx.caller.garment.list(input));
+  if (!result.ok) {
+    log.error("tool failed", { error: result.error });
+    return toErrorResult(result.error);
+  }
+  log.info("tool completed", { count: result.value.length });
+  return okResult(result.value);
+};
+
+export const registerListGarments = (
+  server: McpServer,
+  ctx: ToolContext,
+): void => {
+  server.registerTool(
+    "list_garments",
+    {
+      title: "List garments",
+      description:
+        "ユーザーの服一覧を取得する。category / status / dollSize / locationId でフィルタ可能。",
+      inputSchema: listGarmentsInputSchema.shape,
+    },
+    async (input) => await handleListGarments(input, ctx),
+  );
+};

--- a/workers/src/mcp/tools/list-garments.ts
+++ b/workers/src/mcp/tools/list-garments.ts
@@ -1,54 +1,11 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { z } from "zod";
 import { listGarmentsInputSchema } from "../../trpc/lib/schemas";
-import {
-  okResult,
-  toErrorResult,
-  errorResult,
-  safeCall,
-  type CallToolResult,
-  type McpCaller,
-} from "../adapter";
-import { hasScope, type McpScope } from "../scopes";
-import type { Logger } from "../../lib/logger";
+import { defineTool } from "./define-tool";
 
-type ToolContext = {
-  readonly caller: McpCaller;
-  readonly scope: McpScope;
-  readonly logger: Logger;
-};
-
-export const handleListGarments = async (
-  input: z.infer<typeof listGarmentsInputSchema>,
-  ctx: ToolContext,
-): Promise<CallToolResult> => {
-  const log = ctx.logger.child({ tool: "list_garments" });
-  if (!hasScope(ctx.scope, "read")) {
-    log.warn("scope denied");
-    return errorResult("Forbidden", "FORBIDDEN");
-  }
-  log.info("tool invoked", { input });
-  const result = await safeCall(ctx.caller.garment.list(input));
-  if (!result.ok) {
-    log.error("tool failed", { error: result.error });
-    return toErrorResult(result.error);
-  }
-  log.info("tool completed", { count: result.value.length });
-  return okResult(result.value);
-};
-
-export const registerListGarments = (
-  server: McpServer,
-  ctx: ToolContext,
-): void => {
-  server.registerTool(
-    "list_garments",
-    {
-      title: "List garments",
-      description:
-        "ユーザーの服一覧を取得する。category / status / dollSize / locationId でフィルタ可能。",
-      inputSchema: listGarmentsInputSchema.shape,
-    },
-    async (input) => await handleListGarments(input, ctx),
-  );
-};
+export const listGarmentsTool = defineTool({
+  name: "list_garments",
+  title: "List garments",
+  description:
+    "ユーザーの服一覧を取得する。category / status / dollSize / locationId でフィルタ可能。",
+  inputSchema: listGarmentsInputSchema,
+  call: async (input, ctx) => await ctx.caller.garment.list(input),
+});

--- a/workers/src/mcp/tools/list-storage-cases.test.ts
+++ b/workers/src/mcp/tools/list-storage-cases.test.ts
@@ -1,0 +1,49 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Context as HonoContext } from "hono";
+import { handleListStorageCases } from "./list-storage-cases";
+import { createMcpCaller } from "../adapter";
+import {
+  createStubAuth,
+  createTestCaseInput,
+  createTestLogger,
+  getTestDb,
+  resetDatabase,
+} from "../../test/helpers";
+
+const createStubHonoContext = (): HonoContext => {
+  const headers = new Headers();
+  const stub = { req: { raw: { headers } } };
+  return stub as unknown as HonoContext;
+};
+
+const buildCtx = (scope: "read" | "write") => ({
+  caller: createMcpCaller({
+    env,
+    auth: createStubAuth("mcp-user"),
+    honoContext: createStubHonoContext(),
+    logger: createTestLogger(),
+  }),
+  scope,
+  logger: createTestLogger(),
+});
+
+describe("handleListStorageCases", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("returns the user's storage cases", async () => {
+    const ctx = buildCtx("read");
+    await ctx.caller.location.createCase(createTestCaseInput());
+
+    const result = await handleListStorageCases({}, ctx);
+
+    expect(result.isError).toBeUndefined();
+    const payload = result.structuredContent as {
+      readonly cases: ReadonlyArray<{ readonly name: string }>;
+    };
+    expect(payload.cases).toHaveLength(1);
+    expect(payload.cases[0]?.name).toBe("テスト衣装ケース");
+  });
+});

--- a/workers/src/mcp/tools/list-storage-cases.test.ts
+++ b/workers/src/mcp/tools/list-storage-cases.test.ts
@@ -1,43 +1,22 @@
-import { env } from "cloudflare:test";
 import { describe, it, expect, beforeEach } from "vitest";
-import type { Context as HonoContext } from "hono";
-import { handleListStorageCases } from "./list-storage-cases";
-import { createMcpCaller } from "../adapter";
+import { listStorageCasesTool } from "./list-storage-cases";
 import {
-  createStubAuth,
   createTestCaseInput,
-  createTestLogger,
   getTestDb,
   resetDatabase,
 } from "../../test/helpers";
+import { buildMcpToolCtx } from "../../test/mcp-helpers";
 
-const createStubHonoContext = (): HonoContext => {
-  const headers = new Headers();
-  const stub = { req: { raw: { headers } } };
-  return stub as unknown as HonoContext;
-};
-
-const buildCtx = (scope: "read" | "write") => ({
-  caller: createMcpCaller({
-    env,
-    auth: createStubAuth("mcp-user"),
-    honoContext: createStubHonoContext(),
-    logger: createTestLogger(),
-  }),
-  scope,
-  logger: createTestLogger(),
-});
-
-describe("handleListStorageCases", () => {
+describe("listStorageCasesTool", () => {
   beforeEach(async () => {
     await resetDatabase(getTestDb());
   });
 
   it("returns the user's storage cases", async () => {
-    const ctx = buildCtx("read");
+    const ctx = buildMcpToolCtx("read");
     await ctx.caller.location.createCase(createTestCaseInput());
 
-    const result = await handleListStorageCases({}, ctx);
+    const result = await listStorageCasesTool.handle({}, ctx);
 
     expect(result.isError).toBeUndefined();
     const payload = result.structuredContent as {

--- a/workers/src/mcp/tools/list-storage-cases.ts
+++ b/workers/src/mcp/tools/list-storage-cases.ts
@@ -1,54 +1,10 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import {
-  okResult,
-  toErrorResult,
-  errorResult,
-  safeCall,
-  type CallToolResult,
-  type McpCaller,
-} from "../adapter";
-import { hasScope, type McpScope } from "../scopes";
-import type { Logger } from "../../lib/logger";
+import { defineTool } from "./define-tool";
 
-type ToolContext = {
-  readonly caller: McpCaller;
-  readonly scope: McpScope;
-  readonly logger: Logger;
-};
-
-const inputSchema = z.object({});
-
-export const handleListStorageCases = async (
-  _input: z.infer<typeof inputSchema>,
-  ctx: ToolContext,
-): Promise<CallToolResult> => {
-  const log = ctx.logger.child({ tool: "list_storage_cases" });
-  if (!hasScope(ctx.scope, "read")) {
-    log.warn("scope denied");
-    return errorResult("Forbidden", "FORBIDDEN");
-  }
-  log.info("tool invoked");
-  const result = await safeCall(ctx.caller.location.listCases());
-  if (!result.ok) {
-    log.error("tool failed", { error: result.error });
-    return toErrorResult(result.error);
-  }
-  log.info("tool completed", { count: result.value.cases.length });
-  return okResult(result.value);
-};
-
-export const registerListStorageCases = (
-  server: McpServer,
-  ctx: ToolContext,
-): void => {
-  server.registerTool(
-    "list_storage_cases",
-    {
-      title: "List storage cases",
-      description: "ユーザーの収納ケース（衣装ケース）一覧を取得する。",
-      inputSchema: inputSchema.shape,
-    },
-    async (input) => await handleListStorageCases(input, ctx),
-  );
-};
+export const listStorageCasesTool = defineTool({
+  name: "list_storage_cases",
+  title: "List storage cases",
+  description: "ユーザーの収納ケース（衣装ケース）一覧を取得する。",
+  inputSchema: z.object({}),
+  call: async (_input, ctx) => await ctx.caller.location.listCases(),
+});

--- a/workers/src/mcp/tools/list-storage-cases.ts
+++ b/workers/src/mcp/tools/list-storage-cases.ts
@@ -1,0 +1,54 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  okResult,
+  toErrorResult,
+  errorResult,
+  safeCall,
+  type CallToolResult,
+  type McpCaller,
+} from "../adapter";
+import { hasScope, type McpScope } from "../scopes";
+import type { Logger } from "../../lib/logger";
+
+type ToolContext = {
+  readonly caller: McpCaller;
+  readonly scope: McpScope;
+  readonly logger: Logger;
+};
+
+const inputSchema = z.object({});
+
+export const handleListStorageCases = async (
+  _input: z.infer<typeof inputSchema>,
+  ctx: ToolContext,
+): Promise<CallToolResult> => {
+  const log = ctx.logger.child({ tool: "list_storage_cases" });
+  if (!hasScope(ctx.scope, "read")) {
+    log.warn("scope denied");
+    return errorResult("Forbidden", "FORBIDDEN");
+  }
+  log.info("tool invoked");
+  const result = await safeCall(ctx.caller.location.listCases());
+  if (!result.ok) {
+    log.error("tool failed", { error: result.error });
+    return toErrorResult(result.error);
+  }
+  log.info("tool completed", { count: result.value.cases.length });
+  return okResult(result.value);
+};
+
+export const registerListStorageCases = (
+  server: McpServer,
+  ctx: ToolContext,
+): void => {
+  server.registerTool(
+    "list_storage_cases",
+    {
+      title: "List storage cases",
+      description: "ユーザーの収納ケース（衣装ケース）一覧を取得する。",
+      inputSchema: inputSchema.shape,
+    },
+    async (input) => await handleListStorageCases(input, ctx),
+  );
+};

--- a/workers/src/mcp/tools/register-all.ts
+++ b/workers/src/mcp/tools/register-all.ts
@@ -1,28 +1,25 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { Logger } from "../../lib/logger";
-import type { McpCaller } from "../adapter";
-import type { McpScope } from "../scopes";
-import { registerListGarments } from "./list-garments";
-import { registerGetGarment } from "./get-garment";
-import { registerListDolls } from "./list-dolls";
-import { registerListStorageCases } from "./list-storage-cases";
-import { registerGetStorageCase } from "./get-storage-case";
-import { registerGetOrganizationDigest } from "./get-organization-digest";
-import { registerAddGarmentTags } from "./add-garment-tags";
+import { addGarmentTagsTool } from "./add-garment-tags";
+import type { DefinedTool, ToolContext } from "./define-tool";
+import { getGarmentTool } from "./get-garment";
+import { getOrganizationDigestTool } from "./get-organization-digest";
+import { getStorageCaseTool } from "./get-storage-case";
+import { listDollsTool } from "./list-dolls";
+import { listGarmentsTool } from "./list-garments";
+import { listStorageCasesTool } from "./list-storage-cases";
 
-export const registerAllTools = (
-  server: McpServer,
-  ctx: {
-    readonly caller: McpCaller;
-    readonly scope: McpScope;
-    readonly logger: Logger;
-  },
-): void => {
-  registerListGarments(server, ctx);
-  registerGetGarment(server, ctx);
-  registerListDolls(server, ctx);
-  registerListStorageCases(server, ctx);
-  registerGetStorageCase(server, ctx);
-  registerGetOrganizationDigest(server, ctx);
-  registerAddGarmentTags(server, ctx);
+export const ALL_TOOLS: readonly DefinedTool[] = [
+  listGarmentsTool,
+  getGarmentTool,
+  listDollsTool,
+  listStorageCasesTool,
+  getStorageCaseTool,
+  getOrganizationDigestTool,
+  addGarmentTagsTool,
+];
+
+export const registerAllTools = (server: McpServer, ctx: ToolContext): void => {
+  ALL_TOOLS.forEach((tool) => {
+    tool.register(server, ctx);
+  });
 };

--- a/workers/src/mcp/tools/register-all.ts
+++ b/workers/src/mcp/tools/register-all.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Logger } from "../../lib/logger";
+import type { McpCaller } from "../adapter";
+import type { McpScope } from "../scopes";
+import { registerListGarments } from "./list-garments";
+import { registerGetGarment } from "./get-garment";
+import { registerListDolls } from "./list-dolls";
+import { registerListStorageCases } from "./list-storage-cases";
+import { registerGetStorageCase } from "./get-storage-case";
+import { registerGetOrganizationDigest } from "./get-organization-digest";
+import { registerAddGarmentTags } from "./add-garment-tags";
+
+export const registerAllTools = (
+  server: McpServer,
+  ctx: {
+    readonly caller: McpCaller;
+    readonly scope: McpScope;
+    readonly logger: Logger;
+  },
+): void => {
+  registerListGarments(server, ctx);
+  registerGetGarment(server, ctx);
+  registerListDolls(server, ctx);
+  registerListStorageCases(server, ctx);
+  registerGetStorageCase(server, ctx);
+  registerGetOrganizationDigest(server, ctx);
+  registerAddGarmentTags(server, ctx);
+};

--- a/workers/src/test/helpers.ts
+++ b/workers/src/test/helpers.ts
@@ -37,11 +37,6 @@ export const createStubAuth = (userId: string | undefined): Auth => {
   return stub as unknown as Auth;
 };
 
-const createStubHonoContext = () => {
-  const headers = new Headers();
-  return { req: { raw: { headers } } } as unknown as TRPCContext["honoContext"];
-};
-
 export const createTestCaller = ({
   userId = TEST_USER_ID,
   logger = createTestLogger(),
@@ -52,8 +47,7 @@ export const createTestCaller = ({
   const mockCtx: TRPCContext = {
     env,
     logger,
-    auth: createStubAuth(userId),
-    honoContext: createStubHonoContext(),
+    preAuthenticatedUserId: userId,
   };
   return createCaller(mockCtx);
 };

--- a/workers/src/test/mcp-helpers.ts
+++ b/workers/src/test/mcp-helpers.ts
@@ -1,21 +1,23 @@
 import { env } from "cloudflare:test";
-import type { Context as HonoContext } from "hono";
 import type { Auth } from "../auth";
 import { createMcpCaller } from "../mcp/adapter";
 import type { McpScope } from "../mcp/scopes";
 import { createTestLogger, TEST_USER_ID } from "./helpers";
 
-export const createStubHonoContext = (): HonoContext => {
-  const headers = new Headers();
-  const stub = { req: { raw: { headers } } };
-  return stub as unknown as HonoContext;
-};
-
 type VerifyFn = (args: { body: { key: string } }) => Promise<unknown>;
+type GetSessionFn = (args: { headers: Headers }) => Promise<unknown>;
 
-export const createApiKeyAuthStub = (verifyApiKey: VerifyFn): Auth => {
-  const stub = { api: { verifyApiKey } };
-  return stub as unknown as Auth;
+export const createApiKeyAuthStub = (
+  verifyApiKey: VerifyFn,
+  getSession?: GetSessionFn,
+): Auth => {
+  const api: { verifyApiKey: VerifyFn; getSession?: GetSessionFn } = {
+    verifyApiKey,
+  };
+  if (getSession !== undefined) {
+    api.getSession = getSession;
+  }
+  return { api } as unknown as Auth;
 };
 
 export const buildMcpToolCtx = (

--- a/workers/src/test/mcp-helpers.ts
+++ b/workers/src/test/mcp-helpers.ts
@@ -1,0 +1,33 @@
+import { env } from "cloudflare:test";
+import type { Context as HonoContext } from "hono";
+import type { Auth } from "../auth";
+import { createMcpCaller } from "../mcp/adapter";
+import type { McpScope } from "../mcp/scopes";
+import { createStubAuth, createTestLogger, TEST_USER_ID } from "./helpers";
+
+export const createStubHonoContext = (): HonoContext => {
+  const headers = new Headers();
+  const stub = { req: { raw: { headers } } };
+  return stub as unknown as HonoContext;
+};
+
+type VerifyFn = (args: { body: { key: string } }) => Promise<unknown>;
+
+export const createApiKeyAuthStub = (verifyApiKey: VerifyFn): Auth => {
+  const stub = { api: { verifyApiKey } };
+  return stub as unknown as Auth;
+};
+
+export const buildMcpToolCtx = (
+  scope: McpScope,
+  options: { readonly userId?: string } = {},
+) => ({
+  caller: createMcpCaller({
+    env,
+    auth: createStubAuth(options.userId ?? TEST_USER_ID),
+    honoContext: createStubHonoContext(),
+    logger: createTestLogger(),
+  }),
+  scope,
+  logger: createTestLogger(),
+});

--- a/workers/src/test/mcp-helpers.ts
+++ b/workers/src/test/mcp-helpers.ts
@@ -3,7 +3,7 @@ import type { Context as HonoContext } from "hono";
 import type { Auth } from "../auth";
 import { createMcpCaller } from "../mcp/adapter";
 import type { McpScope } from "../mcp/scopes";
-import { createStubAuth, createTestLogger, TEST_USER_ID } from "./helpers";
+import { createTestLogger, TEST_USER_ID } from "./helpers";
 
 export const createStubHonoContext = (): HonoContext => {
   const headers = new Headers();
@@ -24,8 +24,7 @@ export const buildMcpToolCtx = (
 ) => ({
   caller: createMcpCaller({
     env,
-    auth: createStubAuth(options.userId ?? TEST_USER_ID),
-    honoContext: createStubHonoContext(),
+    userId: options.userId ?? TEST_USER_ID,
     logger: createTestLogger(),
   }),
   scope,

--- a/workers/src/trpc/index.ts
+++ b/workers/src/trpc/index.ts
@@ -10,6 +10,9 @@ export type TRPCContext = {
   readonly honoContext?: HonoContext;
   readonly auth?: Auth;
   readonly logger: Logger;
+  // 上流ですでに認証が確定している場合 (例: MCP の API キー検証後) に渡す。
+  // 値があれば authMiddleware は cookie/Bearer の再評価をスキップし、混在クレデンシャル時の身元なりすましを防ぐ。
+  readonly preAuthenticatedUserId?: string;
 };
 
 export type AuthenticatedTRPCContext = TRPCContext & {
@@ -33,6 +36,12 @@ const loggingMiddleware = t.middleware(async ({ ctx, path, type, next }) => {
 });
 
 const authMiddleware = t.middleware(async ({ ctx, next }) => {
+  if (ctx.preAuthenticatedUserId !== undefined) {
+    return await next({
+      ctx: { ...ctx, userId: ctx.preAuthenticatedUserId },
+    });
+  }
+
   if (ctx.auth === undefined || ctx.honoContext === undefined) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }


### PR DESCRIPTION
## Summary

外部 AI エージェント連携基盤 (#121) の中核タスク。Cloudflare Workers 上で MCP (Model Context Protocol) サーバーを `/api/mcp` に公開し、Claude Desktop / Claude.ai / 自作エージェントから Dollrobe のデータに接続できるようにする。

第 1 弾は **読み取り中心 + タグ追加のみ** に絞る。`coordinate.*` 系は #127 完了後 #131 で追加予定。

Closes #123

## 設計判断

| 論点 | 採用 | 理由 |
|---|---|---|
| MCP transport | `WebStandardStreamableHTTPServerTransport` (stateless POST のみ) | Cloudflare Workers Web 標準 API ネイティブ。`fetch-to-node` 不要。GET / DELETE は 405 を JSON-RPC envelope で返す |
| scope 保存先 | better-auth API key の `permissions` フィールド | 公式の意図と一致、将来 SDK 側 permission チェックに切替可 |
| scope 表現 | `{ mcp: ["read"] }` / `{ mcp: ["read", "write"] }` | better-auth の `Record<string, string[]>` 標準。複数 scope kind を加えやすい |
| `add_garment_tags` | merge + dedup (既存タグを保持) | issue 「タグ追加のみ」 + LLM が誤って既存タグを破壊しない安全設計 |
| Cookie 認証対応 | 非対応 (Bearer のみ) | MCP クライアントの標準が Bearer。Cookie session に scope 概念を後付けしないで済む |
| tRPC procedure 再実装 | しない (createCallerFactory で per-request caller) | 既存ロジック温存、Phase 3 切り替え可能性を維持 |

## 実装の詳細

- **依存追加**: `@modelcontextprotocol/sdk@^1.29.0`
- **新規ディレクトリ**: `workers/src/mcp/{auth,adapter,scopes,server}.ts` + `tools/*.ts`
- **マウント**: `workers/src/index.ts` の `app.use("/trpc/*", ...)` 直前に `app.{post,get,delete}("/api/mcp", ...)` を追加
- **公開する 7 tool**:
  - read: `list_garments`, `get_garment`, `list_dolls`, `list_storage_cases`, `get_storage_case`, `get_organization_digest`
  - write: `add_garment_tags` (write scope 必須)
- **公開しない**: `*.delete`, `scan.*`, `sync.*`, `coordinate.*` — tools/ にファイルを置かない + `scopes.ts` ホワイトリストの二重ガード

## Test plan

- [x] `pnpm precheck` グリーン (typecheck / lint / format / i18n すべて pass)
- [x] `pnpm test:workers workers/src/mcp/` グリーン: **52 tests pass**
  - scopes (13): parsePermissions / hasScope / TOOL_REQUIRED_SCOPE
  - auth (10): Bearer 抽出 / verifyApiKey mock / scope パターン全網羅
  - adapter (10): createMcpCaller の userId 分離 + okResult / errorResult / toErrorResult
  - tools/list-garments (3): フィルタ / 空リスト
  - tools/list-dolls (2)、tools/list-storage-cases (1)、tools/get-storage-case (1)、tools/get-garment (2)、tools/get-organization-digest (1)
  - tools/add-garment-tags (4): read scope 拒否 / マージ + 重複排除 / 非 tag フィールド保護 / 存在しない garment
  - server (5): 401 (no Bearer / no scope) / 405 (GET / DELETE) / initialize handshake
- [x] `pnpm test:workers` 全体: **1073 tests pass** (回帰なし)
- [x] `pnpm test:coverage`: branches 85.05% (閾値 80% を上回る)
- [ ] **Verification (デプロイ後)**: Claude Desktop の `mcp.json` に `{ "url": "https://<deployed>/api/mcp", "headers": { "Authorization": "Bearer <key>" } }` を登録し、`tools/list` で 7 tool 返却 + `list_garments` で実データ確認
- [ ] **Verification (デプロイ後)**: `permissions: { mcp: ["read"] }` の API キーで `add_garment_tags` 呼び出し → MCP レベルで `isError: true` "Forbidden" 返却
- [ ] **Verification (デプロイ後)**: `tools/list` に `garment.delete` / `coordinate.create` / `scan.checkin` / `sync.push` が現れないこと

## API キー発行手順 (本 PR スコープ外)

UI は後続 PR / scripts/ で対応。本 PR では `auth.api.createApiKey({ body: { userId, permissions: { mcp: ["read"] } } })` を直接呼ぶ手順を README 等で案内する想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)