### PR TITLE
feat(mcp): coordinate tool 公開（list_coordinates / create_coordinate）

### DIFF
--- a/workers/src/mcp/scopes.test.ts
+++ b/workers/src/mcp/scopes.test.ts
@@ -60,19 +60,22 @@ describe("TOOL_REQUIRED_SCOPE", () => {
   it("only includes whitelisted tools", () => {
     expect(Object.keys(TOOL_REQUIRED_SCOPE).sort()).toEqual([
       "add_garment_tags",
+      "create_coordinate",
       "get_garment",
       "get_organization_digest",
       "get_storage_case",
+      "list_coordinates",
       "list_dolls",
       "list_garments",
       "list_storage_cases",
     ]);
   });
 
-  it("flags add_garment_tags as the only write tool", () => {
+  it("flags coordinate create and tag write as the write tools", () => {
     const writeOnly = Object.entries(TOOL_REQUIRED_SCOPE)
       .filter(([, scope]) => scope === "write")
-      .map(([name]) => name);
-    expect(writeOnly).toEqual(["add_garment_tags"]);
+      .map(([name]) => name)
+      .sort();
+    expect(writeOnly).toEqual(["add_garment_tags", "create_coordinate"]);
   });
 });

--- a/workers/src/mcp/scopes.ts
+++ b/workers/src/mcp/scopes.ts
@@ -33,7 +33,9 @@ export const TOOL_REQUIRED_SCOPE = {
   list_storage_cases: SCOPE_READ,
   get_storage_case: SCOPE_READ,
   get_organization_digest: SCOPE_READ,
+  list_coordinates: SCOPE_READ,
   add_garment_tags: SCOPE_WRITE,
+  create_coordinate: SCOPE_WRITE,
 } as const satisfies Record<string, McpScope>;
 
 export type McpToolName = keyof typeof TOOL_REQUIRED_SCOPE;

--- a/workers/src/mcp/tools/create-coordinate.test.ts
+++ b/workers/src/mcp/tools/create-coordinate.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createCoordinateTool } from "./create-coordinate";
+import {
+  createTestGarmentInput,
+  getTestDb,
+  resetDatabase,
+} from "../../test/helpers";
+import { buildMcpToolCtx } from "../../test/mcp-helpers";
+
+describe("createCoordinateTool", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("rejects with FORBIDDEN when scope is read-only", async () => {
+    const ctx = buildMcpToolCtx("read");
+
+    const result = await createCoordinateTool.handle(
+      { name: "no-go", garmentIds: [] },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("FORBIDDEN");
+
+    // DB に書き込まれていないこと
+    const list = await ctx.caller.coordinate.list({});
+    expect(list).toHaveLength(0);
+  });
+
+  it("creates a coordinate with isAiGenerated forced to true", async () => {
+    const ctx = buildMcpToolCtx("write");
+
+    const result = await createCoordinateTool.handle(
+      { name: "AI コーデ", garmentIds: [], memo: "from agent" },
+      ctx,
+    );
+
+    expect(result.isError).toBeUndefined();
+    const created = result.structuredContent as {
+      name: string;
+      isAiGenerated: boolean;
+      memo: string | undefined;
+      garmentIds: readonly string[];
+    };
+    expect(created.name).toBe("AI コーデ");
+    expect(created.isAiGenerated).toBe(true);
+    expect(created.memo).toBe("from agent");
+    expect([...created.garmentIds]).toEqual([]);
+  });
+
+  it("forces isAiGenerated to true even when caller passes false (schema strips it)", async () => {
+    const ctx = buildMcpToolCtx("write");
+
+    // Even though `isAiGenerated` is not part of the MCP input schema,
+    // an external client may try to pass it. zod strips unknown keys by default,
+    // and the call() always overrides with true.
+    const result = await createCoordinateTool.handle(
+      { name: "trying false", garmentIds: [], isAiGenerated: false },
+      ctx,
+    );
+
+    expect(result.isError).toBeUndefined();
+    const created = result.structuredContent as { isAiGenerated: boolean };
+    expect(created.isAiGenerated).toBe(true);
+  });
+
+  it("creates a coordinate referencing the user's own garments", async () => {
+    const ctx = buildMcpToolCtx("write");
+    const garment = await ctx.caller.garment.create(
+      createTestGarmentInput({ name: "リボン付きドレス" }),
+    );
+
+    const result = await createCoordinateTool.handle(
+      { name: "リボンコーデ", garmentIds: [garment.id] },
+      ctx,
+    );
+
+    expect(result.isError).toBeUndefined();
+    const created = result.structuredContent as {
+      garmentIds: readonly string[];
+      isAiGenerated: boolean;
+    };
+    expect([...created.garmentIds]).toEqual([garment.id]);
+    expect(created.isAiGenerated).toBe(true);
+  });
+
+  it("returns isError when garmentIds reference non-existent garments", async () => {
+    const ctx = buildMcpToolCtx("write");
+
+    const result = await createCoordinateTool.handle(
+      {
+        name: "missing-garment",
+        garmentIds: ["clxxxxxxxxxxxxxxxxxxxxxxx"],
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("returns isError on zod validation failure (empty name)", async () => {
+    const ctx = buildMcpToolCtx("write");
+
+    const result = await createCoordinateTool.handle(
+      { name: "", garmentIds: [] },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/workers/src/mcp/tools/create-coordinate.ts
+++ b/workers/src/mcp/tools/create-coordinate.ts
@@ -1,0 +1,16 @@
+import { createCoordinateInputSchema } from "../../trpc/lib/schemas";
+import { defineTool } from "./define-tool";
+
+const createCoordinateMcpInputSchema = createCoordinateInputSchema.omit({
+  isAiGenerated: true,
+});
+
+export const createCoordinateTool = defineTool({
+  name: "create_coordinate",
+  title: "Create coordinate",
+  description:
+    "新しいコーデを保存する。外部エージェント経由のため isAiGenerated は自動で true に固定される。garmentIds はユーザー所有の服 ID のみ受け付ける。",
+  inputSchema: createCoordinateMcpInputSchema,
+  call: async (input, ctx) =>
+    await ctx.caller.coordinate.create({ ...input, isAiGenerated: true }),
+});

--- a/workers/src/mcp/tools/list-coordinates.test.ts
+++ b/workers/src/mcp/tools/list-coordinates.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { listCoordinatesTool } from "./list-coordinates";
+import {
+  createTestCoordinateInput,
+  getTestDb,
+  resetDatabase,
+} from "../../test/helpers";
+import { buildMcpToolCtx } from "../../test/mcp-helpers";
+
+describe("listCoordinatesTool", () => {
+  beforeEach(async () => {
+    await resetDatabase(getTestDb());
+  });
+
+  it("returns the user's coordinates as text content (parseable JSON)", async () => {
+    const ctx = buildMcpToolCtx("read");
+    await ctx.caller.coordinate.create(
+      createTestCoordinateInput({ name: "コーデ A" }),
+    );
+    await ctx.caller.coordinate.create(
+      createTestCoordinateInput({ name: "コーデ B" }),
+    );
+
+    const result = await listCoordinatesTool.handle({}, ctx);
+
+    expect(result.isError).toBeUndefined();
+    const list = JSON.parse(result.content[0]!.text) as Array<{
+      name: string;
+    }>;
+    expect(list.map((c) => c.name).sort()).toEqual(["コーデ A", "コーデ B"]);
+  });
+
+  it("filters coordinates by isAiGenerated=true", async () => {
+    const ctx = buildMcpToolCtx("read");
+    await ctx.caller.coordinate.create(
+      createTestCoordinateInput({ name: "AI コーデ", isAiGenerated: true }),
+    );
+    await ctx.caller.coordinate.create(
+      createTestCoordinateInput({ name: "手動コーデ", isAiGenerated: false }),
+    );
+
+    const result = await listCoordinatesTool.handle(
+      { isAiGenerated: true },
+      ctx,
+    );
+
+    expect(result.isError).toBeUndefined();
+    const list = JSON.parse(result.content[0]!.text) as Array<{
+      name: string;
+      isAiGenerated: boolean;
+    }>;
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe("AI コーデ");
+    expect(list[0]?.isAiGenerated).toBe(true);
+  });
+
+  it("filters coordinates by isAiGenerated=false", async () => {
+    const ctx = buildMcpToolCtx("read");
+    await ctx.caller.coordinate.create(
+      createTestCoordinateInput({ name: "AI コーデ", isAiGenerated: true }),
+    );
+    await ctx.caller.coordinate.create(
+      createTestCoordinateInput({ name: "手動コーデ", isAiGenerated: false }),
+    );
+
+    const result = await listCoordinatesTool.handle(
+      { isAiGenerated: false },
+      ctx,
+    );
+
+    expect(result.isError).toBeUndefined();
+    const list = JSON.parse(result.content[0]!.text) as Array<{
+      name: string;
+      isAiGenerated: boolean;
+    }>;
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe("手動コーデ");
+    expect(list[0]?.isAiGenerated).toBe(false);
+  });
+
+  it("returns empty list when no coordinates exist", async () => {
+    const ctx = buildMcpToolCtx("read");
+    const result = await listCoordinatesTool.handle({}, ctx);
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0]!.text)).toEqual([]);
+  });
+
+  it("treats omitted arguments as no-filter (MCP allows undefined params.arguments)", async () => {
+    const ctx = buildMcpToolCtx("read");
+    await ctx.caller.coordinate.create(
+      createTestCoordinateInput({ name: "no-args", isAiGenerated: true }),
+    );
+
+    const result = await listCoordinatesTool.handle(undefined, ctx);
+
+    expect(result.isError).toBeUndefined();
+    const list = JSON.parse(result.content[0]!.text) as Array<{ name: string }>;
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe("no-args");
+  });
+});

--- a/workers/src/mcp/tools/list-coordinates.ts
+++ b/workers/src/mcp/tools/list-coordinates.ts
@@ -1,0 +1,11 @@
+import { listCoordinatesInputSchema } from "../../trpc/lib/schemas";
+import { defineTool } from "./define-tool";
+
+export const listCoordinatesTool = defineTool({
+  name: "list_coordinates",
+  title: "List coordinates",
+  description:
+    "ユーザーのコーデ一覧を取得する。isAiGenerated でフィルタ可能（true: AI 生成のみ, false: 手動作成のみ, 省略: 全件）。updatedAt の降順で返る。",
+  inputSchema: listCoordinatesInputSchema,
+  call: async (input, ctx) => await ctx.caller.coordinate.list(input),
+});

--- a/workers/src/mcp/tools/register-all.ts
+++ b/workers/src/mcp/tools/register-all.ts
@@ -1,9 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { addGarmentTagsTool } from "./add-garment-tags";
+import { createCoordinateTool } from "./create-coordinate";
 import type { DefinedTool, ToolContext } from "./define-tool";
 import { getGarmentTool } from "./get-garment";
 import { getOrganizationDigestTool } from "./get-organization-digest";
 import { getStorageCaseTool } from "./get-storage-case";
+import { listCoordinatesTool } from "./list-coordinates";
 import { listDollsTool } from "./list-dolls";
 import { listGarmentsTool } from "./list-garments";
 import { listStorageCasesTool } from "./list-storage-cases";
@@ -15,7 +17,9 @@ export const ALL_TOOLS: readonly DefinedTool[] = [
   listStorageCasesTool,
   getStorageCaseTool,
   getOrganizationDigestTool,
+  listCoordinatesTool,
   addGarmentTagsTool,
+  createCoordinateTool,
 ];
 
 export const registerAllTools = (server: McpServer, ctx: ToolContext): void => {


### PR DESCRIPTION
## Summary

- 外部 AI エージェント（Claude Desktop 等）が Dollrobe にコーデを保存できるよう、MCP に `list_coordinates` / `create_coordinate` を追加。
- `create_coordinate` は `isAiGenerated` を入力スキーマから `.omit()` し、サーバー側で常に `true` に固定（外部エージェント経由の作成を確実に AI 生成として記録するため）。
- 破壊操作（`update_coordinate` / `delete_coordinate`）は UI 経由のみに限定（issue の Non-goals）。
- `read-write` スコープ要件は既存 `defineTool` の自動エンフォースに任せ、`TOOL_REQUIRED_SCOPE` に `list_coordinates: read` / `create_coordinate: write` を追加するだけで済ませた。

## 変更ファイル

- 新規: `workers/src/mcp/tools/list-coordinates.ts` + test
- 新規: `workers/src/mcp/tools/create-coordinate.ts` + test
- 編集: `workers/src/mcp/scopes.ts` — `TOOL_REQUIRED_SCOPE` に 2 行追加
- 編集: `workers/src/mcp/scopes.test.ts` — whitelist アサーションを更新
- 編集: `workers/src/mcp/tools/register-all.ts` — `ALL_TOOLS` に 2 行追加

inputSchema は `workers/src/trpc/lib/schemas.ts` の `listCoordinatesInputSchema` / `createCoordinateInputSchema` を流用。adapter 経由で `ctx.caller.coordinate.list` / `ctx.caller.coordinate.create` を呼ぶだけのため、サービス層・リポジトリ層には触れていない。

## Test plan

- [x] `pnpm vitest run workers/src/mcp/` — 13 files / 70 tests passed
- [x] `pnpm precheck` — 0 errors（既存の magic-number warning のみ）
- [x] `npx tsc-files -p tsconfig.workers.json` / `tsconfig.workers-test.json` — 変更ファイル全て pass
- [x] `npx eslint` — 変更ファイル全て pass
- [ ] Claude Desktop の MCP settings に `read-write` キーで Dollrobe を登録し、`list_coordinates` が実データを返ること
- [ ] `create_coordinate` で保存したコーデが UI 一覧に `isAiGenerated: true` バッジで現れること
- [ ] API キー `read-only` で `create_coordinate` を叩くと `FORBIDDEN` で拒否されること（テストではカバー済）

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)