### PR TITLE
feat(auth): id/pass 認証・サインアップ・アカウント設定画面を追加

### DIFF
--- a/src/app/settings/account/page.test.tsx
+++ b/src/app/settings/account/page.test.tsx
@@ -101,6 +101,36 @@ describe("AccountSettingsPage", () => {
     });
   });
 
+  it("OAuth-only ユーザーはパスワード設定モードで現在のパスワード入力が出ない", async () => {
+    const { spies } = setupAuthClient({
+      accounts: [{ providerId: "google" }],
+    });
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await screen.findByRole("heading", { name: "パスワード" });
+
+    expect(screen.queryByLabelText("現在のパスワード")).toBeNull();
+    expect(
+      await screen.findByRole("button", { name: "パスワードを設定" }),
+    ).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("パスワード"), "newpass12");
+    await user.type(
+      screen.getByLabelText("新しいパスワード（確認）"),
+      "newpass12",
+    );
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+
+    await waitFor(() => {
+      expect(spies.changePassword).toHaveBeenCalledWith({
+        currentPassword: undefined,
+        newPassword: "newpass12",
+        newPasswordConfirm: "newpass12",
+      });
+    });
+  });
+
   it("退会フローでメール一致時のみ削除ボタンが有効", async () => {
     const { spies } = setupAuthClient();
     const { router } = setupNextNavigation();

--- a/src/app/settings/account/page.test.tsx
+++ b/src/app/settings/account/page.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { server } from "@/test/mocks/server";
+import { unauthenticatedHandler } from "@/test/mocks/handlers";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import { setupAuthClient } from "@/test/mocks/modules/authClient";
+import AccountSettingsPage from "./page";
+
+describe("AccountSettingsPage", () => {
+  beforeEach(() => {
+    setupNextNavigation();
+    setupAuthClient();
+  });
+
+  it("4 セクションすべてが表示される", async () => {
+    await renderWithProviders(<AccountSettingsPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: "プロフィール" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "メールアドレス" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "パスワード" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "アカウントを削除" }),
+    ).toBeInTheDocument();
+  });
+
+  it("プロフィールフォームに現在の値が表示される", async () => {
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const nameInput = await screen.findByLabelText("表示名");
+    expect(nameInput).toHaveValue("テストユーザー");
+  });
+
+  it("プロフィール更新が成功すると updateProfile が呼ばれる", async () => {
+    const { spies } = setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const nameInput = await screen.findByLabelText("表示名");
+    await user.clear(nameInput);
+    await user.type(nameInput, "新しい名前");
+    await user.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    await waitFor(() => {
+      expect(spies.updateProfile).toHaveBeenCalledWith({
+        name: "新しい名前",
+        image: undefined,
+      });
+    });
+  });
+
+  it("メールアドレス変更が成功すると changeEmail が呼ばれる", async () => {
+    const { spies } = setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await user.type(
+      await screen.findByLabelText("新しいメールアドレス"),
+      "new@example.com",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "メールアドレスを変更" }),
+    );
+
+    await waitFor(() => {
+      expect(spies.changeEmail).toHaveBeenCalledWith({
+        newEmail: "new@example.com",
+      });
+    });
+  });
+
+  it("パスワード変更が成功すると changePassword が呼ばれる", async () => {
+    const { spies } = setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await user.type(
+      await screen.findByLabelText("現在のパスワード"),
+      "oldpass12",
+    );
+    await user.type(screen.getByLabelText("新しいパスワード"), "newpass12");
+    await user.type(
+      screen.getByLabelText("新しいパスワード（確認）"),
+      "newpass12",
+    );
+    await user.click(screen.getByRole("button", { name: "パスワードを変更" }));
+
+    await waitFor(() => {
+      expect(spies.changePassword).toHaveBeenCalledWith({
+        currentPassword: "oldpass12",
+        newPassword: "newpass12",
+        newPasswordConfirm: "newpass12",
+      });
+    });
+  });
+
+  it("退会フローでメール一致時のみ削除ボタンが有効", async () => {
+    const { spies } = setupAuthClient();
+    const { router } = setupNextNavigation();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "アカウントを削除する" }),
+    );
+
+    const finalDelete = await screen.findByRole("button", {
+      name: "完全に削除",
+    });
+    expect(finalDelete).toBeDisabled();
+
+    await user.type(
+      screen.getByLabelText("メールアドレスを再入力"),
+      "test@example.com",
+    );
+
+    await waitFor(() => {
+      expect(finalDelete).not.toBeDisabled();
+    });
+
+    await user.click(finalDelete);
+
+    await waitFor(() => {
+      expect(spies.deleteAccount).toHaveBeenCalledWith({
+        confirmEmail: "test@example.com",
+      });
+    });
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/signin");
+    });
+  });
+
+  it("未認証時はサインインへリダイレクトされる", async () => {
+    server.use(unauthenticatedHandler);
+    const { router } = setupNextNavigation();
+
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/signin");
+    });
+  });
+});

--- a/src/app/settings/account/page.test.tsx
+++ b/src/app/settings/account/page.test.tsx
@@ -101,6 +101,34 @@ describe("AccountSettingsPage", () => {
     });
   });
 
+  it("listAccounts 失敗時は credential あり扱いとなり changePassword 経路が出る", async () => {
+    const { spies } = setupAuthClient({ listAccountsShouldFail: true });
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await screen.findByRole("heading", { name: "パスワード" });
+
+    expect(
+      await screen.findByLabelText("現在のパスワード"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "パスワードを設定" }),
+    ).toBeNull();
+
+    await user.type(screen.getByLabelText("現在のパスワード"), "oldpass12");
+    await user.type(screen.getByLabelText("新しいパスワード"), "newpass12");
+    await user.type(
+      screen.getByLabelText("新しいパスワード（確認）"),
+      "newpass12",
+    );
+    await user.click(screen.getByRole("button", { name: "パスワードを変更" }));
+
+    await waitFor(() => {
+      expect(spies.changePassword).toHaveBeenCalled();
+    });
+    expect(spies.setPassword).not.toHaveBeenCalled();
+  });
+
   it("OAuth-only ユーザーは setPassword が呼ばれ、現在のパスワード入力が出ない", async () => {
     const { spies } = setupAuthClient({
       accounts: [{ providerId: "google" }],

--- a/src/app/settings/account/page.test.tsx
+++ b/src/app/settings/account/page.test.tsx
@@ -159,7 +159,7 @@ describe("AccountSettingsPage", () => {
     expect(spies.changePassword).not.toHaveBeenCalled();
   });
 
-  it("退会フローでメール一致時のみ削除ボタンが有効", async () => {
+  it("退会フロー (credential): メール一致 + パスワード入力で削除ボタンが有効になる", async () => {
     const { spies } = setupAuthClient();
     const { router } = setupNextNavigation();
     const user = userEvent.setup();
@@ -179,6 +179,11 @@ describe("AccountSettingsPage", () => {
       "test@example.com",
     );
 
+    // メールだけでは有効化されない (credential ユーザーはパスワード必須)
+    expect(finalDelete).toBeDisabled();
+
+    await user.type(screen.getByLabelText("パスワードを入力"), "secret123");
+
     await waitFor(() => {
       expect(finalDelete).not.toBeDisabled();
     });
@@ -188,6 +193,46 @@ describe("AccountSettingsPage", () => {
     await waitFor(() => {
       expect(spies.deleteAccount).toHaveBeenCalledWith({
         confirmEmail: "test@example.com",
+        password: "secret123",
+      });
+    });
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/signin");
+    });
+  });
+
+  it("退会フロー (OAuth-only): メール一致のみで削除可能、パスワード欄は出ない", async () => {
+    const { spies } = setupAuthClient({ accounts: [] });
+    const { router } = setupNextNavigation();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "アカウントを削除する" }),
+    );
+
+    const finalDelete = await screen.findByRole("button", {
+      name: "完全に削除",
+    });
+    expect(finalDelete).toBeDisabled();
+
+    expect(screen.queryByLabelText("パスワードを入力")).not.toBeInTheDocument();
+
+    await user.type(
+      screen.getByLabelText("メールアドレスを再入力"),
+      "test@example.com",
+    );
+
+    await waitFor(() => {
+      expect(finalDelete).not.toBeDisabled();
+    });
+
+    await user.click(finalDelete);
+
+    await waitFor(() => {
+      expect(spies.deleteAccount).toHaveBeenCalledWith({
+        confirmEmail: "test@example.com",
+        password: undefined,
       });
     });
     await waitFor(() => {

--- a/src/app/settings/account/page.test.tsx
+++ b/src/app/settings/account/page.test.tsx
@@ -101,7 +101,7 @@ describe("AccountSettingsPage", () => {
     });
   });
 
-  it("OAuth-only ユーザーはパスワード設定モードで現在のパスワード入力が出ない", async () => {
+  it("OAuth-only ユーザーは setPassword が呼ばれ、現在のパスワード入力が出ない", async () => {
     const { spies } = setupAuthClient({
       accounts: [{ providerId: "google" }],
     });
@@ -123,12 +123,12 @@ describe("AccountSettingsPage", () => {
     await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
 
     await waitFor(() => {
-      expect(spies.changePassword).toHaveBeenCalledWith({
-        currentPassword: undefined,
+      expect(spies.setPassword).toHaveBeenCalledWith({
         newPassword: "newpass12",
         newPasswordConfirm: "newpass12",
       });
     });
+    expect(spies.changePassword).not.toHaveBeenCalled();
   });
 
   it("退会フローでメール一致時のみ削除ボタンが有効", async () => {

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAtomValue } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
+import DeleteAccountSection from "@/components/settings/account/DeleteAccountSection";
+import EmailChangeForm from "@/components/settings/account/EmailChangeForm";
+import PasswordChangeForm from "@/components/settings/account/PasswordChangeForm";
+import ProfileForm from "@/components/settings/account/ProfileForm";
+import SectionCard from "@/components/settings/account/SectionCard";
+
+const AccountSettingsPage = () => {
+  const router = useRouter();
+  const { user, isAuthenticated, isLoading } = useAtomValue(
+    authSessionUnwrappedAtom,
+  );
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace("/signin");
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  if (isLoading || !isAuthenticated || user === undefined) {
+    return undefined;
+  }
+
+  // OAuth-only ユーザーの password 列の有無はクライアントから判定できないため、
+  // 入力は常に表示し、不正な値は better-auth 側で弾いて失敗トーストで案内する。
+  const hasPassword = true;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SectionCard
+        title={<Trans>プロフィール</Trans>}
+        description={<Trans>他のユーザーや UI に表示されます。</Trans>}
+      >
+        <ProfileForm currentUser={user} />
+      </SectionCard>
+
+      <SectionCard
+        title={<Trans>メールアドレス</Trans>}
+        description={<Trans>ログインに使うメールアドレスです。</Trans>}
+      >
+        <EmailChangeForm currentEmail={user.email} />
+      </SectionCard>
+
+      <SectionCard
+        title={<Trans>パスワード</Trans>}
+        description={<Trans>定期的な更新を推奨します。</Trans>}
+      >
+        <PasswordChangeForm hasPassword={hasPassword} />
+      </SectionCard>
+
+      <DeleteAccountSection currentEmail={user.email} />
+    </div>
+  );
+};
+
+export default AccountSettingsPage;

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -52,7 +52,10 @@ const AccountSettingsPage = () => {
         <PasswordChangeForm hasPassword={hasPassword} />
       </SectionCard>
 
-      <DeleteAccountSection currentEmail={user.email} />
+      <DeleteAccountSection
+        currentEmail={user.email}
+        hasPassword={hasPassword}
+      />
     </div>
   );
 };

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAtomValue } from "jotai";
 import { Trans } from "@lingui/react/macro";
+import { hasPasswordAtom } from "@/stores/accountsAtoms";
 import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
 import DeleteAccountSection from "@/components/settings/account/DeleteAccountSection";
 import EmailChangeForm from "@/components/settings/account/EmailChangeForm";
@@ -16,6 +17,7 @@ const AccountSettingsPage = () => {
   const { user, isAuthenticated, isLoading } = useAtomValue(
     authSessionUnwrappedAtom,
   );
+  const hasPassword = useAtomValue(hasPasswordAtom);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -26,10 +28,6 @@ const AccountSettingsPage = () => {
   if (isLoading || !isAuthenticated || user === undefined) {
     return undefined;
   }
-
-  // OAuth-only ユーザーの password 列の有無はクライアントから判定できないため、
-  // 入力は常に表示し、不正な値は better-auth 側で弾いて失敗トーストで案内する。
-  const hasPassword = true;
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/app/settings/api-keys/page.tsx
+++ b/src/app/settings/api-keys/page.tsx
@@ -13,7 +13,6 @@ import ApiKeyList from "@/components/settings/api-key/ApiKeyList";
 import ApiKeyCreateSheet from "@/components/settings/api-key/ApiKeyCreateSheet";
 import ApiKeyRevealSheet from "@/components/settings/api-key/ApiKeyRevealSheet";
 import Button from "@/components/ui/Button";
-import PageHeader from "@/components/ui/PageHeader";
 import Skeleton from "@/components/ui/Skeleton";
 
 const ApiKeysPage = () => {
@@ -35,9 +34,7 @@ const ApiKeysPage = () => {
   }
 
   return (
-    <div className="flex flex-col gap-6 p-4">
-      <PageHeader title={t`API キー`} backHref="/" backLabel={t`戻る`} />
-
+    <>
       <p className="text-sm text-text-secondary">
         <Trans>
           外部 AI エージェントから接続するための Personal Access Token
@@ -89,7 +86,7 @@ const ApiKeysPage = () => {
         createdKey={createdKey}
         onClose={() => setCreatedKey(undefined)}
       />
-    </div>
+    </>
   );
 };
 

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,0 +1,17 @@
+import { t } from "@lingui/core/macro";
+import SettingsTabs from "@/components/settings/SettingsTabs";
+import PageHeader from "@/components/ui/PageHeader";
+
+const SettingsLayout = ({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-6 p-4">
+    <PageHeader title={t`設定`} backHref="/" backLabel={t`戻る`} />
+    <SettingsTabs />
+    {children}
+  </div>
+);
+
+export default SettingsLayout;

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { t } from "@lingui/core/macro";
 import SettingsTabs from "@/components/settings/SettingsTabs";
 import PageHeader from "@/components/ui/PageHeader";

--- a/src/app/signin/page.test.tsx
+++ b/src/app/signin/page.test.tsx
@@ -1,14 +1,17 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { server } from "@/test/mocks/server";
 import { unauthenticatedHandler } from "@/test/mocks/handlers";
 import { renderWithProviders } from "@/test/testUtils";
 import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import { setupAuthClient } from "@/test/mocks/modules/authClient";
 import SignInPage from "./page";
 
 describe("SignInPage", () => {
   beforeEach(() => {
     setupNextNavigation();
+    setupAuthClient();
   });
 
   it("未認証時に Twitter / Google のログインボタンが表示される", async () => {
@@ -22,6 +25,72 @@ describe("SignInPage", () => {
     expect(
       screen.getByRole("button", { name: "Google でログイン" }),
     ).toBeInTheDocument();
+  });
+
+  it("メールアドレスとパスワードのフォームが表示される", async () => {
+    server.use(unauthenticatedHandler);
+
+    await renderWithProviders(<SignInPage />);
+
+    expect(await screen.findByLabelText("メールアドレス")).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "ログイン" }),
+    ).toBeInTheDocument();
+  });
+
+  it("サインアップへのリンクが表示される", async () => {
+    server.use(unauthenticatedHandler);
+
+    await renderWithProviders(<SignInPage />);
+
+    const link = await screen.findByRole("link", { name: "新規登録" });
+    expect(link).toHaveAttribute("href", "/signup");
+  });
+
+  it("メールとパスワードを入力して送信すると signInWithEmail が呼ばれる", async () => {
+    server.use(unauthenticatedHandler);
+    const { spies } = setupAuthClient();
+    const { router } = setupNextNavigation();
+
+    const user = userEvent.setup();
+    await renderWithProviders(<SignInPage />);
+
+    await user.type(
+      await screen.findByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "secret123");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      expect(spies.signInWithEmail).toHaveBeenCalledWith({
+        email: "user@example.com",
+        password: "secret123",
+      });
+    });
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/");
+    });
+  });
+
+  it("ログイン失敗時にエラーバナーが表示される", async () => {
+    server.use(unauthenticatedHandler);
+    setupAuthClient({ signInShouldFail: true });
+
+    const user = userEvent.setup();
+    await renderWithProviders(<SignInPage />);
+
+    await user.type(
+      await screen.findByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "wrongpass");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "メールアドレスまたはパスワードが正しくありません",
+    );
   });
 
   it("認証済みの場合はホームへリダイレクトされる", async () => {

--- a/src/app/signup/page.test.tsx
+++ b/src/app/signup/page.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { server } from "@/test/mocks/server";
+import { unauthenticatedHandler } from "@/test/mocks/handlers";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import { setupAuthClient } from "@/test/mocks/modules/authClient";
+import SignUpPage from "./page";
+
+describe("SignUpPage", () => {
+  beforeEach(() => {
+    setupNextNavigation();
+    setupAuthClient();
+  });
+
+  it("未認証時に登録フォームと OAuth ボタンが表示される", async () => {
+    server.use(unauthenticatedHandler);
+
+    await renderWithProviders(<SignUpPage />);
+
+    expect(await screen.findByLabelText("表示名")).toBeInTheDocument();
+    expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード（確認）")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "アカウント作成" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Google でログイン" }),
+    ).toBeInTheDocument();
+  });
+
+  it("サインインへのリンクが表示される", async () => {
+    server.use(unauthenticatedHandler);
+
+    await renderWithProviders(<SignUpPage />);
+
+    const link = await screen.findByRole("link", { name: "ログイン" });
+    expect(link).toHaveAttribute("href", "/signin");
+  });
+
+  it("正しい入力で送信すると signUpWithEmail が呼ばれホームへ遷移する", async () => {
+    server.use(unauthenticatedHandler);
+    const { spies } = setupAuthClient();
+    const { router } = setupNextNavigation();
+
+    const user = userEvent.setup();
+    await renderWithProviders(<SignUpPage />);
+
+    await user.type(await screen.findByLabelText("表示名"), "佐藤");
+    await user.type(screen.getByLabelText("メールアドレス"), "new@example.com");
+    await user.type(screen.getByLabelText("パスワード"), "secret123");
+    await user.type(screen.getByLabelText("パスワード（確認）"), "secret123");
+    await user.click(screen.getByRole("button", { name: "アカウント作成" }));
+
+    await waitFor(() => {
+      expect(spies.signUpWithEmail).toHaveBeenCalledWith({
+        name: "佐藤",
+        email: "new@example.com",
+        password: "secret123",
+      });
+    });
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/");
+    });
+  });
+
+  it("パスワード不一致でバリデーションエラーが表示され送信されない", async () => {
+    server.use(unauthenticatedHandler);
+    const { spies } = setupAuthClient();
+
+    const user = userEvent.setup();
+    await renderWithProviders(<SignUpPage />);
+
+    await user.type(await screen.findByLabelText("表示名"), "佐藤");
+    await user.type(screen.getByLabelText("メールアドレス"), "new@example.com");
+    await user.type(screen.getByLabelText("パスワード"), "secret123");
+    await user.type(screen.getByLabelText("パスワード（確認）"), "different1");
+    await user.click(screen.getByRole("button", { name: "アカウント作成" }));
+
+    expect(spies.signUpWithEmail).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText("パスワードが一致しません"),
+    ).toBeInTheDocument();
+  });
+
+  it("サインアップ失敗時にエラーバナーが表示される", async () => {
+    server.use(unauthenticatedHandler);
+    setupAuthClient({ signUpShouldFail: true });
+
+    const user = userEvent.setup();
+    await renderWithProviders(<SignUpPage />);
+
+    await user.type(await screen.findByLabelText("表示名"), "佐藤");
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "exists@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "secret123");
+    await user.type(screen.getByLabelText("パスワード（確認）"), "secret123");
+    await user.click(screen.getByRole("button", { name: "アカウント作成" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "アカウントを作成できませんでした",
+    );
+  });
+
+  it("認証済みの場合はホームへリダイレクトされる", async () => {
+    const { router } = setupNextNavigation();
+
+    await renderWithProviders(<SignUpPage />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/");
+    });
+  });
+});

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -4,14 +4,14 @@ import { useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAtomValue } from "jotai";
-import { Shirt } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
 import AuthDivider from "@/components/auth/AuthDivider";
-import EmailPasswordForm from "@/components/auth/EmailPasswordForm";
 import LoginButton from "@/components/auth/LoginButton";
+import SignUpForm from "@/components/auth/SignUpForm";
 
-const SignInPage = () => {
+const SignUpPage = () => {
   const router = useRouter();
   const { isAuthenticated, isLoading } = useAtomValue(authSessionUnwrappedAtom);
 
@@ -29,17 +29,17 @@ const SignInPage = () => {
     <div className="mx-auto flex w-full max-w-md flex-col gap-7 px-5 pb-10 pt-6 lg:gap-8 lg:pt-10">
       <header className="flex flex-col items-center gap-2 pt-2 text-center">
         <div className="flex size-12 items-center justify-center rounded-2xl bg-primary-100 text-primary-700 ring-1 ring-inset ring-primary-200">
-          <Shirt className="size-6" />
+          <Sparkles className="size-6" />
         </div>
         <h1 className="font-display text-2xl font-bold tracking-tight text-text-primary">
-          <Trans>ドール服管理にログイン</Trans>
+          <Trans>新しいアカウントを作る</Trans>
         </h1>
         <p className="text-sm text-text-secondary">
-          <Trans>引き出しの中身を、いつでもどこでも</Trans>
+          <Trans>30 秒で、最初の引き出しを開けられます</Trans>
         </p>
       </header>
 
-      <EmailPasswordForm />
+      <SignUpForm />
 
       <AuthDivider>
         <Trans>または</Trans>
@@ -52,12 +52,12 @@ const SignInPage = () => {
 
       <p className="text-center text-sm text-text-secondary">
         <Trans>
-          アカウントをお持ちでない方は{" "}
+          すでにアカウントをお持ちの方は{" "}
           <Link
-            href="/signup"
+            href="/signin"
             className="font-medium text-primary-600 underline-offset-4 hover:underline"
           >
-            新規登録
+            ログイン
           </Link>
         </Trans>
       </p>
@@ -65,4 +65,4 @@ const SignInPage = () => {
   );
 };
 
-export default SignInPage;
+export default SignUpPage;

--- a/src/components/auth/AuthDivider.tsx
+++ b/src/components/auth/AuthDivider.tsx
@@ -1,0 +1,15 @@
+type Props = {
+  readonly children: React.ReactNode;
+};
+
+const AuthDivider = ({ children }: Props) => (
+  <div className="relative flex items-center py-1" role="separator">
+    <div className="grow border-t border-border-default" />
+    <span className="px-3 text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+      {children}
+    </span>
+    <div className="grow border-t border-border-default" />
+  </div>
+);
+
+export default AuthDivider;

--- a/src/components/auth/EmailPasswordForm.tsx
+++ b/src/components/auth/EmailPasswordForm.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSetAtom } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { signInEmailSchema, signInWithEmail } from "@/lib/auth";
+import { refreshAuthAtom } from "@/stores/authAtoms";
+import Button from "@/components/ui/Button";
+import ErrorAlert from "@/components/ui/ErrorAlert";
+import Input from "@/components/ui/Input";
+
+type FieldErrors = {
+  readonly email: string | undefined;
+  readonly password: string | undefined;
+};
+
+const EMPTY_ERRORS: FieldErrors = { email: undefined, password: undefined };
+
+const EmailPasswordForm = () => {
+  const router = useRouter();
+  const refreshAuth = useSetAtom(refreshAuthAtom);
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>(EMPTY_ERRORS);
+  const [submitError, setSubmitError] = useState<string | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isSubmitting) return;
+
+    const parsed = signInEmailSchema.safeParse({ email, password });
+    if (!parsed.success) {
+      const flat = parsed.error.flatten().fieldErrors;
+      setFieldErrors({
+        email: flat.email?.[0] ?? undefined,
+        password: flat.password?.[0] ?? undefined,
+      });
+      setSubmitError(undefined);
+      return;
+    }
+
+    setFieldErrors(EMPTY_ERRORS);
+    setSubmitError(undefined);
+    setIsSubmitting(true);
+    const failed = await signInWithEmail(parsed.data).catch(() => true);
+    setIsSubmitting(false);
+
+    if (failed === true) {
+      setSubmitError(t`メールアドレスまたはパスワードが正しくありません`);
+      return;
+    }
+
+    refreshAuth();
+    router.replace("/");
+  };
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
+      <Input
+        type="email"
+        label={t`メールアドレス`}
+        autoComplete="email"
+        inputMode="email"
+        placeholder={t`you@example.com`}
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        error={fieldErrors.email}
+        required
+      />
+      <Input
+        type="password"
+        label={t`パスワード`}
+        autoComplete="current-password"
+        placeholder="••••••••"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        error={fieldErrors.password}
+        required
+      />
+      {submitError !== undefined && <ErrorAlert>{submitError}</ErrorAlert>}
+      <Button
+        type="submit"
+        variant="primary"
+        size="lg"
+        fullWidth
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? <Trans>ログイン中…</Trans> : <Trans>ログイン</Trans>}
+      </Button>
+    </form>
+  );
+};
+
+export default EmailPasswordForm;

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSetAtom } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { signUpEmailSchema, signUpWithEmail } from "@/lib/auth";
+import { refreshAuthAtom } from "@/stores/authAtoms";
+import Button from "@/components/ui/Button";
+import ErrorAlert from "@/components/ui/ErrorAlert";
+import Input from "@/components/ui/Input";
+
+type FieldErrors = {
+  readonly name: string | undefined;
+  readonly email: string | undefined;
+  readonly password: string | undefined;
+  readonly passwordConfirm: string | undefined;
+};
+
+const EMPTY_ERRORS: FieldErrors = {
+  name: undefined,
+  email: undefined,
+  password: undefined,
+  passwordConfirm: undefined,
+};
+
+const SignUpForm = () => {
+  const router = useRouter();
+  const refreshAuth = useSetAtom(refreshAuthAtom);
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>(EMPTY_ERRORS);
+  const [submitError, setSubmitError] = useState<string | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const validate = () => {
+    const parsed = signUpEmailSchema.safeParse({
+      name,
+      email,
+      password,
+      passwordConfirm,
+    });
+    if (parsed.success) {
+      setFieldErrors(EMPTY_ERRORS);
+      return parsed.data;
+    }
+    const flat = parsed.error.flatten().fieldErrors;
+    setFieldErrors({
+      name: flat.name?.[0] ?? undefined,
+      email: flat.email?.[0] ?? undefined,
+      password: flat.password?.[0] ?? undefined,
+      passwordConfirm: flat.passwordConfirm?.[0] ?? undefined,
+    });
+    return undefined;
+  };
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isSubmitting) return;
+
+    const data = validate();
+    if (data === undefined) {
+      setSubmitError(undefined);
+      return;
+    }
+
+    setSubmitError(undefined);
+    setIsSubmitting(true);
+    const failed = await signUpWithEmail({
+      name: data.name,
+      email: data.email,
+      password: data.password,
+    }).catch(() => true);
+    setIsSubmitting(false);
+
+    if (failed === true) {
+      setSubmitError(
+        t`アカウントを作成できませんでした。メールアドレスがすでに使われている可能性があります。`,
+      );
+      return;
+    }
+
+    refreshAuth();
+    router.replace("/");
+  };
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
+      <Input
+        type="text"
+        label={t`表示名`}
+        autoComplete="name"
+        placeholder={t`例: ドリーラー`}
+        maxLength={60}
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        error={fieldErrors.name}
+        required
+      />
+      <Input
+        type="email"
+        label={t`メールアドレス`}
+        autoComplete="email"
+        inputMode="email"
+        placeholder={t`you@example.com`}
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        error={fieldErrors.email}
+        required
+      />
+      <Input
+        type="password"
+        label={t`パスワード`}
+        autoComplete="new-password"
+        placeholder="••••••••"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        error={fieldErrors.password}
+        aria-describedby="password-hint"
+        required
+      />
+      <p id="password-hint" className="-mt-2 text-xs text-text-tertiary">
+        <Trans>8 文字以上。英数字を含めると安全です。</Trans>
+      </p>
+      <Input
+        type="password"
+        label={t`パスワード（確認）`}
+        autoComplete="new-password"
+        placeholder="••••••••"
+        value={passwordConfirm}
+        onChange={(e) => setPasswordConfirm(e.target.value)}
+        error={fieldErrors.passwordConfirm}
+        required
+      />
+      {submitError !== undefined && <ErrorAlert>{submitError}</ErrorAlert>}
+      <Button
+        type="submit"
+        variant="primary"
+        size="lg"
+        fullWidth
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? <Trans>登録中…</Trans> : <Trans>アカウント作成</Trans>}
+      </Button>
+    </form>
+  );
+};
+
+export default SignUpForm;

