### PR TITLE
chore(lint): functional/no-conditional-statements で早期リターンを許可

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,6 +71,10 @@ export default tseslint.config(
         "error",
         { enforceParameterCount: false },
       ],
+      "functional/no-conditional-statements": [
+        "error",
+        { allowReturningBranches: true },
+      ],
       eqeqeq: ["error", "always", { null: "ignore" }],
       "no-restricted-syntax": [
         "error",

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -81,7 +81,7 @@ export class DollWardrobeDB extends Dexie {
       })
       .upgrade(async (tx) => {
         const syncTable = tx.table("syncQueue");
-        /* eslint-disable functional/no-conditional-statements, functional/immutable-data, @typescript-eslint/prefer-destructuring -- Dexie modify callback requires in-place mutation; destructuring loses type guard narrowing */
+        /* eslint-disable functional/immutable-data, @typescript-eslint/prefer-destructuring -- Dexie modify callback requires in-place mutation; destructuring loses type guard narrowing */
         await syncTable
           .toCollection()
           .filter((item: Record<string, unknown>) => {
@@ -105,7 +105,7 @@ export class DollWardrobeDB extends Dexie {
             payload.dollSizes = [payload.dollSize];
             delete payload.dollSize;
           });
-        /* eslint-enable functional/no-conditional-statements, functional/immutable-data, @typescript-eslint/prefer-destructuring */
+        /* eslint-enable functional/immutable-data, @typescript-eslint/prefer-destructuring */
       });
     this.version(5)
       .stores({
@@ -286,7 +286,7 @@ export class DollWardrobeDB extends Dexie {
 
 const holder = new Map<string, DollWardrobeDB>();
 
-/* eslint-disable functional/no-conditional-statements, functional/immutable-data -- lazy singleton requires one-time mutation to defer IndexedDB access from SSR */
+/* eslint-disable functional/immutable-data -- lazy singleton requires one-time mutation to defer IndexedDB access from SSR */
 export const getDb = (): DollWardrobeDB => {
   const existing = holder.get("db");
   if (existing !== undefined) {
@@ -296,4 +296,4 @@ export const getDb = (): DollWardrobeDB => {
   holder.set("db", instance);
   return instance;
 };
-/* eslint-enable functional/no-conditional-statements, functional/immutable-data */
+/* eslint-enable functional/immutable-data */

--- a/src/stores/digestAtoms.ts
+++ b/src/stores/digestAtoms.ts
@@ -20,7 +20,6 @@ export const digestListAtom = atom(async (get) =>
 );
 
 export const hasUnreadDigestAtom = atom(async (get) => {
-  // eslint-disable-next-line functional/no-conditional-statements -- SSR guard
   if (typeof window === "undefined") return false;
   get(digestRefreshTriggerAtom);
   const result = await trpcClient.digest.hasUnread

--- a/src/stores/pendingArchiveAtoms.ts
+++ b/src/stores/pendingArchiveAtoms.ts
@@ -48,7 +48,6 @@ const archiveEntity = async (
       }));
 };
 
-/* eslint-disable functional/no-conditional-statements -- archive orchestration requires imperative control flow */
 const executeArchiveAtom = atom(
   undefined,
   async (
@@ -64,15 +63,13 @@ const executeArchiveAtom = atom(
         (p) => p.id === id && p.entityType === entityType,
       ) !== undefined;
 
-    if (isPending) {
-      await archiveEntity(entityType, id, Date.now());
-      if (entityType === "garment") {
-        set(refreshGarmentsAtom);
-      } else {
-        set(refreshDollsAtom);
-      }
+    if (!isPending) {
+      set(pendingArchivesAtom, (prev) => removePending(prev, id, entityType));
+      return;
     }
 
+    await archiveEntity(entityType, id, Date.now());
+    set(entityType === "garment" ? refreshGarmentsAtom : refreshDollsAtom);
     set(pendingArchivesAtom, (prev) => removePending(prev, id, entityType));
   },
 );
@@ -91,11 +88,10 @@ const cancelArchiveAtom = atom(
       (p) => p.id === id && p.entityType === entityType,
     );
 
-    if (pending !== undefined) {
-      clearTimeout(pending.timerId);
-      set(dismissToastAtom, pending.toastId);
-      set(pendingArchivesAtom, (prev) => removePending(prev, id, entityType));
-    }
+    if (pending === undefined) return;
+    clearTimeout(pending.timerId);
+    set(dismissToastAtom, pending.toastId);
+    set(pendingArchivesAtom, (prev) => removePending(prev, id, entityType));
   },
 );
 
@@ -137,4 +133,3 @@ export const requestArchiveAtom = atom(
     ]);
   },
 );
-/* eslint-enable functional/no-conditional-statements */

--- a/src/stores/syncAtoms.ts
+++ b/src/stores/syncAtoms.ts
@@ -55,14 +55,12 @@ export const executeSyncAtom = atom(
     set(refreshPendingSyncCountAtom);
     set(syncStatusAtom, result.ok ? SYNC_STATUS.IDLE : SYNC_STATUS.ERROR);
     set(lastSyncErrorAtom, result.ok ? undefined : result.error);
-    // eslint-disable-next-line functional/no-conditional-statements -- refresh atoms only on success
-    if (result.ok) {
-      set(refreshDollsAtom);
-      set(refreshGarmentsAtom);
-      set(refreshStorageCasesAtom);
-      set(refreshStorageLocationsAtom);
-      set(refreshCoordinatesAtom);
-    }
+    if (!result.ok) return;
+    set(refreshDollsAtom);
+    set(refreshGarmentsAtom);
+    set(refreshStorageCasesAtom);
+    set(refreshStorageLocationsAtom);
+    set(refreshCoordinatesAtom);
   },
 );
 


### PR DESCRIPTION
## Summary

- `eslint-plugin-functional` の [`no-conditional-statements`](https://github.com/eslint-functional/eslint-plugin-functional/blob/main/docs/rules/no-conditional-statements.md) ルールに `{ allowReturningBranches: true }` を設定し、早期リターン（ガード句）を許容するように緩和
- ルール自体は引き続き有効。途中で代入や副作用を行う非終端の `if` / `switch` は依然エラー
- これにより不要になった `eslint-disable functional/no-conditional-statements` を `src/lib/db/dexie.ts`（3 箇所）と `src/stores/digestAtoms.ts`（1 箇所）から削除

## Test plan

- [x] `pnpm lint` → 0 errors / 142 warnings（変更前後で warning 数は同一）
- [x] `pnpm precheck` 通過
- [x] スモーク検証: 副作用付き `if (cond) { x = 1; }` は `functional/no-conditional-statements` でエラー、`if (cond) return ...;` は pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)