--- a/src/components/auth/UserMenu.test.tsx
+++ b/src/components/auth/UserMenu.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 import { server } from "@/test/mocks/server";
 import { unauthenticatedHandler } from "@/test/mocks/handlers";
@@ -23,5 +24,53 @@ describe("UserMenu", () => {
 
     const loginLink = await screen.findByRole("link", { name: "ログイン" });
     expect(loginLink).toHaveAttribute("href", "/signin");
+  });
+
+  it("ログアウトボタン押下で確認モーダルが開く", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<UserMenu />);
+
+    await user.click(await screen.findByLabelText("ログアウト"));
+
+    expect(
+      await screen.findByRole("heading", { name: "ログアウトしますか？" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "再びログインするまで、収納場所の確認や服の登録ができなくなります。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("確認モーダルのキャンセルでモーダルが閉じる", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<UserMenu />);
+
+    await user.click(await screen.findByLabelText("ログアウト"));
+    await screen.findByRole("heading", { name: "ログアウトしますか？" });
+    await user.click(await screen.findByRole("button", { name: "キャンセル" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "ログアウトしますか？" }),
+      ).toBeNull();
+    });
+  });
+
+  it("確認モーダルでログアウト確定するとモーダルが閉じる", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<UserMenu />);
+
+    await user.click(await screen.findByLabelText("ログアウト"));
+    const confirmButtons = await screen.findAllByRole("button", {
+      name: "ログアウト",
+    });
+    await user.click(confirmButtons[confirmButtons.length - 1]!);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "ログアウトしますか？" }),
+      ).toBeNull();
+    });
   });
 });

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -7,11 +7,13 @@ import { LogOut, Settings } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import { authSessionUnwrappedAtom, signOutAtom } from "@/stores/authAtoms";
+import ConfirmSheet from "@/components/ui/ConfirmSheet";
 
 const UserMenu = () => {
   const authState = useAtomValue(authSessionUnwrappedAtom);
   const signOut = useSetAtom(signOutAtom);
   const [isMounted, setIsMounted] = useState(false);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
   useEffect(() => {
     setIsMounted(true);
@@ -52,14 +54,22 @@ const UserMenu = () => {
       </Link>
       <button
         type="button"
-        onClick={() => {
-          signOut();
-        }}
+        onClick={() => setIsConfirmOpen(true)}
         className="p-1 text-text-tertiary hover:text-text-primary"
         aria-label={t`ログアウト`}
       >
         <LogOut className="size-4" />
       </button>
+      <ConfirmSheet
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={() => {
+          signOut();
+        }}
+        title={t`ログアウトしますか？`}
+        message={t`再びログインするまで、収納場所の確認や服の登録ができなくなります。`}
+        confirmLabel={t`ログアウト`}
+      />
     </div>
   );
 };

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -44,7 +44,7 @@ const UserMenu = () => {
         </div>
       )}
       <Link
-        href="/settings/api-keys"
+        href="/settings/account"
         className="p-1 text-text-tertiary hover:text-text-primary"
         aria-label={t`設定`}
       >

--- a/src/components/garment/GarmentForm.test.tsx
+++ b/src/components/garment/GarmentForm.test.tsx
@@ -87,7 +87,9 @@ describe("GarmentForm", () => {
       expect(garments[0]?.dollSizes).toEqual(["SD"]);
       expect(garments[0]?.status).toBe("stored");
     });
-    expect(navHandle.router.push).toHaveBeenCalledWith("/garments");
+    await waitFor(() => {
+      expect(navHandle.router.push).toHaveBeenCalledWith("/garments");
+    });
   });
 
   it("カテゴリを変更して登録すると反映される", async () => {

--- a/src/components/settings/SettingsTabs.test.tsx
+++ b/src/components/settings/SettingsTabs.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import SettingsTabs from "./SettingsTabs";
+
+describe("SettingsTabs", () => {
+  beforeEach(() => {
+    setupNextNavigation();
+  });
+
+  it("/settings/account にいるときアカウントタブが選択状態になる", async () => {
+    setupNextNavigation({ pathname: "/settings/account" });
+
+    await renderWithProviders(<SettingsTabs />);
+
+    expect(screen.getByRole("link", { name: "アカウント" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: "API キー" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("/settings/api-keys にいるとき API キータブが選択状態になる", async () => {
+    setupNextNavigation({ pathname: "/settings/api-keys" });
+
+    await renderWithProviders(<SettingsTabs />);
+
+    expect(screen.getByRole("link", { name: "API キー" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(
+      screen.getByRole("link", { name: "アカウント" }),
+    ).not.toHaveAttribute("aria-current");
+  });
+});

--- a/src/components/settings/SettingsTabs.tsx
+++ b/src/components/settings/SettingsTabs.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import clsx from "clsx";
+
+const SettingsTabs = () => {
+  const pathname = usePathname();
+  const isAccount = pathname?.startsWith("/settings/account") ?? false;
+  const isApiKeys = pathname?.startsWith("/settings/api-keys") ?? false;
+
+  return (
+    <nav
+      className="inline-flex rounded-xl bg-primary-50 p-1 text-sm font-medium"
+      aria-label={t`設定`}
+    >
+      <Link
+        href="/settings/account"
+        aria-current={isAccount ? "page" : undefined}
+        className={clsx(
+          "rounded-lg px-4 py-1.5 transition-colors",
+          isAccount
+            ? "bg-surface-overlay text-text-primary shadow-sm"
+            : "text-text-secondary hover:text-text-primary",
+        )}
+      >
+        <Trans>アカウント</Trans>
+      </Link>
+      <Link
+        href="/settings/api-keys"
+        aria-current={isApiKeys ? "page" : undefined}
+        className={clsx(
+          "rounded-lg px-4 py-1.5 transition-colors",
+          isApiKeys
+            ? "bg-surface-overlay text-text-primary shadow-sm"
+            : "text-text-secondary hover:text-text-primary",
+        )}
+      >
+        <Trans>API キー</Trans>
+      </Link>
+    </nav>
+  );
+};
+
+export default SettingsTabs;

--- a/src/components/settings/account/DeleteAccountSection.tsx
+++ b/src/components/settings/account/DeleteAccountSection.tsx
@@ -39,14 +39,16 @@ const DeleteAccountSection = ({ currentEmail }: Props) => {
     if (isDisabled) return;
     setIsSubmitting(true);
     const failed = await deleteAccount({ confirmEmail }).catch(() => true);
-    setIsSubmitting(false);
 
     if (failed === true) {
+      setIsSubmitting(false);
       addToast({ message: t`アカウントの削除に失敗しました` });
       return;
     }
 
-    refreshAuth();
+    // 新しい session 取得を待ってから遷移しないと、/signin が unwrap の prev
+    // (認証済み) を見て / に弾く race が起きる。
+    await refreshAuth();
     router.replace("/signin");
   };
 

--- a/src/components/settings/account/DeleteAccountSection.tsx
+++ b/src/components/settings/account/DeleteAccountSection.tsx
@@ -15,34 +15,45 @@ import Input from "@/components/ui/Input";
 
 type Props = {
   readonly currentEmail: string;
+  readonly hasPassword: boolean;
 };
 
-const DeleteAccountSection = ({ currentEmail }: Props) => {
+const DeleteAccountSection = ({ currentEmail, hasPassword }: Props) => {
   const router = useRouter();
   const refreshAuth = useSetAtom(refreshAuthAtom);
   const addToast = useSetAtom(addToastAtom);
 
   const [isOpen, setIsOpen] = useState(false);
   const [confirmEmail, setConfirmEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const isMatch = confirmEmail === currentEmail;
-  const isDisabled = !isMatch || isSubmitting;
+  const isEmailMatch = confirmEmail === currentEmail;
+  const isPasswordReady = !hasPassword || password.length > 0;
+  const isDisabled = !isEmailMatch || !isPasswordReady || isSubmitting;
 
   const handleClose = () => {
     if (isSubmitting) return;
     setConfirmEmail("");
+    setPassword("");
     setIsOpen(false);
   };
 
   const handleDelete = async () => {
     if (isDisabled) return;
     setIsSubmitting(true);
-    const failed = await deleteAccount({ confirmEmail }).catch(() => true);
+    const failed = await deleteAccount({
+      confirmEmail,
+      password: hasPassword ? password : undefined,
+    }).catch(() => true);
 
     if (failed === true) {
       setIsSubmitting(false);
-      addToast({ message: t`アカウントの削除に失敗しました` });
+      addToast({
+        message: hasPassword
+          ? t`パスワードが正しくないか、アカウントの削除に失敗しました`
+          : t`アカウントの削除に失敗しました`,
+      });
       return;
     }
 
@@ -101,11 +112,21 @@ const DeleteAccountSection = ({ currentEmail }: Props) => {
             value={confirmEmail}
             onChange={(e) => setConfirmEmail(e.target.value)}
             error={
-              confirmEmail !== "" && !isMatch
+              confirmEmail !== "" && !isEmailMatch
                 ? t`メールアドレスが一致しません`
                 : undefined
             }
           />
+          {hasPassword ? (
+            <Input
+              type="password"
+              label={t`パスワードを入力`}
+              autoComplete="current-password"
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          ) : undefined}
           <div className="flex gap-3">
             <Button variant="ghost" fullWidth onClick={handleClose}>
               <Trans>キャンセル</Trans>

--- a/src/components/settings/account/DeleteAccountSection.tsx
+++ b/src/components/settings/account/DeleteAccountSection.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSetAtom } from "jotai";
+import { AlertTriangle } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { deleteAccount } from "@/lib/auth";
+import { refreshAuthAtom } from "@/stores/authAtoms";
+import { addToastAtom } from "@/stores/toastAtoms";
+import BottomSheet from "@/components/ui/BottomSheet";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+type Props = {
+  readonly currentEmail: string;
+};
+
+const DeleteAccountSection = ({ currentEmail }: Props) => {
+  const router = useRouter();
+  const refreshAuth = useSetAtom(refreshAuthAtom);
+  const addToast = useSetAtom(addToastAtom);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [confirmEmail, setConfirmEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isMatch = confirmEmail === currentEmail;
+  const isDisabled = !isMatch || isSubmitting;
+
+  const handleClose = () => {
+    if (isSubmitting) return;
+    setConfirmEmail("");
+    setIsOpen(false);
+  };
+
+  const handleDelete = async () => {
+    if (isDisabled) return;
+    setIsSubmitting(true);
+    const failed = await deleteAccount({ confirmEmail }).catch(() => true);
+    setIsSubmitting(false);
+
+    if (failed === true) {
+      addToast({ message: t`アカウントの削除に失敗しました` });
+      return;
+    }
+
+    refreshAuth();
+    router.replace("/signin");
+  };
+
+  return (
+    <section
+      aria-labelledby="danger-zone-title"
+      className="mt-4 rounded-2xl border border-danger/20 bg-red-50/40 p-5"
+    >
+      <header className="mb-4 flex items-start gap-3">
+        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-red-100 text-danger">
+          <AlertTriangle className="size-4" />
+        </div>
+        <div className="flex flex-col gap-1">
+          <h3
+            id="danger-zone-title"
+            className="font-display text-base font-bold text-text-primary"
+          >
+            <Trans>アカウントを削除</Trans>
+          </h3>
+          <p className="text-xs text-text-tertiary">
+            <Trans>
+              登録した服・収納場所・コーデ・ドールはすべて削除され、復元できません。
+            </Trans>
+          </p>
+        </div>
+      </header>
+
+      <Button variant="danger" size="md" onClick={() => setIsOpen(true)}>
+        <Trans>アカウントを削除する</Trans>
+      </Button>
+
+      <BottomSheet
+        isOpen={isOpen}
+        onClose={handleClose}
+        title={t`本当に削除しますか？`}
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-text-secondary">
+            <Trans>
+              この操作は取り消せません。確認のため、登録メールアドレスを入力してください。
+            </Trans>
+          </p>
+          <p className="rounded-lg bg-primary-50 px-3 py-2 font-mono text-xs text-text-primary">
+            {currentEmail}
+          </p>
+          <Input
+            type="email"
+            label={t`メールアドレスを再入力`}
+            autoComplete="off"
+            value={confirmEmail}
+            onChange={(e) => setConfirmEmail(e.target.value)}
+            error={
+              confirmEmail !== "" && !isMatch
+                ? t`メールアドレスが一致しません`
+                : undefined
+            }
+          />
+          <div className="flex gap-3">
+            <Button variant="ghost" fullWidth onClick={handleClose}>
+              <Trans>キャンセル</Trans>
+            </Button>
+            <Button
+              variant="danger"
+              fullWidth
+              disabled={isDisabled}
+              onClick={handleDelete}
+            >
+              <Trans>完全に削除</Trans>
+            </Button>
+          </div>
+        </div>
+      </BottomSheet>
+    </section>
+  );
+};
+
+export default DeleteAccountSection;

--- a/src/components/settings/account/EmailChangeForm.tsx
+++ b/src/components/settings/account/EmailChangeForm.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { changeEmail, changeEmailSchema } from "@/lib/auth";
+import { refreshAuthAtom } from "@/stores/authAtoms";
+import { addToastAtom } from "@/stores/toastAtoms";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+type Props = {
+  readonly currentEmail: string;
+};
+
+const EmailChangeForm = ({ currentEmail }: Props) => {
+  const refreshAuth = useSetAtom(refreshAuthAtom);
+  const addToast = useSetAtom(addToastAtom);
+
+  const [newEmail, setNewEmail] = useState("");
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const trimmed = newEmail.trim();
+  const isDisabled = isSubmitting || trimmed === "" || trimmed === currentEmail;
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isDisabled) return;
+
+    const parsed = changeEmailSchema.safeParse({ newEmail });
+    if (!parsed.success) {
+      setError(parsed.error.flatten().fieldErrors.newEmail?.[0] ?? undefined);
+      return;
+    }
+
+    setError(undefined);
+    setIsSubmitting(true);
+    const failed = await changeEmail(parsed.data).catch(() => true);
+    setIsSubmitting(false);
+
+    if (failed === true) {
+      addToast({ message: t`メールアドレスの変更に失敗しました` });
+      return;
+    }
+
+    refreshAuth();
+    setNewEmail("");
+    addToast({ message: t`メールアドレスを変更しました` });
+  };
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
+      <div className="rounded-lg bg-primary-50 px-3 py-2 text-xs font-mono text-text-primary">
+        {currentEmail}
+      </div>
+      <Input
+        type="email"
+        label={t`新しいメールアドレス`}
+        autoComplete="email"
+        inputMode="email"
+        placeholder={t`new@example.com`}
+        value={newEmail}
+        onChange={(e) => setNewEmail(e.target.value)}
+        error={error}
+        required
+      />
+      <div className="flex justify-end">
+        <Button type="submit" variant="primary" size="md" disabled={isDisabled}>
+          <Trans>メールアドレスを変更</Trans>
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default EmailChangeForm;

--- a/src/components/settings/account/PasswordChangeForm.tsx
+++ b/src/components/settings/account/PasswordChangeForm.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { changePassword, changePasswordSchema } from "@/lib/auth";
+import { addToastAtom } from "@/stores/toastAtoms";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+type Props = {
+  readonly hasPassword: boolean;
+};
+
+type FieldErrors = {
+  readonly currentPassword: string | undefined;
+  readonly newPassword: string | undefined;
+  readonly newPasswordConfirm: string | undefined;
+};
+
+const EMPTY_ERRORS: FieldErrors = {
+  currentPassword: undefined,
+  newPassword: undefined,
+  newPasswordConfirm: undefined,
+};
+
+const PasswordChangeForm = ({ hasPassword }: Props) => {
+  const addToast = useSetAtom(addToastAtom);
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [newPasswordConfirm, setNewPasswordConfirm] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>(EMPTY_ERRORS);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isDisabled =
+    isSubmitting ||
+    newPassword === "" ||
+    newPasswordConfirm === "" ||
+    (hasPassword && currentPassword === "");
+
+  const validate = () => {
+    const parsed = changePasswordSchema.safeParse({
+      currentPassword: hasPassword ? currentPassword : undefined,
+      newPassword,
+      newPasswordConfirm,
+    });
+    if (parsed.success) {
+      setFieldErrors(EMPTY_ERRORS);
+      return parsed.data;
+    }
+    const flat = parsed.error.flatten().fieldErrors;
+    setFieldErrors({
+      currentPassword: flat.currentPassword?.[0] ?? undefined,
+      newPassword: flat.newPassword?.[0] ?? undefined,
+      newPasswordConfirm: flat.newPasswordConfirm?.[0] ?? undefined,
+    });
+    return undefined;
+  };
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isDisabled) return;
+
+    const data = validate();
+    if (data === undefined) return;
+
+    setIsSubmitting(true);
+    const failed = await changePassword(data).catch(() => true);
+    setIsSubmitting(false);
+
+    if (failed === true) {
+      addToast({
+        message: hasPassword
+          ? t`現在のパスワードが正しくないか、更新に失敗しました`
+          : t`パスワードの設定に失敗しました`,
+      });
+      return;
+    }
+
+    setCurrentPassword("");
+    setNewPassword("");
+    setNewPasswordConfirm("");
+    addToast({
+      message: hasPassword
+        ? t`パスワードを変更しました`
+        : t`パスワードを設定しました`,
+    });
+  };
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
+      {hasPassword ? (
+        <Input
+          type="password"
+          label={t`現在のパスワード`}
+          autoComplete="current-password"
+          placeholder="••••••••"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          error={fieldErrors.currentPassword}
+          required
+        />
+      ) : (
+        <p className="rounded-lg bg-primary-50 px-3 py-2 text-xs text-text-secondary">
+          <Trans>
+            ソーシャルログインで作成されたアカウントです。新しいパスワードを設定すると、メール
+            + パスワードでもログインできるようになります。
+          </Trans>
+        </p>
+      )}
+      <Input
+        type="password"
+        label={hasPassword ? t`新しいパスワード` : t`パスワード`}
+        autoComplete="new-password"
+        placeholder="••••••••"
+        value={newPassword}
+        onChange={(e) => setNewPassword(e.target.value)}
+        error={fieldErrors.newPassword}
+        required
+      />
+      <Input
+        type="password"
+        label={t`新しいパスワード（確認）`}
+        autoComplete="new-password"
+        placeholder="••••••••"
+        value={newPasswordConfirm}
+        onChange={(e) => setNewPasswordConfirm(e.target.value)}
+        error={fieldErrors.newPasswordConfirm}
+        required
+      />
+      <div className="flex justify-end">
+        <Button type="submit" variant="primary" size="md" disabled={isDisabled}>
+          {hasPassword ? (
+            <Trans>パスワードを変更</Trans>
+          ) : (
+            <Trans>パスワードを設定</Trans>
+          )}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default PasswordChangeForm;

--- a/src/components/settings/account/PasswordChangeForm.tsx
+++ b/src/components/settings/account/PasswordChangeForm.tsx
@@ -4,7 +4,12 @@ import { useState } from "react";
 import { useSetAtom } from "jotai";
 import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
-import { changePassword, changePasswordSchema } from "@/lib/auth";
+import {
+  changePassword,
+  changePasswordSchema,
+  setPassword,
+  setPasswordSchema,
+} from "@/lib/auth";
 import { addToastAtom } from "@/stores/toastAtoms";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
@@ -41,16 +46,19 @@ const PasswordChangeForm = ({ hasPassword }: Props) => {
     (hasPassword && currentPassword === "");
 
   const validate = () => {
-    const parsed = changePasswordSchema.safeParse({
-      currentPassword: hasPassword ? currentPassword : undefined,
-      newPassword,
-      newPasswordConfirm,
-    });
+    const parsed = hasPassword
+      ? changePasswordSchema.safeParse({
+          currentPassword,
+          newPassword,
+          newPasswordConfirm,
+        })
+      : setPasswordSchema.safeParse({ newPassword, newPasswordConfirm });
     if (parsed.success) {
       setFieldErrors(EMPTY_ERRORS);
       return parsed.data;
     }
-    const flat = parsed.error.flatten().fieldErrors;
+    const flat: Record<string, readonly string[] | undefined> =
+      parsed.error.flatten().fieldErrors;
     setFieldErrors({
       currentPassword: flat.currentPassword?.[0] ?? undefined,
       newPassword: flat.newPassword?.[0] ?? undefined,
@@ -67,7 +75,12 @@ const PasswordChangeForm = ({ hasPassword }: Props) => {
     if (data === undefined) return;
 
     setIsSubmitting(true);
-    const failed = await changePassword(data).catch(() => true);
+    const failed = hasPassword
+      ? await changePassword(data).catch(() => true)
+      : await setPassword({
+          newPassword: data.newPassword,
+          newPasswordConfirm: data.newPasswordConfirm,
+        }).catch(() => true);
     setIsSubmitting(false);
 
     if (failed === true) {

--- a/src/components/settings/account/ProfileForm.tsx
+++ b/src/components/settings/account/ProfileForm.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { updateProfile, updateProfileSchema } from "@/lib/auth";
+import { refreshAuthAtom } from "@/stores/authAtoms";
+import { addToastAtom } from "@/stores/toastAtoms";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+type Props = {
+  readonly currentUser: {
+    readonly name: string;
+    readonly email: string;
+    readonly image: string | undefined;
+  };
+};
+
+type FieldErrors = {
+  readonly name: string | undefined;
+  readonly image: string | undefined;
+};
+
+const EMPTY_ERRORS: FieldErrors = { name: undefined, image: undefined };
+
+const ProfileForm = ({ currentUser }: Props) => {
+  const refreshAuth = useSetAtom(refreshAuthAtom);
+  const addToast = useSetAtom(addToastAtom);
+
+  const [name, setName] = useState(currentUser.name);
+  const [image, setImage] = useState(currentUser.image ?? "");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>(EMPTY_ERRORS);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const trimmedName = name.trim();
+  const isUnchanged =
+    trimmedName === currentUser.name &&
+    image.trim() === (currentUser.image ?? "");
+  const isDisabled = isSubmitting || isUnchanged || trimmedName === "";
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isDisabled) return;
+
+    const parsed = updateProfileSchema.safeParse({
+      name,
+      image: image.trim() === "" ? undefined : image,
+    });
+    if (!parsed.success) {
+      const flat = parsed.error.flatten().fieldErrors;
+      setFieldErrors({
+        name: flat.name?.[0] ?? undefined,
+        image: flat.image?.[0] ?? undefined,
+      });
+      return;
+    }
+
+    setFieldErrors(EMPTY_ERRORS);
+    setIsSubmitting(true);
+    const failed = await updateProfile(parsed.data).catch(() => true);
+    setIsSubmitting(false);
+
+    if (failed === true) {
+      addToast({ message: t`プロフィールの更新に失敗しました` });
+      return;
+    }
+
+    refreshAuth();
+    addToast({ message: t`プロフィールを更新しました` });
+  };
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
+      <div className="flex items-center gap-4">
+        {currentUser.image !== undefined ? (
+          <img
+            src={currentUser.image}
+            alt=""
+            className="size-16 rounded-2xl object-cover ring-1 ring-inset ring-primary-200"
+          />
+        ) : (
+          <div
+            className="flex size-16 items-center justify-center rounded-2xl bg-primary-100 font-display text-xl font-bold text-primary-700 ring-1 ring-inset ring-primary-200"
+            aria-hidden
+          >
+            {currentUser.name.charAt(0)}
+          </div>
+        )}
+        <div className="flex flex-col gap-0.5">
+          <p className="font-display text-base font-bold text-text-primary">
+            {currentUser.name}
+          </p>
+          <p className="text-xs text-text-tertiary">{currentUser.email}</p>
+        </div>
+      </div>
+
+      <Input
+        type="text"
+        label={t`表示名`}
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        maxLength={60}
+        error={fieldErrors.name}
+        required
+      />
+      <Input
+        type="url"
+        label={t`プロフィール画像 URL`}
+        placeholder={t`https://...`}
+        value={image}
+        onChange={(e) => setImage(e.target.value)}
+        error={fieldErrors.image}
+      />
+
+      <div className="flex justify-end">
+        <Button type="submit" variant="primary" size="md" disabled={isDisabled}>
+          <Trans>変更を保存</Trans>
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default ProfileForm;

--- a/src/components/settings/account/SectionCard.tsx
+++ b/src/components/settings/account/SectionCard.tsx
@@ -1,0 +1,21 @@
+type Props = {
+  readonly title: React.ReactNode;
+  readonly description?: React.ReactNode;
+  readonly children: React.ReactNode;
+};
+
+const SectionCard = ({ title, description, children }: Props) => (
+  <section className="rounded-2xl border border-border-default bg-surface-overlay p-5">
+    <header className="mb-4 flex flex-col gap-1">
+      <h3 className="font-display text-base font-bold text-text-primary">
+        {title}
+      </h3>
+      {description !== undefined && (
+        <p className="text-xs text-text-tertiary">{description}</p>
+      )}
+    </header>
+    {children}
+  </section>
+);
+
+export default SectionCard;

--- a/src/components/ui/ErrorAlert.tsx
+++ b/src/components/ui/ErrorAlert.tsx
@@ -1,0 +1,14 @@
+type Props = {
+  readonly children: React.ReactNode;
+};
+
+const ErrorAlert = ({ children }: Props) => (
+  <p
+    role="alert"
+    className="rounded-lg border border-danger/30 bg-red-50/70 px-3 py-2 text-xs text-danger"
+  >
+    {children}
+  </p>
+);
+
+export default ErrorAlert;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -219,12 +219,22 @@ export const setPassword = async (input: SetPasswordInput): Promise<void> => {
     : fail(error.message ?? "パスワード設定に失敗しました");
 };
 
+// confirmEmail を server に送り、session の user.email と一致するか
+// サーバ側で検証してから auth.api.deleteUser を実行する。client.deleteUser
+// は schema 上 confirmEmail を受け取らないため、$fetch で intercept route
+// を直接叩く形にする。クライアント側のメール一致チェックだけだと、stale
+// state や bypass で意図しない削除が成立し得る。
 export const deleteAccount = async (
   input: DeleteAccountInput,
 ): Promise<void> => {
-  const { error } = await client.deleteUser(
-    input.password === undefined ? {} : { password: input.password },
-  );
+  const body =
+    input.password === undefined
+      ? { confirmEmail: input.confirmEmail }
+      : { confirmEmail: input.confirmEmail, password: input.password };
+  const { error } = await client.$fetch("/delete-user", {
+    method: "POST",
+    body,
+  });
   return error === null
     ? undefined
     : fail(error.message ?? "アカウント削除に失敗しました");

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -70,12 +70,13 @@ const PASSWORD_MIN = 8;
 const PASSWORD_MAX = 128;
 const NAME_MAX = 60;
 
-const emailField = z.email().trim();
+const emailField = z.string().trim().pipe(z.email());
 const passwordField = z.string().min(PASSWORD_MIN).max(PASSWORD_MAX);
 const nameField = z.string().trim().min(1).max(NAME_MAX);
 const optionalImageField = z
-  .url()
+  .string()
   .trim()
+  .pipe(z.url())
   .optional()
   .or(z.literal("").transform(() => undefined));
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -56,9 +56,14 @@ export type LinkedAccount = {
   readonly providerId: string;
 };
 
+// 取得失敗時は throw し、accountsAtom 側で "error" sentinel に変換する。
+// [] を返すと credential ありユーザーが OAuth-only と誤判定され、setPassword
+// 分岐に流されて詰まる。fail-closed を効かせるため呼び出し側で reject を伝える。
 export const listAccounts = async (): Promise<readonly LinkedAccount[]> => {
   const { data, error } = await client.listAccounts();
-  return error === null ? data.map((a) => ({ providerId: a.providerId })) : [];
+  return error === null
+    ? data.map((a) => ({ providerId: a.providerId }))
+    : fail(error.message ?? "アカウント一覧の取得に失敗しました");
 };
 
 const PASSWORD_MIN = 8;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -111,6 +111,16 @@ export const changePasswordSchema = z
     message: "パスワードが一致しません",
   });
 
+export const setPasswordSchema = z
+  .object({
+    newPassword: passwordField,
+    newPasswordConfirm: passwordField,
+  })
+  .refine((v) => v.newPassword === v.newPasswordConfirm, {
+    path: ["newPasswordConfirm"],
+    message: "パスワードが一致しません",
+  });
+
 export const deleteAccountSchema = z.object({
   confirmEmail: emailField,
   password: z.string().min(1).optional(),
@@ -121,6 +131,7 @@ export type SignUpEmailInput = z.infer<typeof signUpEmailSchema>;
 export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
 export type ChangeEmailInput = z.infer<typeof changeEmailSchema>;
 export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
+export type SetPasswordInput = z.infer<typeof setPasswordSchema>;
 export type DeleteAccountInput = z.infer<typeof deleteAccountSchema>;
 
 const fail = (msg: string): never => {
@@ -187,6 +198,19 @@ export const changePassword = async (
   return error === null
     ? undefined
     : fail(error.message ?? "パスワード変更に失敗しました");
+};
+
+// OAuth-only ユーザー (credential アカウント未保有) 向けの初回パスワード設定。
+// better-auth の POST /set-password を呼ぶ。既に credential ありなら 400 で弾かれる。
+// client.setPassword は dynamic proxy で型に出ないため、$fetch を直接使う。
+export const setPassword = async (input: SetPasswordInput): Promise<void> => {
+  const { error } = await client.$fetch("/set-password", {
+    method: "POST",
+    body: { newPassword: input.newPassword },
+  });
+  return error === null
+    ? undefined
+    : fail(error.message ?? "パスワード設定に失敗しました");
 };
 
 export const deleteAccount = async (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -31,7 +31,7 @@ export type SessionResponse = {
     | undefined;
 };
 
-const { signOut: clientSignOut, signIn } = client;
+const { signOut: clientSignOut, signIn, signUp } = client;
 const { social } = signIn;
 
 export const signInSocial = social;
@@ -50,6 +50,145 @@ export const getSession = async (): Promise<SessionResponse> => {
             },
           },
   };
+};
+
+const PASSWORD_MIN = 8;
+const PASSWORD_MAX = 128;
+const NAME_MAX = 60;
+
+const emailField = z.email().trim();
+const passwordField = z.string().min(PASSWORD_MIN).max(PASSWORD_MAX);
+const nameField = z.string().trim().min(1).max(NAME_MAX);
+const optionalImageField = z
+  .url()
+  .trim()
+  .optional()
+  .or(z.literal("").transform(() => undefined));
+
+export const signInEmailSchema = z.object({
+  email: emailField,
+  password: z.string().min(1),
+});
+
+export const signUpEmailSchema = z
+  .object({
+    name: nameField,
+    email: emailField,
+    password: passwordField,
+    passwordConfirm: passwordField,
+  })
+  .refine((v) => v.password === v.passwordConfirm, {
+    path: ["passwordConfirm"],
+    message: "パスワードが一致しません",
+  });
+
+export const updateProfileSchema = z.object({
+  name: nameField,
+  image: optionalImageField,
+});
+
+export const changeEmailSchema = z.object({
+  newEmail: emailField,
+});
+
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1).optional(),
+    newPassword: passwordField,
+    newPasswordConfirm: passwordField,
+  })
+  .refine((v) => v.newPassword === v.newPasswordConfirm, {
+    path: ["newPasswordConfirm"],
+    message: "パスワードが一致しません",
+  });
+
+export const deleteAccountSchema = z.object({
+  confirmEmail: emailField,
+  password: z.string().min(1).optional(),
+});
+
+export type SignInEmailInput = z.infer<typeof signInEmailSchema>;
+export type SignUpEmailInput = z.infer<typeof signUpEmailSchema>;
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
+export type ChangeEmailInput = z.infer<typeof changeEmailSchema>;
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
+export type DeleteAccountInput = z.infer<typeof deleteAccountSchema>;
+
+const fail = (msg: string): never => {
+  // eslint-disable-next-line functional/no-throw-statements -- caller catches
+  throw new Error(msg);
+};
+
+export const signInWithEmail = async (
+  input: SignInEmailInput,
+): Promise<void> => {
+  const { error } = await client.signIn.email({
+    email: input.email,
+    password: input.password,
+  });
+  return error === null
+    ? undefined
+    : fail(error.message ?? "ログインに失敗しました");
+};
+
+export const signUpWithEmail = async (input: {
+  readonly name: string;
+  readonly email: string;
+  readonly password: string;
+}): Promise<void> => {
+  const { error } = await signUp.email({
+    name: input.name,
+    email: input.email,
+    password: input.password,
+  });
+  return error === null
+    ? undefined
+    : fail(error.message ?? "サインアップに失敗しました");
+};
+
+export const updateProfile = async (
+  input: UpdateProfileInput,
+): Promise<void> => {
+  const { error } = await client.updateUser({
+    name: input.name,
+    image: input.image,
+  });
+  return error === null
+    ? undefined
+    : fail(error.message ?? "プロフィール更新に失敗しました");
+};
+
+export const changeEmail = async (input: ChangeEmailInput): Promise<void> => {
+  const { error } = await client.changeEmail({
+    newEmail: input.newEmail,
+  });
+  return error === null
+    ? undefined
+    : fail(error.message ?? "メールアドレス変更に失敗しました");
+};
+
+export const changePassword = async (
+  input: ChangePasswordInput,
+): Promise<void> => {
+  const { error } = await client.changePassword({
+    currentPassword: input.currentPassword ?? "",
+    newPassword: input.newPassword,
+    revokeOtherSessions: true,
+  });
+  return error === null
+    ? undefined
+    : fail(error.message ?? "パスワード変更に失敗しました");
+};
+
+export const deleteAccount = async (
+  input: DeleteAccountInput,
+): Promise<void> => {
+  const { error } = await client.deleteUser(
+    input.password === undefined ? {} : { password: input.password },
+  );
+  return error === null
+    ? undefined
+    : fail(error.message ?? "アカウント削除に失敗しました");
 };
 
 export const API_KEY_SCOPE = Object.freeze({
@@ -109,11 +248,6 @@ const toMillis = (raw: unknown): number => {
 const toLastRequest = (raw: unknown): number | undefined => {
   const ms = toMillis(raw);
   return ms === 0 ? undefined : ms;
-};
-
-const fail = (msg: string): never => {
-  // eslint-disable-next-line functional/no-throw-statements -- ErrorBoundary handles via Suspense
-  throw new Error(msg);
 };
 
 export const createApiKey = async (input: {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -52,6 +52,15 @@ export const getSession = async (): Promise<SessionResponse> => {
   };
 };
 
+export type LinkedAccount = {
+  readonly providerId: string;
+};
+
+export const listAccounts = async (): Promise<readonly LinkedAccount[]> => {
+  const { data, error } = await client.listAccounts();
+  return error === null ? data.map((a) => ({ providerId: a.providerId })) : [];
+};
+
 const PASSWORD_MIN = 8;
 const PASSWORD_MAX = 128;
 const NAME_MAX = 60;

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1050,8 +1050,13 @@ msgid "リセット"
 msgstr "Reset"
 
 #: src/components/auth/UserMenu.tsx
+#: src/components/auth/UserMenu.tsx
 msgid "ログアウト"
 msgstr "Sign out"
+
+#: src/components/auth/UserMenu.tsx
+msgid "ログアウトしますか？"
+msgstr "Sign out?"
 
 #: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/UserMenu.tsx
@@ -1229,6 +1234,10 @@ msgstr "All dolls"
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
 msgstr "All present"
+
+#: src/components/auth/UserMenu.tsx
+msgid "再びログインするまで、収納場所の確認や服の登録ができなくなります。"
+msgstr "You won't be able to check storage or register garments until you sign in again."
 
 #: src/app/dolls/page.tsx
 msgid "最初のドールを登録してみましょう"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -171,7 +171,6 @@ msgstr "8 or more characters. Including letters and numbers is safer."
 msgid "AI"
 msgstr "AI"
 
-#: src/app/settings/api-keys/page.tsx
 #: src/components/settings/SettingsTabs.tsx
 msgid "API キー"
 msgstr "API keys"
@@ -1439,7 +1438,6 @@ msgstr "Restore"
 
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
-#: src/app/settings/api-keys/page.tsx
 #: src/app/settings/layout.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -159,11 +159,20 @@ msgstr "Permanently delete \"{0}\"? This action cannot be undone."
 msgid "「{0}」を紛失としてマークします。収納場所の情報はクリアされます。"
 msgstr "Mark \"{0}\" as lost. Its location information will be cleared."
 
+#: src/app/signup/page.tsx
+msgid "30 秒で、最初の引き出しを開けられます"
+msgstr "Open your first drawer in 30 seconds"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "8 文字以上。英数字を含めると安全です。"
+msgstr "8 or more characters. Including letters and numbers is safer."
+
 #: src/components/coordinate/OriginBadge.tsx
 msgid "AI"
 msgstr "AI"
 
 #: src/app/settings/api-keys/page.tsx
+#: src/components/settings/SettingsTabs.tsx
 msgid "API キー"
 msgstr "API keys"
 
@@ -241,6 +250,10 @@ msgstr "DDS (~55cm)"
 msgid "Google でログイン"
 msgstr "Sign in with Google"
 
+#: src/components/settings/account/ProfileForm.tsx
+msgid "https://..."
+msgstr "https://..."
+
 #: src/lib/i18n-labels.ts
 msgid "MDD L胸 (~40cm)"
 msgstr "MDD L-bust (~40cm)"
@@ -256,6 +269,10 @@ msgstr "MDD S-bust (~40cm)"
 #: src/lib/i18n-labels.ts
 msgid "MSD (~43cm)"
 msgstr "MSD (~43cm)"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "new@example.com"
+msgstr "new@example.com"
 
 #: src/app/nfc-write/page.tsx
 msgid "NFC タグにタッチしてください..."
@@ -339,6 +356,11 @@ msgstr "Sign in with X (Twitter)"
 msgid "YoSD (~26cm)"
 msgstr "YoSD (~26cm)"
 
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+msgid "you@example.com"
+msgstr "you@example.com"
+
 #: src/app/archive/page.tsx
 #: src/components/doll/DollDetail.tsx
 #: src/components/doll/DollDetail.tsx
@@ -374,6 +396,34 @@ msgstr "Archive is empty"
 #: src/lib/i18n-labels.ts
 msgid "アウター"
 msgstr "Outerwear"
+
+#: src/components/settings/SettingsTabs.tsx
+msgid "アカウント"
+msgstr "Account"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントの削除に失敗しました"
+msgstr "Failed to delete account"
+
+#: src/app/signin/page.tsx
+msgid "アカウントをお持ちでない方は <0>新規登録</0>"
+msgstr "Don't have an account? <0>Sign up</0>"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "アカウントを作成できませんでした。メールアドレスがすでに使われている可能性があります。"
+msgstr "Could not create account. The email may already be in use."
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントを削除"
+msgstr "Delete Account"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントを削除する"
+msgstr "Delete account"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "アカウント作成"
+msgstr "Create Account"
 
 #: src/lib/i18n-labels.ts
 msgid "アクセサリー"
@@ -460,6 +510,7 @@ msgstr "Color"
 #: src/components/location/StorageCaseEditForm.tsx
 #: src/components/location/StorageCaseForm.tsx
 #: src/components/location/StorageLocationEditForm.tsx
+#: src/components/settings/account/DeleteAccountSection.tsx
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 #: src/components/ui/ConfirmSheet.tsx
 msgid "キャンセル"
@@ -551,6 +602,10 @@ msgstr "Mark all garments in this location as confirmed"
 msgid "この引き出しの他の服、まだありますか？"
 msgstr "Are all the other clothes in this drawer still there?"
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "この操作は取り消せません。確認のため、登録メールアドレスを入力してください。"
+msgstr "This action cannot be undone. To confirm, enter your registered email address."
+
 #: src/components/settings/api-key/ApiKeyRevealSheet.tsx
 msgid "コピー"
 msgstr "Copy"
@@ -623,6 +678,10 @@ msgstr "Scope"
 msgid "ステータス"
 msgstr "Status"
 
+#: src/app/signup/page.tsx
+msgid "すでにアカウントをお持ちの方は <0>ログイン</0>"
+msgstr "Already have an account? <0>Sign in</0>"
+
 #: src/app/dolls/page.tsx
 #: src/app/dolls/page.tsx
 #: src/app/garments/page.tsx
@@ -653,8 +712,12 @@ msgid "セット内容"
 msgstr "Set Contents"
 
 #: src/app/signin/page.tsx
-msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
-msgstr "Sign in with a social account to access all features, including QR/NFC scan tracking and API key issuance."
+#~ msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+#~ msgstr "Sign in with a social account to access all features, including QR/NFC scan tracking and API key issuance."
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "ソーシャルログインで作成されたアカウントです。新しいパスワードを設定すると、メール + パスワードでもログインできるようになります。"
+msgstr "This account was created via social login. Once you set a password, you can also sign in with email + password."
 
 #: src/lib/i18n-labels.ts
 msgid "ソックス/タイツ"
@@ -743,6 +806,10 @@ msgstr "Doll list"
 msgid "ドール服の名前"
 msgstr "Garment name"
 
+#: src/app/signin/page.tsx
+msgid "ドール服管理にログイン"
+msgstr "Sign in to Doll Wardrobe"
+
 #: src/lib/i18n-labels.ts
 msgid "トップス"
 msgstr "Tops"
@@ -758,6 +825,37 @@ msgstr "Missing"
 #: src/components/scan/OrphanCheckoutDialog.tsx
 #~ msgid "なくした"
 #~ msgstr "Lost"
+
+#: src/app/settings/account/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワード"
+msgstr "Password"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "パスワード（確認）"
+msgstr "Password (Confirm)"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードの設定に失敗しました"
+msgstr "Failed to set password"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを変更"
+msgstr "Change Password"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを変更しました"
+msgstr "Password changed"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを設定"
+msgstr "Set Password"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを設定しました"
+msgstr "Password set"
 
 #: src/lib/i18n-labels.ts
 msgid "ピンク"
@@ -783,6 +881,22 @@ msgstr "Brand/Maker"
 #: src/components/garment/ImageUpload.tsx
 msgid "プレビュー"
 msgstr "Preview"
+
+#: src/app/settings/account/page.tsx
+msgid "プロフィール"
+msgstr "Profile"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィールの更新に失敗しました"
+msgstr "Failed to update profile"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィールを更新しました"
+msgstr "Profile updated"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィール画像 URL"
+msgstr "Profile Image URL"
 
 #: src/components/ui/Pagination.tsx
 msgid "ページネーション"
@@ -838,6 +952,11 @@ msgstr "No outfits yet"
 msgid "まだドールがいません"
 msgstr "No dolls yet"
 
+#: src/app/signin/page.tsx
+#: src/app/signup/page.tsx
+msgid "または"
+msgstr "OR"
+
 #: src/components/garment/csv/CsvDropZone.tsx
 msgid "またはクリックしてファイルを選択"
 msgstr "or click to select a file"
@@ -866,6 +985,36 @@ msgstr "Not yet opened"
 #: src/components/doll/DollForm.tsx
 msgid "メーカー"
 msgstr "Maker"
+
+#: src/app/settings/account/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+msgid "メールアドレス"
+msgstr "Email Address"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "メールアドレスが一致しません"
+msgstr "Email addresses do not match"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスの変更に失敗しました"
+msgstr "Failed to change email"
+
+#: src/components/auth/EmailPasswordForm.tsx
+msgid "メールアドレスまたはパスワードが正しくありません"
+msgstr "Email or password is incorrect"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "メールアドレスを再入力"
+msgstr "Re-enter Email Address"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスを変更"
+msgstr "Change Email"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスを変更しました"
+msgstr "Email changed"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/components/coordinate/CoordinateBuilder.tsx
@@ -905,10 +1054,18 @@ msgstr "Reset"
 msgid "ログアウト"
 msgstr "Sign out"
 
-#: src/app/signin/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/UserMenu.tsx
 msgid "ログイン"
 msgstr "Sign in"
+
+#: src/app/settings/account/page.tsx
+msgid "ログインに使うメールアドレスです。"
+msgstr "The email address you use to sign in."
+
+#: src/components/auth/EmailPasswordForm.tsx
+msgid "ログイン中…"
+msgstr "Signing in…"
 
 #: src/app/garments/page.tsx
 #: src/lib/nav-items.ts
@@ -982,6 +1139,10 @@ msgstr "Sort"
 msgid "今ここにいなくても確認"
 msgstr "Confirm without being here"
 
+#: src/app/settings/account/page.tsx
+msgid "他のユーザーや UI に表示されます。"
+msgstr "Shown to other users and in the UI."
+
 #: src/components/location/StorageCaseForm.tsx
 msgid "作成"
 msgstr "Create"
@@ -1001,6 +1162,10 @@ msgstr "In use"
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "例: agent-1"
 msgstr "e.g. agent-1"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "例: ドリーラー"
+msgstr "e.g. Dolllr"
 
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "例: ワンピース用"
@@ -1214,6 +1379,10 @@ msgstr "Location set"
 msgid "変更"
 msgstr "Change"
 
+#: src/components/settings/account/ProfileForm.tsx
+msgid "変更を保存"
+msgstr "Save Changes"
+
 #: src/app/settings/api-keys/page.tsx
 msgid "外部 AI エージェントから接続するための Personal Access Token を発行・管理します。"
 msgstr "Issue and manage Personal Access Tokens for external AI agents to connect."
@@ -1239,8 +1408,13 @@ msgstr "Done"
 #: src/components/doll/DollDetail.tsx
 #: src/components/garment/GarmentDetail.tsx
 #: src/components/garment/GarmentDetail.tsx
+#: src/components/settings/account/DeleteAccountSection.tsx
 msgid "完全に削除"
 msgstr "Delete permanently"
+
+#: src/app/settings/account/page.tsx
+msgid "定期的な更新を推奨します。"
+msgstr "Regular updates are recommended."
 
 #: src/lib/i18n-labels.ts
 msgid "帽子/ヘッドドレス"
@@ -1249,6 +1423,10 @@ msgstr "Hats/Headdress"
 #: src/components/location/StorageCaseForm.tsx
 msgid "引き出し"
 msgstr "Drawer"
+
+#: src/app/signin/page.tsx
+msgid "引き出しの中身を、いつでもどこでも"
+msgstr "Your drawers, anytime and anywhere"
 
 #: src/components/location/StorageGrid.tsx
 msgid "引き出しを編集"
@@ -1262,7 +1440,7 @@ msgstr "Restore"
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
 #: src/app/settings/api-keys/page.tsx
-#: src/app/signin/page.tsx
+#: src/app/settings/layout.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
@@ -1281,6 +1459,22 @@ msgstr "New API key"
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "新しい API キーを発行"
 msgstr "Issue a new API key"
+
+#: src/app/signup/page.tsx
+msgid "新しいアカウントを作る"
+msgstr "Create a new account"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "新しいパスワード"
+msgstr "New Password"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "新しいパスワード（確認）"
+msgstr "New Password (Confirm)"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "新しいメールアドレス"
+msgstr "New Email Address"
 
 #: src/components/digest/DigestBanner.tsx
 msgid "新しい週間レポートが届いています"
@@ -1385,6 +1579,10 @@ msgstr "Unassigned"
 msgid "未配置にする"
 msgstr "Unassign"
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "本当に削除しますか？"
+msgstr "Are you sure you want to delete?"
+
 #: src/components/digest/DigestCard.tsx
 msgid "次に引き出しを開けたときに自動で確認されます"
 msgstr "Will be confirmed automatically the next time you open the drawer"
@@ -1409,6 +1607,14 @@ msgstr "Auto-generated every Monday"
 msgid "状態"
 msgstr "Status"
 
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "現在のパスワード"
+msgstr "Current Password"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "現在のパスワードが正しくないか、更新に失敗しました"
+msgstr "Current password is incorrect, or update failed"
+
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "生キーは発行直後の一度しか表示されません。安全な場所に保管してください。"
 msgstr "The raw key is shown only once right after issuance. Keep it in a safe place."
@@ -1427,10 +1633,18 @@ msgstr "Issue"
 msgid "登録された服がありません"
 msgstr "No garments registered yet."
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "登録した服・収納場所・コーデ・ドールはすべて削除され、復元できません。"
+msgstr "All registered garments, locations, coordinates, and dolls will be deleted and cannot be restored."
+
 #: src/components/doll/DollForm.tsx
 #: src/components/garment/GarmentForm.tsx
 msgid "登録する"
 msgstr "Register"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "登録中…"
+msgstr "Registering…"
 
 #: src/components/garment/bulk/BulkRegistrationProgress.tsx
 msgid "登録完了"
@@ -1547,6 +1761,11 @@ msgstr "Add costume cases to manage garment storage"
 msgid "表示件数"
 msgstr "Items per page"
 
+#: src/components/auth/SignUpForm.tsx
+#: src/components/settings/account/ProfileForm.tsx
+msgid "表示名"
+msgstr "Display Name"
+
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
@@ -1563,7 +1782,9 @@ msgstr "Items needing review ({0})"
 msgid "言語"
 msgstr "Language"
 
+#: src/app/settings/layout.tsx
 #: src/components/auth/UserMenu.tsx
+#: src/components/settings/SettingsTabs.tsx
 msgid "設定"
 msgstr "Settings"
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -159,11 +159,20 @@ msgstr "「{0}」を完全に削除しますか？この操作は取り消せま
 msgid "「{0}」を紛失としてマークします。収納場所の情報はクリアされます。"
 msgstr "「{0}」を紛失としてマークします。収納場所の情報はクリアされます。"
 
+#: src/app/signup/page.tsx
+msgid "30 秒で、最初の引き出しを開けられます"
+msgstr "30 秒で、最初の引き出しを開けられます"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "8 文字以上。英数字を含めると安全です。"
+msgstr "8 文字以上。英数字を含めると安全です。"
+
 #: src/components/coordinate/OriginBadge.tsx
 msgid "AI"
 msgstr "AI"
 
 #: src/app/settings/api-keys/page.tsx
+#: src/components/settings/SettingsTabs.tsx
 msgid "API キー"
 msgstr "API キー"
 
@@ -241,6 +250,10 @@ msgstr "DDS (~55cm)"
 msgid "Google でログイン"
 msgstr "Google でログイン"
 
+#: src/components/settings/account/ProfileForm.tsx
+msgid "https://..."
+msgstr "https://..."
+
 #: src/lib/i18n-labels.ts
 msgid "MDD L胸 (~40cm)"
 msgstr "MDD L胸 (~40cm)"
@@ -256,6 +269,10 @@ msgstr "MDD S胸 (~40cm)"
 #: src/lib/i18n-labels.ts
 msgid "MSD (~43cm)"
 msgstr "MSD (~43cm)"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "new@example.com"
+msgstr "new@example.com"
 
 #: src/app/nfc-write/page.tsx
 msgid "NFC タグにタッチしてください..."
@@ -339,6 +356,11 @@ msgstr "X (Twitter) でログイン"
 msgid "YoSD (~26cm)"
 msgstr "YoSD (~26cm)"
 
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+msgid "you@example.com"
+msgstr "you@example.com"
+
 #: src/app/archive/page.tsx
 #: src/components/doll/DollDetail.tsx
 #: src/components/doll/DollDetail.tsx
@@ -374,6 +396,34 @@ msgstr "アーカイブは空です"
 #: src/lib/i18n-labels.ts
 msgid "アウター"
 msgstr "アウター"
+
+#: src/components/settings/SettingsTabs.tsx
+msgid "アカウント"
+msgstr "アカウント"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントの削除に失敗しました"
+msgstr "アカウントの削除に失敗しました"
+
+#: src/app/signin/page.tsx
+msgid "アカウントをお持ちでない方は <0>新規登録</0>"
+msgstr "アカウントをお持ちでない方は <0>新規登録</0>"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "アカウントを作成できませんでした。メールアドレスがすでに使われている可能性があります。"
+msgstr "アカウントを作成できませんでした。メールアドレスがすでに使われている可能性があります。"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントを削除"
+msgstr "アカウントを削除"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントを削除する"
+msgstr "アカウントを削除する"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "アカウント作成"
+msgstr "アカウント作成"
 
 #: src/lib/i18n-labels.ts
 msgid "アクセサリー"
@@ -460,6 +510,7 @@ msgstr "カラー"
 #: src/components/location/StorageCaseEditForm.tsx
 #: src/components/location/StorageCaseForm.tsx
 #: src/components/location/StorageLocationEditForm.tsx
+#: src/components/settings/account/DeleteAccountSection.tsx
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 #: src/components/ui/ConfirmSheet.tsx
 msgid "キャンセル"
@@ -551,6 +602,10 @@ msgstr "この場所の全服を確認済みにする"
 msgid "この引き出しの他の服、まだありますか？"
 msgstr "この引き出しの他の服、まだありますか？"
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "この操作は取り消せません。確認のため、登録メールアドレスを入力してください。"
+msgstr "この操作は取り消せません。確認のため、登録メールアドレスを入力してください。"
+
 #: src/components/settings/api-key/ApiKeyRevealSheet.tsx
 msgid "コピー"
 msgstr "コピー"
@@ -623,6 +678,10 @@ msgstr "スコープ"
 msgid "ステータス"
 msgstr "ステータス"
 
+#: src/app/signup/page.tsx
+msgid "すでにアカウントをお持ちの方は <0>ログイン</0>"
+msgstr "すでにアカウントをお持ちの方は <0>ログイン</0>"
+
 #: src/app/dolls/page.tsx
 #: src/app/dolls/page.tsx
 #: src/app/garments/page.tsx
@@ -653,8 +712,12 @@ msgid "セット内容"
 msgstr "セット内容"
 
 #: src/app/signin/page.tsx
-msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
-msgstr "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+#~ msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+#~ msgstr "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "ソーシャルログインで作成されたアカウントです。新しいパスワードを設定すると、メール + パスワードでもログインできるようになります。"
+msgstr "ソーシャルログインで作成されたアカウントです。新しいパスワードを設定すると、メール + パスワードでもログインできるようになります。"
 
 #: src/lib/i18n-labels.ts
 msgid "ソックス/タイツ"
@@ -743,6 +806,10 @@ msgstr "ドール一覧"
 msgid "ドール服の名前"
 msgstr "ドール服の名前"
 
+#: src/app/signin/page.tsx
+msgid "ドール服管理にログイン"
+msgstr "ドール服管理にログイン"
+
 #: src/lib/i18n-labels.ts
 msgid "トップス"
 msgstr "トップス"
@@ -758,6 +825,37 @@ msgstr "ない"
 #: src/components/scan/OrphanCheckoutDialog.tsx
 #~ msgid "なくした"
 #~ msgstr "なくした"
+
+#: src/app/settings/account/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワード"
+msgstr "パスワード"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "パスワード（確認）"
+msgstr "パスワード（確認）"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードの設定に失敗しました"
+msgstr "パスワードの設定に失敗しました"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを変更"
+msgstr "パスワードを変更"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを変更しました"
+msgstr "パスワードを変更しました"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを設定"
+msgstr "パスワードを設定"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを設定しました"
+msgstr "パスワードを設定しました"
 
 #: src/lib/i18n-labels.ts
 msgid "ピンク"
@@ -783,6 +881,22 @@ msgstr "ブランド/メーカー"
 #: src/components/garment/ImageUpload.tsx
 msgid "プレビュー"
 msgstr "プレビュー"
+
+#: src/app/settings/account/page.tsx
+msgid "プロフィール"
+msgstr "プロフィール"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィールの更新に失敗しました"
+msgstr "プロフィールの更新に失敗しました"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィールを更新しました"
+msgstr "プロフィールを更新しました"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィール画像 URL"
+msgstr "プロフィール画像 URL"
 
 #: src/components/ui/Pagination.tsx
 msgid "ページネーション"
@@ -838,6 +952,11 @@ msgstr "まだコーデがありません"
 msgid "まだドールがいません"
 msgstr "まだドールがいません"
 
+#: src/app/signin/page.tsx
+#: src/app/signup/page.tsx
+msgid "または"
+msgstr "または"
+
 #: src/components/garment/csv/CsvDropZone.tsx
 msgid "またはクリックしてファイルを選択"
 msgstr "またはクリックしてファイルを選択"
@@ -866,6 +985,36 @@ msgstr "まだ開けていません"
 #: src/components/doll/DollForm.tsx
 msgid "メーカー"
 msgstr "メーカー"
+
+#: src/app/settings/account/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+msgid "メールアドレス"
+msgstr "メールアドレス"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "メールアドレスが一致しません"
+msgstr "メールアドレスが一致しません"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスの変更に失敗しました"
+msgstr "メールアドレスの変更に失敗しました"
+
+#: src/components/auth/EmailPasswordForm.tsx
+msgid "メールアドレスまたはパスワードが正しくありません"
+msgstr "メールアドレスまたはパスワードが正しくありません"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "メールアドレスを再入力"
+msgstr "メールアドレスを再入力"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスを変更"
+msgstr "メールアドレスを変更"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスを変更しました"
+msgstr "メールアドレスを変更しました"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/components/coordinate/CoordinateBuilder.tsx
@@ -905,10 +1054,18 @@ msgstr "リセット"
 msgid "ログアウト"
 msgstr "ログアウト"
 
-#: src/app/signin/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/UserMenu.tsx
 msgid "ログイン"
 msgstr "ログイン"
+
+#: src/app/settings/account/page.tsx
+msgid "ログインに使うメールアドレスです。"
+msgstr "ログインに使うメールアドレスです。"
+
+#: src/components/auth/EmailPasswordForm.tsx
+msgid "ログイン中…"
+msgstr "ログイン中…"
 
 #: src/app/garments/page.tsx
 #: src/lib/nav-items.ts
@@ -982,6 +1139,10 @@ msgstr "並び替え"
 msgid "今ここにいなくても確認"
 msgstr "今ここにいなくても確認"
 
+#: src/app/settings/account/page.tsx
+msgid "他のユーザーや UI に表示されます。"
+msgstr "他のユーザーや UI に表示されます。"
+
 #: src/components/location/StorageCaseForm.tsx
 msgid "作成"
 msgstr "作成"
@@ -1001,6 +1162,10 @@ msgstr "使用中"
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "例: agent-1"
 msgstr "例: agent-1"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "例: ドリーラー"
+msgstr "例: ドリーラー"
 
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "例: ワンピース用"
@@ -1214,6 +1379,10 @@ msgstr "場所を設定しました"
 msgid "変更"
 msgstr "変更"
 
+#: src/components/settings/account/ProfileForm.tsx
+msgid "変更を保存"
+msgstr "変更を保存"
+
 #: src/app/settings/api-keys/page.tsx
 msgid "外部 AI エージェントから接続するための Personal Access Token を発行・管理します。"
 msgstr "外部 AI エージェントから接続するための Personal Access Token を発行・管理します。"
@@ -1239,8 +1408,13 @@ msgstr "完了"
 #: src/components/doll/DollDetail.tsx
 #: src/components/garment/GarmentDetail.tsx
 #: src/components/garment/GarmentDetail.tsx
+#: src/components/settings/account/DeleteAccountSection.tsx
 msgid "完全に削除"
 msgstr "完全に削除"
+
+#: src/app/settings/account/page.tsx
+msgid "定期的な更新を推奨します。"
+msgstr "定期的な更新を推奨します。"
 
 #: src/lib/i18n-labels.ts
 msgid "帽子/ヘッドドレス"
@@ -1249,6 +1423,10 @@ msgstr "帽子/ヘッドドレス"
 #: src/components/location/StorageCaseForm.tsx
 msgid "引き出し"
 msgstr "引き出し"
+
+#: src/app/signin/page.tsx
+msgid "引き出しの中身を、いつでもどこでも"
+msgstr "引き出しの中身を、いつでもどこでも"
 
 #: src/components/location/StorageGrid.tsx
 msgid "引き出しを編集"
@@ -1262,7 +1440,7 @@ msgstr "復元"
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
 #: src/app/settings/api-keys/page.tsx
-#: src/app/signin/page.tsx
+#: src/app/settings/layout.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
@@ -1281,6 +1459,22 @@ msgstr "新しい API キー"
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "新しい API キーを発行"
 msgstr "新しい API キーを発行"
+
+#: src/app/signup/page.tsx
+msgid "新しいアカウントを作る"
+msgstr "新しいアカウントを作る"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "新しいパスワード"
+msgstr "新しいパスワード"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "新しいパスワード（確認）"
+msgstr "新しいパスワード（確認）"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "新しいメールアドレス"
+msgstr "新しいメールアドレス"
 
 #: src/components/digest/DigestBanner.tsx
 msgid "新しい週間レポートが届いています"
@@ -1385,6 +1579,10 @@ msgstr "未配置"
 msgid "未配置にする"
 msgstr "未配置にする"
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "本当に削除しますか？"
+msgstr "本当に削除しますか？"
+
 #: src/components/digest/DigestCard.tsx
 msgid "次に引き出しを開けたときに自動で確認されます"
 msgstr "次に引き出しを開けたときに自動で確認されます"
@@ -1409,6 +1607,14 @@ msgstr "毎週月曜日に自動生成されます"
 msgid "状態"
 msgstr "状態"
 
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "現在のパスワード"
+msgstr "現在のパスワード"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "現在のパスワードが正しくないか、更新に失敗しました"
+msgstr "現在のパスワードが正しくないか、更新に失敗しました"
+
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "生キーは発行直後の一度しか表示されません。安全な場所に保管してください。"
 msgstr "生キーは発行直後の一度しか表示されません。安全な場所に保管してください。"
@@ -1427,10 +1633,18 @@ msgstr "発行"
 msgid "登録された服がありません"
 msgstr "登録された服がありません"
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "登録した服・収納場所・コーデ・ドールはすべて削除され、復元できません。"
+msgstr "登録した服・収納場所・コーデ・ドールはすべて削除され、復元できません。"
+
 #: src/components/doll/DollForm.tsx
 #: src/components/garment/GarmentForm.tsx
 msgid "登録する"
 msgstr "登録する"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "登録中…"
+msgstr "登録中…"
 
 #: src/components/garment/bulk/BulkRegistrationProgress.tsx
 msgid "登録完了"
@@ -1547,6 +1761,11 @@ msgstr "衣装ケースを追加して、服の収納場所を管理しましょ
 msgid "表示件数"
 msgstr "表示件数"
 
+#: src/components/auth/SignUpForm.tsx
+#: src/components/settings/account/ProfileForm.tsx
+msgid "表示名"
+msgstr "表示名"
+
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
@@ -1563,7 +1782,9 @@ msgstr "要確認のアイテム（{0}件）"
 msgid "言語"
 msgstr "言語"
 
+#: src/app/settings/layout.tsx
 #: src/components/auth/UserMenu.tsx
+#: src/components/settings/SettingsTabs.tsx
 msgid "設定"
 msgstr "設定"
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1050,8 +1050,13 @@ msgid "リセット"
 msgstr "リセット"
 
 #: src/components/auth/UserMenu.tsx
+#: src/components/auth/UserMenu.tsx
 msgid "ログアウト"
 msgstr "ログアウト"
+
+#: src/components/auth/UserMenu.tsx
+msgid "ログアウトしますか？"
+msgstr "ログアウトしますか？"
 
 #: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/UserMenu.tsx
@@ -1229,6 +1234,10 @@ msgstr "全ドール"
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
 msgstr "全部ある"
+
+#: src/components/auth/UserMenu.tsx
+msgid "再びログインするまで、収納場所の確認や服の登録ができなくなります。"
+msgstr "再びログインするまで、収納場所の確認や服の登録ができなくなります。"
 
 #: src/app/dolls/page.tsx
 msgid "最初のドールを登録してみましょう"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -171,7 +171,6 @@ msgstr "8 文字以上。英数字を含めると安全です。"
 msgid "AI"
 msgstr "AI"
 
-#: src/app/settings/api-keys/page.tsx
 #: src/components/settings/SettingsTabs.tsx
 msgid "API キー"
 msgstr "API キー"
@@ -1439,7 +1438,6 @@ msgstr "復元"
 
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
-#: src/app/settings/api-keys/page.tsx
 #: src/app/settings/layout.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -159,11 +159,20 @@ msgstr "\"{0}\"을(를) 완전히 삭제하시겠습니까? 이 작업은 되돌
 msgid "「{0}」を紛失としてマークします。収納場所の情報はクリアされます。"
 msgstr "\"{0}\"을(를) 분실로 표시합니다. 수납 위치 정보는 지워집니다."
 
+#: src/app/signup/page.tsx
+msgid "30 秒で、最初の引き出しを開けられます"
+msgstr "30초 만에 첫 번째 서랍을 열 수 있어요"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "8 文字以上。英数字を含めると安全です。"
+msgstr "8자 이상. 영문과 숫자를 포함하면 안전합니다."
+
 #: src/components/coordinate/OriginBadge.tsx
 msgid "AI"
 msgstr "AI"
 
 #: src/app/settings/api-keys/page.tsx
+#: src/components/settings/SettingsTabs.tsx
 msgid "API キー"
 msgstr "API 키"
 
@@ -241,6 +250,10 @@ msgstr "DDS (~55cm)"
 msgid "Google でログイン"
 msgstr "Google로 로그인"
 
+#: src/components/settings/account/ProfileForm.tsx
+msgid "https://..."
+msgstr "https://..."
+
 #: src/lib/i18n-labels.ts
 msgid "MDD L胸 (~40cm)"
 msgstr "MDD L버스트 (~40cm)"
@@ -256,6 +269,10 @@ msgstr "MDD S버스트 (~40cm)"
 #: src/lib/i18n-labels.ts
 msgid "MSD (~43cm)"
 msgstr "MSD (~43cm)"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "new@example.com"
+msgstr "new@example.com"
 
 #: src/app/nfc-write/page.tsx
 msgid "NFC タグにタッチしてください..."
@@ -339,6 +356,11 @@ msgstr "X (Twitter)로 로그인"
 msgid "YoSD (~26cm)"
 msgstr "YoSD (~26cm)"
 
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+msgid "you@example.com"
+msgstr "you@example.com"
+
 #: src/app/archive/page.tsx
 #: src/components/doll/DollDetail.tsx
 #: src/components/doll/DollDetail.tsx
@@ -374,6 +396,34 @@ msgstr "아카이브가 비어 있습니다"
 #: src/lib/i18n-labels.ts
 msgid "アウター"
 msgstr "아우터"
+
+#: src/components/settings/SettingsTabs.tsx
+msgid "アカウント"
+msgstr "계정"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントの削除に失敗しました"
+msgstr "계정 삭제에 실패했습니다"
+
+#: src/app/signin/page.tsx
+msgid "アカウントをお持ちでない方は <0>新規登録</0>"
+msgstr "계정이 없으신가요? <0>회원가입</0>"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "アカウントを作成できませんでした。メールアドレスがすでに使われている可能性があります。"
+msgstr "계정을 만들 수 없습니다. 이메일이 이미 사용 중일 수 있습니다."
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントを削除"
+msgstr "계정 삭제"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントを削除する"
+msgstr "계정 삭제하기"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "アカウント作成"
+msgstr "계정 만들기"
 
 #: src/lib/i18n-labels.ts
 msgid "アクセサリー"
@@ -460,6 +510,7 @@ msgstr "컬러"
 #: src/components/location/StorageCaseEditForm.tsx
 #: src/components/location/StorageCaseForm.tsx
 #: src/components/location/StorageLocationEditForm.tsx
+#: src/components/settings/account/DeleteAccountSection.tsx
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 #: src/components/ui/ConfirmSheet.tsx
 msgid "キャンセル"
@@ -551,6 +602,10 @@ msgstr "이 장소의 모든 옷을 확인 완료로 표시"
 msgid "この引き出しの他の服、まだありますか？"
 msgstr "이 서랍의 다른 옷들, 아직 있나요?"
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "この操作は取り消せません。確認のため、登録メールアドレスを入力してください。"
+msgstr "이 작업은 취소할 수 없습니다. 확인을 위해 등록된 이메일 주소를 입력하세요."
+
 #: src/components/settings/api-key/ApiKeyRevealSheet.tsx
 msgid "コピー"
 msgstr "복사"
@@ -623,6 +678,10 @@ msgstr "스코프"
 msgid "ステータス"
 msgstr "상태"
 
+#: src/app/signup/page.tsx
+msgid "すでにアカウントをお持ちの方は <0>ログイン</0>"
+msgstr "이미 계정이 있으신가요? <0>로그인</0>"
+
 #: src/app/dolls/page.tsx
 #: src/app/dolls/page.tsx
 #: src/app/garments/page.tsx
@@ -653,8 +712,12 @@ msgid "セット内容"
 msgstr "세트 구성"
 
 #: src/app/signin/page.tsx
-msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
-msgstr "소셜 계정으로 로그인하면 QR/NFC 스캔 기록과 API 키 발급을 비롯한 모든 기능을 이용할 수 있습니다."
+#~ msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+#~ msgstr "소셜 계정으로 로그인하면 QR/NFC 스캔 기록과 API 키 발급을 비롯한 모든 기능을 이용할 수 있습니다."
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "ソーシャルログインで作成されたアカウントです。新しいパスワードを設定すると、メール + パスワードでもログインできるようになります。"
+msgstr "소셜 로그인으로 만들어진 계정입니다. 새 비밀번호를 설정하면 이메일 + 비밀번호로도 로그인할 수 있습니다."
 
 #: src/lib/i18n-labels.ts
 msgid "ソックス/タイツ"
@@ -743,6 +806,10 @@ msgstr "인형 목록"
 msgid "ドール服の名前"
 msgstr "인형 옷 이름"
 
+#: src/app/signin/page.tsx
+msgid "ドール服管理にログイン"
+msgstr "인형 옷 관리에 로그인"
+
 #: src/lib/i18n-labels.ts
 msgid "トップス"
 msgstr "상의"
@@ -758,6 +825,37 @@ msgstr "없음"
 #: src/components/scan/OrphanCheckoutDialog.tsx
 #~ msgid "なくした"
 #~ msgstr "분실함"
+
+#: src/app/settings/account/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワード"
+msgstr "비밀번호"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "パスワード（確認）"
+msgstr "비밀번호 (확인)"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードの設定に失敗しました"
+msgstr "비밀번호 설정에 실패했습니다"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを変更"
+msgstr "비밀번호 변경"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを変更しました"
+msgstr "비밀번호가 변경되었습니다"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを設定"
+msgstr "비밀번호 설정"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを設定しました"
+msgstr "비밀번호가 설정되었습니다"
 
 #: src/lib/i18n-labels.ts
 msgid "ピンク"
@@ -783,6 +881,22 @@ msgstr "브랜드/메이커"
 #: src/components/garment/ImageUpload.tsx
 msgid "プレビュー"
 msgstr "미리보기"
+
+#: src/app/settings/account/page.tsx
+msgid "プロフィール"
+msgstr "프로필"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィールの更新に失敗しました"
+msgstr "프로필 업데이트에 실패했습니다"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィールを更新しました"
+msgstr "프로필을 업데이트했습니다"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィール画像 URL"
+msgstr "프로필 이미지 URL"
 
 #: src/components/ui/Pagination.tsx
 msgid "ページネーション"
@@ -838,6 +952,11 @@ msgstr "아직 코디가 없습니다"
 msgid "まだドールがいません"
 msgstr "아직 인형이 없습니다"
 
+#: src/app/signin/page.tsx
+#: src/app/signup/page.tsx
+msgid "または"
+msgstr "또는"
+
 #: src/components/garment/csv/CsvDropZone.tsx
 msgid "またはクリックしてファイルを選択"
 msgstr "또는 클릭하여 파일 선택"
@@ -866,6 +985,36 @@ msgstr "아직 열지 않았습니다"
 #: src/components/doll/DollForm.tsx
 msgid "メーカー"
 msgstr "메이커"
+
+#: src/app/settings/account/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+msgid "メールアドレス"
+msgstr "이메일 주소"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "メールアドレスが一致しません"
+msgstr "이메일 주소가 일치하지 않습니다"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスの変更に失敗しました"
+msgstr "이메일 변경에 실패했습니다"
+
+#: src/components/auth/EmailPasswordForm.tsx
+msgid "メールアドレスまたはパスワードが正しくありません"
+msgstr "이메일 또는 비밀번호가 올바르지 않습니다"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "メールアドレスを再入力"
+msgstr "이메일 주소 재입력"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスを変更"
+msgstr "이메일 변경"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスを変更しました"
+msgstr "이메일이 변경되었습니다"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/components/coordinate/CoordinateBuilder.tsx
@@ -905,10 +1054,18 @@ msgstr "초기화"
 msgid "ログアウト"
 msgstr "로그아웃"
 
-#: src/app/signin/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/UserMenu.tsx
 msgid "ログイン"
 msgstr "로그인"
+
+#: src/app/settings/account/page.tsx
+msgid "ログインに使うメールアドレスです。"
+msgstr "로그인에 사용하는 이메일 주소입니다."
+
+#: src/components/auth/EmailPasswordForm.tsx
+msgid "ログイン中…"
+msgstr "로그인 중…"
 
 #: src/app/garments/page.tsx
 #: src/lib/nav-items.ts
@@ -982,6 +1139,10 @@ msgstr "정렬"
 msgid "今ここにいなくても確認"
 msgstr "지금 여기 없어도 확인"
 
+#: src/app/settings/account/page.tsx
+msgid "他のユーザーや UI に表示されます。"
+msgstr "다른 사용자나 UI에 표시됩니다."
+
 #: src/components/location/StorageCaseForm.tsx
 msgid "作成"
 msgstr "생성"
@@ -1001,6 +1162,10 @@ msgstr "사용 중"
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "例: agent-1"
 msgstr "예: agent-1"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "例: ドリーラー"
+msgstr "예: 돌러"
 
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "例: ワンピース用"
@@ -1214,6 +1379,10 @@ msgstr "장소가 설정되었습니다"
 msgid "変更"
 msgstr "변경"
 
+#: src/components/settings/account/ProfileForm.tsx
+msgid "変更を保存"
+msgstr "변경 사항 저장"
+
 #: src/app/settings/api-keys/page.tsx
 msgid "外部 AI エージェントから接続するための Personal Access Token を発行・管理します。"
 msgstr "외부 AI 에이전트에서 연결하기 위한 Personal Access Token을 발급·관리합니다."
@@ -1239,8 +1408,13 @@ msgstr "완료"
 #: src/components/doll/DollDetail.tsx
 #: src/components/garment/GarmentDetail.tsx
 #: src/components/garment/GarmentDetail.tsx
+#: src/components/settings/account/DeleteAccountSection.tsx
 msgid "完全に削除"
 msgstr "영구 삭제"
+
+#: src/app/settings/account/page.tsx
+msgid "定期的な更新を推奨します。"
+msgstr "정기적인 업데이트를 권장합니다."
 
 #: src/lib/i18n-labels.ts
 msgid "帽子/ヘッドドレス"
@@ -1249,6 +1423,10 @@ msgstr "모자/헤드드레스"
 #: src/components/location/StorageCaseForm.tsx
 msgid "引き出し"
 msgstr "서랍"
+
+#: src/app/signin/page.tsx
+msgid "引き出しの中身を、いつでもどこでも"
+msgstr "서랍 속을 언제 어디서나"
 
 #: src/components/location/StorageGrid.tsx
 msgid "引き出しを編集"
@@ -1262,7 +1440,7 @@ msgstr "복원"
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
 #: src/app/settings/api-keys/page.tsx
-#: src/app/signin/page.tsx
+#: src/app/settings/layout.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
@@ -1281,6 +1459,22 @@ msgstr "새 API 키"
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "新しい API キーを発行"
 msgstr "새 API 키 발급"
+
+#: src/app/signup/page.tsx
+msgid "新しいアカウントを作る"
+msgstr "새 계정 만들기"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "新しいパスワード"
+msgstr "새 비밀번호"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "新しいパスワード（確認）"
+msgstr "새 비밀번호 (확인)"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "新しいメールアドレス"
+msgstr "새 이메일 주소"
 
 #: src/components/digest/DigestBanner.tsx
 msgid "新しい週間レポートが届いています"
@@ -1385,6 +1579,10 @@ msgstr "미배치"
 msgid "未配置にする"
 msgstr "미배치로 설정"
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "本当に削除しますか？"
+msgstr "정말 삭제하시겠습니까?"
+
 #: src/components/digest/DigestCard.tsx
 msgid "次に引き出しを開けたときに自動で確認されます"
 msgstr "다음에 서랍을 열 때 자동으로 확인됩니다"
@@ -1409,6 +1607,14 @@ msgstr "매주 월요일에 자동 생성됩니다"
 msgid "状態"
 msgstr "상태"
 
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "現在のパスワード"
+msgstr "현재 비밀번호"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "現在のパスワードが正しくないか、更新に失敗しました"
+msgstr "현재 비밀번호가 올바르지 않거나 업데이트에 실패했습니다"
+
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "生キーは発行直後の一度しか表示されません。安全な場所に保管してください。"
 msgstr "원본 키는 발급 직후 한 번만 표시됩니다. 안전한 곳에 보관해 주세요."
@@ -1427,10 +1633,18 @@ msgstr "발급"
 msgid "登録された服がありません"
 msgstr "등록된 옷이 없습니다."
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "登録した服・収納場所・コーデ・ドールはすべて削除され、復元できません。"
+msgstr "등록한 옷·보관 장소·코디·인형은 모두 삭제되며 복구할 수 없습니다."
+
 #: src/components/doll/DollForm.tsx
 #: src/components/garment/GarmentForm.tsx
 msgid "登録する"
 msgstr "등록"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "登録中…"
+msgstr "등록 중…"
 
 #: src/components/garment/bulk/BulkRegistrationProgress.tsx
 msgid "登録完了"
@@ -1547,6 +1761,11 @@ msgstr "의상 케이스를 추가하여 옷의 수납 장소를 관리하세요
 msgid "表示件数"
 msgstr "표시 건수"
 
+#: src/components/auth/SignUpForm.tsx
+#: src/components/settings/account/ProfileForm.tsx
+msgid "表示名"
+msgstr "표시 이름"
+
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
@@ -1563,7 +1782,9 @@ msgstr "확인 필요 아이템 ({0}건)"
 msgid "言語"
 msgstr "언어"
 
+#: src/app/settings/layout.tsx
 #: src/components/auth/UserMenu.tsx
+#: src/components/settings/SettingsTabs.tsx
 msgid "設定"
 msgstr "설정"
 

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -171,7 +171,6 @@ msgstr "8자 이상. 영문과 숫자를 포함하면 안전합니다."
 msgid "AI"
 msgstr "AI"
 
-#: src/app/settings/api-keys/page.tsx
 #: src/components/settings/SettingsTabs.tsx
 msgid "API キー"
 msgstr "API 키"
@@ -1439,7 +1438,6 @@ msgstr "복원"
 
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
-#: src/app/settings/api-keys/page.tsx
 #: src/app/settings/layout.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -1050,8 +1050,13 @@ msgid "リセット"
 msgstr "초기화"
 
 #: src/components/auth/UserMenu.tsx
+#: src/components/auth/UserMenu.tsx
 msgid "ログアウト"
 msgstr "로그아웃"
+
+#: src/components/auth/UserMenu.tsx
+msgid "ログアウトしますか？"
+msgstr "로그아웃하시겠습니까?"
 
 #: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/UserMenu.tsx
@@ -1229,6 +1234,10 @@ msgstr "모든 인형"
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
 msgstr "전부 있음"
+
+#: src/components/auth/UserMenu.tsx
+msgid "再びログインするまで、収納場所の確認や服の登録ができなくなります。"
+msgstr "다시 로그인할 때까지 보관 장소 확인이나 옷 등록을 할 수 없습니다."
 
 #: src/app/dolls/page.tsx
 msgid "最初のドールを登録してみましょう"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -159,11 +159,20 @@ msgstr "确定永久删除\"{0}\"吗？此操作无法撤销。"
 msgid "「{0}」を紛失としてマークします。収納場所の情報はクリアされます。"
 msgstr "将「{0}」标记为丢失。收纳位置信息将被清除。"
 
+#: src/app/signup/page.tsx
+msgid "30 秒で、最初の引き出しを開けられます"
+msgstr "30 秒内打开第一个抽屉"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "8 文字以上。英数字を含めると安全です。"
+msgstr "至少 8 个字符。包含字母和数字更安全。"
+
 #: src/components/coordinate/OriginBadge.tsx
 msgid "AI"
 msgstr "AI"
 
 #: src/app/settings/api-keys/page.tsx
+#: src/components/settings/SettingsTabs.tsx
 msgid "API キー"
 msgstr "API 密钥"
 
@@ -241,6 +250,10 @@ msgstr "DDS (~55cm)"
 msgid "Google でログイン"
 msgstr "使用Google登录"
 
+#: src/components/settings/account/ProfileForm.tsx
+msgid "https://..."
+msgstr "https://..."
+
 #: src/lib/i18n-labels.ts
 msgid "MDD L胸 (~40cm)"
 msgstr "MDD L胸 (~40cm)"
@@ -256,6 +269,10 @@ msgstr "MDD S胸 (~40cm)"
 #: src/lib/i18n-labels.ts
 msgid "MSD (~43cm)"
 msgstr "MSD (~43cm)"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "new@example.com"
+msgstr "new@example.com"
 
 #: src/app/nfc-write/page.tsx
 msgid "NFC タグにタッチしてください..."
@@ -339,6 +356,11 @@ msgstr "使用X (Twitter)登录"
 msgid "YoSD (~26cm)"
 msgstr "YoSD (~26cm)"
 
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+msgid "you@example.com"
+msgstr "you@example.com"
+
 #: src/app/archive/page.tsx
 #: src/components/doll/DollDetail.tsx
 #: src/components/doll/DollDetail.tsx
@@ -374,6 +396,34 @@ msgstr "归档为空"
 #: src/lib/i18n-labels.ts
 msgid "アウター"
 msgstr "外套"
+
+#: src/components/settings/SettingsTabs.tsx
+msgid "アカウント"
+msgstr "账户"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントの削除に失敗しました"
+msgstr "删除账户失败"
+
+#: src/app/signin/page.tsx
+msgid "アカウントをお持ちでない方は <0>新規登録</0>"
+msgstr "还没有账户？<0>注册</0>"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "アカウントを作成できませんでした。メールアドレスがすでに使われている可能性があります。"
+msgstr "无法创建账户。该邮箱可能已被使用。"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントを削除"
+msgstr "删除账户"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "アカウントを削除する"
+msgstr "删除我的账户"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "アカウント作成"
+msgstr "创建账户"
 
 #: src/lib/i18n-labels.ts
 msgid "アクセサリー"
@@ -460,6 +510,7 @@ msgstr "颜色"
 #: src/components/location/StorageCaseEditForm.tsx
 #: src/components/location/StorageCaseForm.tsx
 #: src/components/location/StorageLocationEditForm.tsx
+#: src/components/settings/account/DeleteAccountSection.tsx
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 #: src/components/ui/ConfirmSheet.tsx
 msgid "キャンセル"
@@ -551,6 +602,10 @@ msgstr "将此位置的所有衣服标记为已确认"
 msgid "この引き出しの他の服、まだありますか？"
 msgstr "这个抽屉里的其他衣服都还在吗？"
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "この操作は取り消せません。確認のため、登録メールアドレスを入力してください。"
+msgstr "此操作无法撤销。为了确认，请输入注册的邮箱地址。"
+
 #: src/components/settings/api-key/ApiKeyRevealSheet.tsx
 msgid "コピー"
 msgstr "复制"
@@ -623,6 +678,10 @@ msgstr "范围"
 msgid "ステータス"
 msgstr "状态"
 
+#: src/app/signup/page.tsx
+msgid "すでにアカウントをお持ちの方は <0>ログイン</0>"
+msgstr "已有账户？<0>登录</0>"
+
 #: src/app/dolls/page.tsx
 #: src/app/dolls/page.tsx
 #: src/app/garments/page.tsx
@@ -653,8 +712,12 @@ msgid "セット内容"
 msgstr "套装内容"
 
 #: src/app/signin/page.tsx
-msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
-msgstr "使用社交账号登录后，即可使用 QR/NFC 扫描记录和 API 密钥发行等全部功能。"
+#~ msgid "ソーシャルアカウントでログインすると、QR/NFC スキャンの記録や API キーの発行など、すべての機能を利用できます。"
+#~ msgstr "使用社交账号登录后，即可使用 QR/NFC 扫描记录和 API 密钥发行等全部功能。"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "ソーシャルログインで作成されたアカウントです。新しいパスワードを設定すると、メール + パスワードでもログインできるようになります。"
+msgstr "此账户是通过社交登录创建的。设置新密码后，也可以使用邮箱 + 密码登录。"
 
 #: src/lib/i18n-labels.ts
 msgid "ソックス/タイツ"
@@ -743,6 +806,10 @@ msgstr "娃娃列表"
 msgid "ドール服の名前"
 msgstr "娃衣名称"
 
+#: src/app/signin/page.tsx
+msgid "ドール服管理にログイン"
+msgstr "登录人偶衣物管理"
+
 #: src/lib/i18n-labels.ts
 msgid "トップス"
 msgstr "上衣"
@@ -758,6 +825,37 @@ msgstr "不在"
 #: src/components/scan/OrphanCheckoutDialog.tsx
 #~ msgid "なくした"
 #~ msgstr "丢失了"
+
+#: src/app/settings/account/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワード"
+msgstr "密码"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "パスワード（確認）"
+msgstr "密码（确认）"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードの設定に失敗しました"
+msgstr "设置密码失败"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを変更"
+msgstr "修改密码"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを変更しました"
+msgstr "密码已修改"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを設定"
+msgstr "设置密码"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "パスワードを設定しました"
+msgstr "密码已设置"
 
 #: src/lib/i18n-labels.ts
 msgid "ピンク"
@@ -783,6 +881,22 @@ msgstr "品牌/厂商"
 #: src/components/garment/ImageUpload.tsx
 msgid "プレビュー"
 msgstr "预览"
+
+#: src/app/settings/account/page.tsx
+msgid "プロフィール"
+msgstr "个人资料"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィールの更新に失敗しました"
+msgstr "更新个人资料失败"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィールを更新しました"
+msgstr "已更新个人资料"
+
+#: src/components/settings/account/ProfileForm.tsx
+msgid "プロフィール画像 URL"
+msgstr "个人资料图片 URL"
 
 #: src/components/ui/Pagination.tsx
 msgid "ページネーション"
@@ -838,6 +952,11 @@ msgstr "还没有搭配"
 msgid "まだドールがいません"
 msgstr "还没有娃娃"
 
+#: src/app/signin/page.tsx
+#: src/app/signup/page.tsx
+msgid "または"
+msgstr "或"
+
 #: src/components/garment/csv/CsvDropZone.tsx
 msgid "またはクリックしてファイルを選択"
 msgstr "或点击选择文件"
@@ -866,6 +985,36 @@ msgstr "尚未打开"
 #: src/components/doll/DollForm.tsx
 msgid "メーカー"
 msgstr "厂商"
+
+#: src/app/settings/account/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
+#: src/components/auth/SignUpForm.tsx
+msgid "メールアドレス"
+msgstr "邮箱地址"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "メールアドレスが一致しません"
+msgstr "邮箱地址不匹配"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスの変更に失敗しました"
+msgstr "修改邮箱失败"
+
+#: src/components/auth/EmailPasswordForm.tsx
+msgid "メールアドレスまたはパスワードが正しくありません"
+msgstr "邮箱或密码不正确"
+
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "メールアドレスを再入力"
+msgstr "重新输入邮箱地址"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスを変更"
+msgstr "修改邮箱"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "メールアドレスを変更しました"
+msgstr "邮箱已修改"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/components/coordinate/CoordinateBuilder.tsx
@@ -905,10 +1054,18 @@ msgstr "重置"
 msgid "ログアウト"
 msgstr "退出登录"
 
-#: src/app/signin/page.tsx
+#: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/UserMenu.tsx
 msgid "ログイン"
 msgstr "登录"
+
+#: src/app/settings/account/page.tsx
+msgid "ログインに使うメールアドレスです。"
+msgstr "用于登录的邮箱地址。"
+
+#: src/components/auth/EmailPasswordForm.tsx
+msgid "ログイン中…"
+msgstr "登录中…"
 
 #: src/app/garments/page.tsx
 #: src/lib/nav-items.ts
@@ -982,6 +1139,10 @@ msgstr "排序"
 msgid "今ここにいなくても確認"
 msgstr "不在现场也可确认"
 
+#: src/app/settings/account/page.tsx
+msgid "他のユーザーや UI に表示されます。"
+msgstr "将显示给其他用户和在 UI 中。"
+
 #: src/components/location/StorageCaseForm.tsx
 msgid "作成"
 msgstr "创建"
@@ -1001,6 +1162,10 @@ msgstr "使用中"
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "例: agent-1"
 msgstr "例如: agent-1"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "例: ドリーラー"
+msgstr "例：玩偶师"
 
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "例: ワンピース用"
@@ -1214,6 +1379,10 @@ msgstr "位置已设置"
 msgid "変更"
 msgstr "更改"
 
+#: src/components/settings/account/ProfileForm.tsx
+msgid "変更を保存"
+msgstr "保存更改"
+
 #: src/app/settings/api-keys/page.tsx
 msgid "外部 AI エージェントから接続するための Personal Access Token を発行・管理します。"
 msgstr "为外部 AI 代理连接签发和管理 Personal Access Token。"
@@ -1239,8 +1408,13 @@ msgstr "完成"
 #: src/components/doll/DollDetail.tsx
 #: src/components/garment/GarmentDetail.tsx
 #: src/components/garment/GarmentDetail.tsx
+#: src/components/settings/account/DeleteAccountSection.tsx
 msgid "完全に削除"
 msgstr "永久删除"
+
+#: src/app/settings/account/page.tsx
+msgid "定期的な更新を推奨します。"
+msgstr "建议定期更新。"
 
 #: src/lib/i18n-labels.ts
 msgid "帽子/ヘッドドレス"
@@ -1249,6 +1423,10 @@ msgstr "帽子/头饰"
 #: src/components/location/StorageCaseForm.tsx
 msgid "引き出し"
 msgstr "抽屉"
+
+#: src/app/signin/page.tsx
+msgid "引き出しの中身を、いつでもどこでも"
+msgstr "随时随地查看抽屉里的物品"
 
 #: src/components/location/StorageGrid.tsx
 msgid "引き出しを編集"
@@ -1262,7 +1440,7 @@ msgstr "恢复"
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
 #: src/app/settings/api-keys/page.tsx
-#: src/app/signin/page.tsx
+#: src/app/settings/layout.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
@@ -1281,6 +1459,22 @@ msgstr "新建 API 密钥"
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "新しい API キーを発行"
 msgstr "签发新的 API 密钥"
+
+#: src/app/signup/page.tsx
+msgid "新しいアカウントを作る"
+msgstr "创建新账户"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "新しいパスワード"
+msgstr "新密码"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "新しいパスワード（確認）"
+msgstr "新密码（确认）"
+
+#: src/components/settings/account/EmailChangeForm.tsx
+msgid "新しいメールアドレス"
+msgstr "新邮箱地址"
 
 #: src/components/digest/DigestBanner.tsx
 msgid "新しい週間レポートが届いています"
@@ -1385,6 +1579,10 @@ msgstr "未分配"
 msgid "未配置にする"
 msgstr "取消分配"
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "本当に削除しますか？"
+msgstr "确定要删除吗？"
+
 #: src/components/digest/DigestCard.tsx
 msgid "次に引き出しを開けたときに自動で確認されます"
 msgstr "下次打开抽屉时将自动确认"
@@ -1409,6 +1607,14 @@ msgstr "每周一自动生成"
 msgid "状態"
 msgstr "状态"
 
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "現在のパスワード"
+msgstr "当前密码"
+
+#: src/components/settings/account/PasswordChangeForm.tsx
+msgid "現在のパスワードが正しくないか、更新に失敗しました"
+msgstr "当前密码不正确，或更新失败"
+
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "生キーは発行直後の一度しか表示されません。安全な場所に保管してください。"
 msgstr "原始密钥仅在签发后显示一次。请妥善保管。"
@@ -1427,10 +1633,18 @@ msgstr "签发"
 msgid "登録された服がありません"
 msgstr "还没有登记的衣服。"
 
+#: src/components/settings/account/DeleteAccountSection.tsx
+msgid "登録した服・収納場所・コーデ・ドールはすべて削除され、復元できません。"
+msgstr "已注册的衣物、收纳位置、搭配和人偶都将被删除，无法恢复。"
+
 #: src/components/doll/DollForm.tsx
 #: src/components/garment/GarmentForm.tsx
 msgid "登録する"
 msgstr "登记"
+
+#: src/components/auth/SignUpForm.tsx
+msgid "登録中…"
+msgstr "注册中…"
 
 #: src/components/garment/bulk/BulkRegistrationProgress.tsx
 msgid "登録完了"
@@ -1547,6 +1761,11 @@ msgstr "添加收纳箱来管理衣服的存放位置"
 msgid "表示件数"
 msgstr "每页显示数"
 
+#: src/components/auth/SignUpForm.tsx
+#: src/components/settings/account/ProfileForm.tsx
+msgid "表示名"
+msgstr "显示名称"
+
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/components/digest/DigestCard.tsx
 #: src/lib/i18n-labels.ts
@@ -1563,7 +1782,9 @@ msgstr "待确认的物品（{0}件）"
 msgid "言語"
 msgstr "语言"
 
+#: src/app/settings/layout.tsx
 #: src/components/auth/UserMenu.tsx
+#: src/components/settings/SettingsTabs.tsx
 msgid "設定"
 msgstr "设置"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1050,8 +1050,13 @@ msgid "リセット"
 msgstr "重置"
 
 #: src/components/auth/UserMenu.tsx
+#: src/components/auth/UserMenu.tsx
 msgid "ログアウト"
 msgstr "退出登录"
+
+#: src/components/auth/UserMenu.tsx
+msgid "ログアウトしますか？"
+msgstr "要退出登录吗？"
 
 #: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/UserMenu.tsx
@@ -1229,6 +1234,10 @@ msgstr "所有娃娃"
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
 msgstr "全部都在"
+
+#: src/components/auth/UserMenu.tsx
+msgid "再びログインするまで、収納場所の確認や服の登録ができなくなります。"
+msgstr "在再次登录之前，无法查看收纳位置或注册衣物。"
 
 #: src/app/dolls/page.tsx
 msgid "最初のドールを登録してみましょう"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -171,7 +171,6 @@ msgstr "至少 8 个字符。包含字母和数字更安全。"
 msgid "AI"
 msgstr "AI"
 
-#: src/app/settings/api-keys/page.tsx
 #: src/components/settings/SettingsTabs.tsx
 msgid "API キー"
 msgstr "API 密钥"
@@ -1439,7 +1438,6 @@ msgstr "恢复"
 
 #: src/app/nfc-write/page.tsx
 #: src/app/nfc-write/page.tsx
-#: src/app/settings/api-keys/page.tsx
 #: src/app/settings/layout.tsx
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx

--- a/src/stores/accountsAtoms.ts
+++ b/src/stores/accountsAtoms.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { atom } from "jotai";
+import { unwrap } from "jotai/utils";
+import { listAccounts, type LinkedAccount } from "@/lib/auth";
+import { authSessionAtom } from "@/stores/authAtoms";
+
+const CREDENTIAL_PROVIDER_ID = "credential";
+
+const accountsAtom = atom(async (get): Promise<readonly LinkedAccount[]> => {
+  const session = await get(authSessionAtom);
+  return session.isAuthenticated ? await listAccounts().catch(() => []) : [];
+});
+
+export const accountsUnwrappedAtom = unwrap(
+  accountsAtom,
+  (prev): readonly LinkedAccount[] => prev ?? [],
+);
+
+export const hasPasswordAtom = atom((get) => {
+  const accounts = get(accountsUnwrappedAtom);
+  return accounts.some((a) => a.providerId === CREDENTIAL_PROVIDER_ID);
+});

--- a/src/stores/accountsAtoms.ts
+++ b/src/stores/accountsAtoms.ts
@@ -18,9 +18,12 @@ const accountsAtom = atom(async (get): Promise<AccountsState> => {
     : [];
 });
 
+// 初回ロード中 (prev 未確定) も "error" 扱いにすることで fail-closed を効かせる。
+// [] フォールバックにすると credential ありユーザーがロード完了前に setPassword
+// 分岐へ流れて誤送信する race を防ぐ。
 export const accountsUnwrappedAtom = unwrap(
   accountsAtom,
-  (prev): AccountsState => prev ?? [],
+  (prev): AccountsState => prev ?? "error",
 );
 
 export const hasPasswordAtom = atom((get) => {

--- a/src/stores/accountsAtoms.ts
+++ b/src/stores/accountsAtoms.ts
@@ -7,17 +7,29 @@ import { authSessionAtom } from "@/stores/authAtoms";
 
 const CREDENTIAL_PROVIDER_ID = "credential";
 
-const accountsAtom = atom(async (get): Promise<readonly LinkedAccount[]> => {
+// 取得失敗を「credential 無し」と誤認させないため、エラーは "error" sentinel で
+// 表現する。fail-closed (= credential あり扱い) で hasPasswordAtom が解決する。
+type AccountsState = readonly LinkedAccount[] | "error";
+
+const accountsAtom = atom(async (get): Promise<AccountsState> => {
   const session = await get(authSessionAtom);
-  return session.isAuthenticated ? await listAccounts().catch(() => []) : [];
+  return session.isAuthenticated
+    ? await listAccounts().catch((): "error" => "error")
+    : [];
 });
 
 export const accountsUnwrappedAtom = unwrap(
   accountsAtom,
-  (prev): readonly LinkedAccount[] => prev ?? [],
+  (prev): AccountsState => prev ?? [],
 );
 
 export const hasPasswordAtom = atom((get) => {
   const accounts = get(accountsUnwrappedAtom);
-  return accounts.some((a) => a.providerId === CREDENTIAL_PROVIDER_ID);
+  // 取得失敗時は credential 保有として扱い、credential ありユーザーが
+  // 誤って setPassword 分岐に入って詰まないようにする。OAuth-only
+  // ユーザーは listAccounts が成功するまで「現在のパスワード」入力が
+  // 出るが、ロード完了後に正しいモードへ切り替わる。
+  return accounts === "error"
+    ? true
+    : accounts.some((a) => a.providerId === CREDENTIAL_PROVIDER_ID);
 });

--- a/src/stores/authAtoms.ts
+++ b/src/stores/authAtoms.ts
@@ -52,6 +52,10 @@ export const signOutAtom = atom(undefined, async (_get, set) => {
   set(authRefreshTriggerAtom, (prev) => prev + 1);
 });
 
-export const refreshAuthAtom = atom(undefined, (_get, set) => {
+// trigger を増やしただけでは authSessionAtom が再解決する前にナビゲートが走り、
+// unwrap が prev (古い認証済み状態) を返してしまう。await get で新しい session が
+// 解決するまで待つことで、退会後に /signin で stale auth が見える race を防ぐ。
+export const refreshAuthAtom = atom(undefined, async (get, set) => {
   set(authRefreshTriggerAtom, (prev) => prev + 1);
+  await get(authSessionAtom);
 });

--- a/src/test/mocks/modules/authClient.ts
+++ b/src/test/mocks/modules/authClient.ts
@@ -6,6 +6,7 @@ import type {
   ChangePasswordInput,
   CreatedApiKey,
   DeleteAccountInput,
+  LinkedAccount,
   SignInEmailInput,
   UpdateProfileInput,
 } from "@/lib/auth";
@@ -20,11 +21,13 @@ type Spies = {
   readonly changeEmail: ReturnType<typeof vi.fn>;
   readonly changePassword: ReturnType<typeof vi.fn>;
   readonly deleteAccount: ReturnType<typeof vi.fn>;
+  readonly listAccounts: ReturnType<typeof vi.fn>;
 };
 
 type State = {
   readonly apiKeys: readonly ApiKeySummary[];
   readonly nextCreated: CreatedApiKey | undefined;
+  readonly accounts: readonly LinkedAccount[];
   readonly createShouldFail: boolean;
   readonly listShouldFail: boolean;
   readonly revokeShouldFail: boolean;
@@ -40,6 +43,7 @@ type State = {
 const createInitial = (): State => ({
   apiKeys: [],
   nextCreated: undefined,
+  accounts: [{ providerId: "credential" }],
   createShouldFail: false,
   listShouldFail: false,
   revokeShouldFail: false,
@@ -59,6 +63,7 @@ const createInitial = (): State => ({
     changeEmail: vi.fn(),
     changePassword: vi.fn(),
     deleteAccount: vi.fn(),
+    listAccounts: vi.fn(),
   },
 });
 
@@ -161,12 +166,18 @@ export const authClientFactory = async () => {
         await Promise.reject(new Error("Failed to delete account"));
       }
     },
+    listAccounts: async (): Promise<readonly LinkedAccount[]> => {
+      const s = getState();
+      s.spies.listAccounts();
+      return await Promise.resolve(s.accounts);
+    },
   };
 };
 
 type SetupOverrides = {
   readonly apiKeys?: readonly ApiKeySummary[];
   readonly nextCreated?: CreatedApiKey;
+  readonly accounts?: readonly LinkedAccount[];
   readonly createShouldFail?: boolean;
   readonly listShouldFail?: boolean;
   readonly revokeShouldFail?: boolean;
@@ -189,10 +200,12 @@ export const setupAuthClient = (overrides: SetupOverrides = {}) => {
   current.spies.changeEmail.mockClear();
   current.spies.changePassword.mockClear();
   current.spies.deleteAccount.mockClear();
+  current.spies.listAccounts.mockClear();
 
   setState({
     apiKeys: overrides.apiKeys ?? [],
     nextCreated: overrides.nextCreated,
+    accounts: overrides.accounts ?? [{ providerId: "credential" }],
     createShouldFail: overrides.createShouldFail ?? false,
     listShouldFail: overrides.listShouldFail ?? false,
     revokeShouldFail: overrides.revokeShouldFail ?? false,

--- a/src/test/mocks/modules/authClient.ts
+++ b/src/test/mocks/modules/authClient.ts
@@ -1,10 +1,25 @@
 import { vi } from "vitest";
-import type { ApiKeyScope, ApiKeySummary, CreatedApiKey } from "@/lib/auth";
+import type {
+  ApiKeyScope,
+  ApiKeySummary,
+  ChangeEmailInput,
+  ChangePasswordInput,
+  CreatedApiKey,
+  DeleteAccountInput,
+  SignInEmailInput,
+  UpdateProfileInput,
+} from "@/lib/auth";
 
 type Spies = {
   readonly createApiKey: ReturnType<typeof vi.fn>;
   readonly listApiKeys: ReturnType<typeof vi.fn>;
   readonly revokeApiKey: ReturnType<typeof vi.fn>;
+  readonly signInWithEmail: ReturnType<typeof vi.fn>;
+  readonly signUpWithEmail: ReturnType<typeof vi.fn>;
+  readonly updateProfile: ReturnType<typeof vi.fn>;
+  readonly changeEmail: ReturnType<typeof vi.fn>;
+  readonly changePassword: ReturnType<typeof vi.fn>;
+  readonly deleteAccount: ReturnType<typeof vi.fn>;
 };
 
 type State = {
@@ -13,6 +28,12 @@ type State = {
   readonly createShouldFail: boolean;
   readonly listShouldFail: boolean;
   readonly revokeShouldFail: boolean;
+  readonly signInShouldFail: boolean;
+  readonly signUpShouldFail: boolean;
+  readonly updateProfileShouldFail: boolean;
+  readonly changeEmailShouldFail: boolean;
+  readonly changePasswordShouldFail: boolean;
+  readonly deleteAccountShouldFail: boolean;
   readonly spies: Spies;
 };
 
@@ -22,10 +43,22 @@ const createInitial = (): State => ({
   createShouldFail: false,
   listShouldFail: false,
   revokeShouldFail: false,
+  signInShouldFail: false,
+  signUpShouldFail: false,
+  updateProfileShouldFail: false,
+  changeEmailShouldFail: false,
+  changePasswordShouldFail: false,
+  deleteAccountShouldFail: false,
   spies: {
     createApiKey: vi.fn(),
     listApiKeys: vi.fn(),
     revokeApiKey: vi.fn(),
+    signInWithEmail: vi.fn(),
+    signUpWithEmail: vi.fn(),
+    updateProfile: vi.fn(),
+    changeEmail: vi.fn(),
+    changePassword: vi.fn(),
+    deleteAccount: vi.fn(),
   },
 });
 
@@ -82,6 +115,52 @@ export const authClientFactory = async () => {
         apiKeys: s.apiKeys.filter((k) => k.id !== keyId),
       });
     },
+    signInWithEmail: async (input: SignInEmailInput): Promise<void> => {
+      const s = getState();
+      s.spies.signInWithEmail(input);
+      if (s.signInShouldFail) {
+        await Promise.reject(new Error("Failed to sign in"));
+      }
+    },
+    signUpWithEmail: async (input: {
+      readonly name: string;
+      readonly email: string;
+      readonly password: string;
+    }): Promise<void> => {
+      const s = getState();
+      s.spies.signUpWithEmail(input);
+      if (s.signUpShouldFail) {
+        await Promise.reject(new Error("Failed to sign up"));
+      }
+    },
+    updateProfile: async (input: UpdateProfileInput): Promise<void> => {
+      const s = getState();
+      s.spies.updateProfile(input);
+      if (s.updateProfileShouldFail) {
+        await Promise.reject(new Error("Failed to update profile"));
+      }
+    },
+    changeEmail: async (input: ChangeEmailInput): Promise<void> => {
+      const s = getState();
+      s.spies.changeEmail(input);
+      if (s.changeEmailShouldFail) {
+        await Promise.reject(new Error("Failed to change email"));
+      }
+    },
+    changePassword: async (input: ChangePasswordInput): Promise<void> => {
+      const s = getState();
+      s.spies.changePassword(input);
+      if (s.changePasswordShouldFail) {
+        await Promise.reject(new Error("Failed to change password"));
+      }
+    },
+    deleteAccount: async (input: DeleteAccountInput): Promise<void> => {
+      const s = getState();
+      s.spies.deleteAccount(input);
+      if (s.deleteAccountShouldFail) {
+        await Promise.reject(new Error("Failed to delete account"));
+      }
+    },
   };
 };
 
@@ -91,6 +170,12 @@ type SetupOverrides = {
   readonly createShouldFail?: boolean;
   readonly listShouldFail?: boolean;
   readonly revokeShouldFail?: boolean;
+  readonly signInShouldFail?: boolean;
+  readonly signUpShouldFail?: boolean;
+  readonly updateProfileShouldFail?: boolean;
+  readonly changeEmailShouldFail?: boolean;
+  readonly changePasswordShouldFail?: boolean;
+  readonly deleteAccountShouldFail?: boolean;
 };
 
 export const setupAuthClient = (overrides: SetupOverrides = {}) => {
@@ -98,6 +183,12 @@ export const setupAuthClient = (overrides: SetupOverrides = {}) => {
   current.spies.createApiKey.mockClear();
   current.spies.listApiKeys.mockClear();
   current.spies.revokeApiKey.mockClear();
+  current.spies.signInWithEmail.mockClear();
+  current.spies.signUpWithEmail.mockClear();
+  current.spies.updateProfile.mockClear();
+  current.spies.changeEmail.mockClear();
+  current.spies.changePassword.mockClear();
+  current.spies.deleteAccount.mockClear();
 
   setState({
     apiKeys: overrides.apiKeys ?? [],
@@ -105,6 +196,12 @@ export const setupAuthClient = (overrides: SetupOverrides = {}) => {
     createShouldFail: overrides.createShouldFail ?? false,
     listShouldFail: overrides.listShouldFail ?? false,
     revokeShouldFail: overrides.revokeShouldFail ?? false,
+    signInShouldFail: overrides.signInShouldFail ?? false,
+    signUpShouldFail: overrides.signUpShouldFail ?? false,
+    updateProfileShouldFail: overrides.updateProfileShouldFail ?? false,
+    changeEmailShouldFail: overrides.changeEmailShouldFail ?? false,
+    changePasswordShouldFail: overrides.changePasswordShouldFail ?? false,
+    deleteAccountShouldFail: overrides.deleteAccountShouldFail ?? false,
     spies: current.spies,
   });
 

--- a/src/test/mocks/modules/authClient.ts
+++ b/src/test/mocks/modules/authClient.ts
@@ -7,6 +7,7 @@ import type {
   CreatedApiKey,
   DeleteAccountInput,
   LinkedAccount,
+  SetPasswordInput,
   SignInEmailInput,
   UpdateProfileInput,
 } from "@/lib/auth";
@@ -20,6 +21,7 @@ type Spies = {
   readonly updateProfile: ReturnType<typeof vi.fn>;
   readonly changeEmail: ReturnType<typeof vi.fn>;
   readonly changePassword: ReturnType<typeof vi.fn>;
+  readonly setPassword: ReturnType<typeof vi.fn>;
   readonly deleteAccount: ReturnType<typeof vi.fn>;
   readonly listAccounts: ReturnType<typeof vi.fn>;
 };
@@ -36,6 +38,7 @@ type State = {
   readonly updateProfileShouldFail: boolean;
   readonly changeEmailShouldFail: boolean;
   readonly changePasswordShouldFail: boolean;
+  readonly setPasswordShouldFail: boolean;
   readonly deleteAccountShouldFail: boolean;
   readonly spies: Spies;
 };
@@ -52,6 +55,7 @@ const createInitial = (): State => ({
   updateProfileShouldFail: false,
   changeEmailShouldFail: false,
   changePasswordShouldFail: false,
+  setPasswordShouldFail: false,
   deleteAccountShouldFail: false,
   spies: {
     createApiKey: vi.fn(),
@@ -62,6 +66,7 @@ const createInitial = (): State => ({
     updateProfile: vi.fn(),
     changeEmail: vi.fn(),
     changePassword: vi.fn(),
+    setPassword: vi.fn(),
     deleteAccount: vi.fn(),
     listAccounts: vi.fn(),
   },
@@ -159,6 +164,13 @@ export const authClientFactory = async () => {
         await Promise.reject(new Error("Failed to change password"));
       }
     },
+    setPassword: async (input: SetPasswordInput): Promise<void> => {
+      const s = getState();
+      s.spies.setPassword(input);
+      if (s.setPasswordShouldFail) {
+        await Promise.reject(new Error("Failed to set password"));
+      }
+    },
     deleteAccount: async (input: DeleteAccountInput): Promise<void> => {
       const s = getState();
       s.spies.deleteAccount(input);
@@ -186,6 +198,7 @@ type SetupOverrides = {
   readonly updateProfileShouldFail?: boolean;
   readonly changeEmailShouldFail?: boolean;
   readonly changePasswordShouldFail?: boolean;
+  readonly setPasswordShouldFail?: boolean;
   readonly deleteAccountShouldFail?: boolean;
 };
 
@@ -199,6 +212,7 @@ export const setupAuthClient = (overrides: SetupOverrides = {}) => {
   current.spies.updateProfile.mockClear();
   current.spies.changeEmail.mockClear();
   current.spies.changePassword.mockClear();
+  current.spies.setPassword.mockClear();
   current.spies.deleteAccount.mockClear();
   current.spies.listAccounts.mockClear();
 
@@ -214,6 +228,7 @@ export const setupAuthClient = (overrides: SetupOverrides = {}) => {
     updateProfileShouldFail: overrides.updateProfileShouldFail ?? false,
     changeEmailShouldFail: overrides.changeEmailShouldFail ?? false,
     changePasswordShouldFail: overrides.changePasswordShouldFail ?? false,
+    setPasswordShouldFail: overrides.setPasswordShouldFail ?? false,
     deleteAccountShouldFail: overrides.deleteAccountShouldFail ?? false,
     spies: current.spies,
   });

--- a/src/test/mocks/modules/authClient.ts
+++ b/src/test/mocks/modules/authClient.ts
@@ -40,6 +40,7 @@ type State = {
   readonly changePasswordShouldFail: boolean;
   readonly setPasswordShouldFail: boolean;
   readonly deleteAccountShouldFail: boolean;
+  readonly listAccountsShouldFail: boolean;
   readonly spies: Spies;
 };
 
@@ -57,6 +58,7 @@ const createInitial = (): State => ({
   changePasswordShouldFail: false,
   setPasswordShouldFail: false,
   deleteAccountShouldFail: false,
+  listAccountsShouldFail: false,
   spies: {
     createApiKey: vi.fn(),
     listApiKeys: vi.fn(),
@@ -181,7 +183,9 @@ export const authClientFactory = async () => {
     listAccounts: async (): Promise<readonly LinkedAccount[]> => {
       const s = getState();
       s.spies.listAccounts();
-      return await Promise.resolve(s.accounts);
+      return s.listAccountsShouldFail
+        ? await Promise.reject(new Error("Failed to list accounts"))
+        : await Promise.resolve(s.accounts);
     },
   };
 };
@@ -200,6 +204,7 @@ type SetupOverrides = {
   readonly changePasswordShouldFail?: boolean;
   readonly setPasswordShouldFail?: boolean;
   readonly deleteAccountShouldFail?: boolean;
+  readonly listAccountsShouldFail?: boolean;
 };
 
 export const setupAuthClient = (overrides: SetupOverrides = {}) => {
@@ -230,6 +235,7 @@ export const setupAuthClient = (overrides: SetupOverrides = {}) => {
     changePasswordShouldFail: overrides.changePasswordShouldFail ?? false,
     setPasswordShouldFail: overrides.setPasswordShouldFail ?? false,
     deleteAccountShouldFail: overrides.deleteAccountShouldFail ?? false,
+    listAccountsShouldFail: overrides.listAccountsShouldFail ?? false,
     spies: current.spies,
   });
 

--- a/workers/migrations/0013_storage_user_id_indexes.sql
+++ b/workers/migrations/0013_storage_user_id_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_storage_cases_user_id ON storage_cases (user_id);
+CREATE INDEX IF NOT EXISTS idx_storage_locations_user_id ON storage_locations (user_id);

--- a/workers/src/auth.ts
+++ b/workers/src/auth.ts
@@ -25,6 +25,11 @@ export const createAuth = ({ env }: { readonly env: Env }) =>
       minPasswordLength: 8,
       maxPasswordLength: 128,
     },
+    // 退会・メール変更でセッションの freshAge 制約を無効化
+    // (UI 側でメール再入力 / 現在のパスワード入力で本人性を担保)
+    session: {
+      freshAge: 0,
+    },
     socialProviders: {
       twitter: {
         clientId: env.TWITTER_CLIENT_ID,

--- a/workers/src/auth.ts
+++ b/workers/src/auth.ts
@@ -41,7 +41,13 @@ export const createAuth = ({ env }: { readonly env: Env }) =>
       },
     },
     user: {
-      changeEmail: { enabled: true },
+      changeEmail: {
+        enabled: true,
+        // emailVerified が false のユーザー (今回はメール検証を要求しないため
+        // 全員が該当) は即時メール更新を許可。verification 基盤を後から
+        // 追加する場合は sendChangeEmailConfirmation 等を併設する。
+        updateEmailWithoutVerification: true,
+      },
       deleteUser: {
         enabled: true,
         beforeDelete: async (user) => {

--- a/workers/src/auth.ts
+++ b/workers/src/auth.ts
@@ -1,6 +1,16 @@
 import { betterAuth } from "better-auth";
 import { apiKey } from "@better-auth/api-key";
+import { eq } from "drizzle-orm";
 import type { Env } from "./types";
+import { createDrizzle } from "./db/client";
+import {
+  coordinates,
+  digests,
+  dolls,
+  garments,
+  storageCases,
+  storageLocations,
+} from "./db/schema";
 
 export const createAuth = ({ env }: { readonly env: Env }) =>
   betterAuth({
@@ -8,6 +18,13 @@ export const createAuth = ({ env }: { readonly env: Env }) =>
     secret: env.BETTER_AUTH_SECRET,
     baseURL: env.BETTER_AUTH_URL,
     basePath: "/api/auth",
+    emailAndPassword: {
+      enabled: true,
+      autoSignIn: true,
+      requireEmailVerification: false,
+      minPasswordLength: 8,
+      maxPasswordLength: 128,
+    },
     socialProviders: {
       twitter: {
         clientId: env.TWITTER_CLIENT_ID,
@@ -16,6 +33,29 @@ export const createAuth = ({ env }: { readonly env: Env }) =>
       google: {
         clientId: env.GOOGLE_CLIENT_ID,
         clientSecret: env.GOOGLE_CLIENT_SECRET,
+      },
+    },
+    user: {
+      changeEmail: { enabled: true },
+      deleteUser: {
+        enabled: true,
+        beforeDelete: async (user) => {
+          const drizzleDb = createDrizzle(env.DB);
+          await Promise.all([
+            drizzleDb.delete(garments).where(eq(garments.userId, user.id)),
+            drizzleDb
+              .delete(storageLocations)
+              .where(eq(storageLocations.userId, user.id)),
+            drizzleDb
+              .delete(storageCases)
+              .where(eq(storageCases.userId, user.id)),
+            drizzleDb
+              .delete(coordinates)
+              .where(eq(coordinates.userId, user.id)),
+            drizzleDb.delete(dolls).where(eq(dolls.userId, user.id)),
+            drizzleDb.delete(digests).where(eq(digests.userId, user.id)),
+          ]);
+        },
       },
     },
     plugins: [apiKey()],

--- a/workers/src/auth.ts
+++ b/workers/src/auth.ts
@@ -40,8 +40,10 @@ export const createAuth = ({ env }: { readonly env: Env }) =>
       deleteUser: {
         enabled: true,
         beforeDelete: async (user) => {
+          // FK: garments.location_id → storage_locations.id, storage_locations.case_id → storage_cases.id
+          // 子→親の順で batch 実行し、D1 の FK 制約違反を避ける
           const drizzleDb = createDrizzle(env.DB);
-          await Promise.all([
+          await drizzleDb.batch([
             drizzleDb.delete(garments).where(eq(garments.userId, user.id)),
             drizzleDb
               .delete(storageLocations)

--- a/workers/src/auth.ts
+++ b/workers/src/auth.ts
@@ -25,11 +25,6 @@ export const createAuth = ({ env }: { readonly env: Env }) =>
       minPasswordLength: 8,
       maxPasswordLength: 128,
     },
-    // 退会・メール変更でセッションの freshAge 制約を無効化
-    // (UI 側でメール再入力 / 現在のパスワード入力で本人性を担保)
-    session: {
-      freshAge: 0,
-    },
     socialProviders: {
       twitter: {
         clientId: env.TWITTER_CLIENT_ID,

--- a/workers/src/db/schema.ts
+++ b/workers/src/db/schema.ts
@@ -47,16 +47,20 @@ export const garments = sqliteTable(
   ],
 );
 
-export const storageCases = sqliteTable("storage_cases", {
-  id: text("id").primaryKey(),
-  userId: text("user_id").notNull(),
-  name: text("name").notNull(),
-  type: text("type").notNull().default("grid"),
-  description: text("description"),
-  rows: integer("rows").notNull().default(5),
-  cols: integer("cols").notNull().default(3),
-  createdAt: integer("created_at").notNull(),
-});
+export const storageCases = sqliteTable(
+  "storage_cases",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id").notNull(),
+    name: text("name").notNull(),
+    type: text("type").notNull().default("grid"),
+    description: text("description"),
+    rows: integer("rows").notNull().default(5),
+    cols: integer("cols").notNull().default(3),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [index("idx_storage_cases_user_id").on(table.userId)],
+);
 
 export const storageLocations = sqliteTable(
   "storage_locations",
@@ -76,7 +80,10 @@ export const storageLocations = sqliteTable(
     correctionCount: integer("correction_count").notNull().default(0),
     createdAt: integer("created_at").notNull(),
   },
-  (table) => [index("idx_locations_case_id").on(table.caseId)],
+  (table) => [
+    index("idx_locations_case_id").on(table.caseId),
+    index("idx_storage_locations_user_id").on(table.userId),
+  ],
 );
 
 export const coordinates = sqliteTable("coordinates", {

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -4,6 +4,7 @@ import { logger } from "hono/logger";
 import { requestId } from "hono/request-id";
 import { timing } from "hono/timing";
 import { trpcServer } from "@hono/trpc-server";
+import { APIError } from "better-auth/api";
 import { appRouter } from "./trpc/router";
 import type { TRPCContext } from "./trpc/index";
 import type { Env } from "./types";
@@ -67,6 +68,38 @@ app.use("*", async (c, next) => {
 app.use("*", async (c, next) => {
   c.set("auth", createAuth({ env: c.env }));
   await next();
+});
+
+// better-auth の setPassword はサーバー内部 API としてのみ提供されており、
+// HTTP route が無いため /api/auth/* の handler では 404 になる。
+// ここで intercept して auth.api.setPassword をサーバーから呼び出す。
+type SetPasswordBody = { readonly newPassword?: unknown };
+
+const isAPIError = (e: unknown): e is APIError => e instanceof APIError;
+
+app.post("/api/auth/set-password", async (c) => {
+  const auth = c.get("auth");
+  const parsed = await c.req
+    .json<SetPasswordBody>()
+    .catch((): SetPasswordBody => ({}));
+  const newPassword = parsed.newPassword;
+
+  if (typeof newPassword !== "string") {
+    return c.json({ message: "newPassword required" }, 400);
+  }
+
+  const result = await auth.api
+    .setPassword({
+      body: { newPassword },
+      headers: c.req.raw.headers,
+    })
+    .catch((e: unknown) => e);
+
+  return isAPIError(result)
+    ? c.json({ message: result.body?.message ?? "Failed" }, 400)
+    : result instanceof Error
+      ? c.json({ message: "Failed" }, 500)
+      : c.json({ status: true });
 });
 
 app.all("/api/auth/*", async (c) => {

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -102,6 +102,54 @@ app.post("/api/auth/set-password", async (c) => {
       : c.json({ status: true });
 });
 
+// confirmEmail をサーバ側で検証してから better-auth の deleteUser を呼ぶ。
+// UI 側のメール再入力チェックだけでは stale state / bypass で意図しない
+// 削除が成立し得るため、session.user.email との一致を fail-closed で確認する。
+type DeleteUserBody = {
+  readonly confirmEmail?: unknown;
+  readonly password?: unknown;
+};
+
+app.post("/api/auth/delete-user", async (c) => {
+  const auth = c.get("auth");
+  const parsed = await c.req
+    .json<DeleteUserBody>()
+    .catch((): DeleteUserBody => ({}));
+  const confirmEmail = parsed.confirmEmail;
+  const password = parsed.password;
+
+  if (typeof confirmEmail !== "string" || confirmEmail.trim() === "") {
+    return c.json({ message: "confirmEmail required" }, 400);
+  }
+
+  const session = await auth.api
+    .getSession({ headers: c.req.raw.headers })
+    .catch((): null => null);
+
+  if (session === null) {
+    return c.json({ message: "Unauthorized" }, 401);
+  }
+
+  // 大文字小文字差で本人なのに弾かれるのを避けるため、両辺を小文字化して比較
+  if (session.user.email.toLowerCase() !== confirmEmail.trim().toLowerCase()) {
+    return c.json({ message: "確認メールアドレスが一致しません" }, 403);
+  }
+
+  const body = typeof password === "string" ? { password } : {};
+  const result = await auth.api
+    .deleteUser({
+      body,
+      headers: c.req.raw.headers,
+    })
+    .catch((e: unknown) => e);
+
+  return isAPIError(result)
+    ? c.json({ message: result.body?.message ?? "Failed" }, 400)
+    : result instanceof Error
+      ? c.json({ message: "Failed" }, 500)
+      : c.json({ status: true });
+});
+
 app.all("/api/auth/*", async (c) => {
   const auth = c.get("auth");
   return await auth.handler(c.req.raw);


### PR DESCRIPTION
## Summary

- better-auth に `emailAndPassword` プラグインを有効化し、`/signin` にメール+パスワードフォームを追加。新規 `/signup` 画面と `/settings/account`（プロフィール / メール変更 / パスワード変更 / 退会）を新設
- 退会時は better-auth の `user.deleteUser.beforeDelete` フックで garments / locations / cases / coordinates / dolls / digests を `Promise.all` で並列削除。あわせて `storage_cases` / `storage_locations` の `user_id` インデックスを追加（`workers/migrations/0013_storage_user_id_indexes.sql`）
- UI は `/frontend-design` スキルのガイダンスを既存トーン（Tailwind v4・既存 Button/Input/Card/PageHeader）に落とし込み、認証ロックアップ・"または" Divider・Pill segmented タブ・SectionCard・DangerZone（半透明赤＋AlertTriangle）で構成

## 主な変更

### Backend
- `workers/src/auth.ts`: `emailAndPassword` 有効化（メール検証なし、autoSignIn、min 8 / max 128）+ `user.changeEmail` / `deleteUser` 有効化 + 退会時の関連データ並列削除
- `workers/src/db/schema.ts` + `workers/migrations/0013_storage_user_id_indexes.sql`: `storage_cases.user_id` / `storage_locations.user_id` インデックス追加

### Frontend
- `src/lib/auth.ts`: Zod スキーマ 6 種（signIn / signUp / updateProfile / changeEmail / changePassword / deleteAccount）と薄いラッパー関数
- `src/components/auth/`: `AuthDivider` / `EmailPasswordForm` / `SignUpForm` 新規、`UserMenu` の設定リンクを `/settings/account` へ
- `src/components/ui/ErrorAlert.tsx`: 認証フォームの送信エラーバナー（DRY）
- `src/components/settings/`: `SettingsTabs`（タブナビ）+ `account/{SectionCard,ProfileForm,EmailChangeForm,PasswordChangeForm,DeleteAccountSection}`
- `src/app/`: `signup/page.tsx`, `settings/layout.tsx`, `settings/account/page.tsx`

### i18n
- 新規 52 メッセージ × en / ko / zh の翻訳を追加

### テスト
- 新規 21 件追加（signin 拡充 +5 / signup 6 / settings/account 7 / SettingsTabs 2 / 既存テストとの整合）— 全 1061 件パス
- `src/test/mocks/modules/authClient.ts`: email 系 6 メソッドの spy / `*ShouldFail` フラグ追加

## 既知の制約

- **パスワードリセット**（forgot password）は今回スコープ外（メール送信基盤が必要なため別 PR）
- **OAuth-only ユーザーのパスワード設定モード切替**: クライアントから `account.password` の有無を確実に判定できないため、フォームは常に「現在のパスワード」入力を表示。空送信は better-auth が弾き、失敗トーストで誘導
- **退会時のパスワード再認証**は省略し、メール再入力のみで防護（既存セッションが本人性を担保）

## Test plan

- [x] `pnpm precheck:full`（typecheck / lint / format / i18n / 1061 件テスト）パス
- [x] `pnpm test:coverage`: 全体 branches 82.18%（80% 必達クリア）、新規 page は 100%
- [ ] ローカル `pnpm dev` + `pnpm dev:workers` で動作確認:
  - [ ] `/signup` → 表示名 + メール + パスワード入力 → 自動的に `/` へ
  - [ ] サインアウト → `/signin` で同じメール/パスワードで再ログイン
  - [ ] `/settings/account` で表示名 / 画像 URL を更新 → ヘッダーに反映
  - [ ] メールアドレス変更 → 新メールでログインできる
  - [ ] パスワード変更 → 新パスワードでログイン、旧パスワードで失敗
  - [ ] 退会 → メール再入力 → セッション切れ + 関連データが消える
  - [ ] OAuth でサインアップしたユーザーが「パスワードを設定」できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)