### PR TITLE
refactor: 早期リターン許可に伴う三項ネスト・disable コメント整理

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -259,7 +259,8 @@ const permissionsSchema = z
 
 const permissionsToScope = (raw: unknown): ApiKeyScope => {
   const parsed = permissionsSchema.safeParse(raw);
-  const actions = parsed.success ? (parsed.data?.all ?? []) : [];
+  if (!parsed.success) return API_KEY_SCOPE.READ_ONLY;
+  const actions = parsed.data?.all ?? [];
   return actions.includes("write")
     ? API_KEY_SCOPE.READ_WRITE
     : API_KEY_SCOPE.READ_ONLY;
@@ -285,13 +286,10 @@ const dateLikeSchema = z
 
 const toMillis = (raw: unknown): number => {
   const parsed = dateLikeSchema.safeParse(raw);
-  return !parsed.success || parsed.data == null
-    ? 0
-    : parsed.data instanceof Date
-      ? parsed.data.getTime()
-      : typeof parsed.data === "number"
-        ? parsed.data
-        : new Date(parsed.data).getTime();
+  if (!parsed.success || parsed.data == null) return 0;
+  if (parsed.data instanceof Date) return parsed.data.getTime();
+  if (typeof parsed.data === "number") return parsed.data;
+  return new Date(parsed.data).getTime();
 };
 
 const toLastRequest = (raw: unknown): number | undefined => {

--- a/src/lib/csv/parseCsv.ts
+++ b/src/lib/csv/parseCsv.ts
@@ -58,14 +58,11 @@ export const parseCsv = (text: string): ParsedCsvResult => {
     .filter((line) => line.trim() !== "");
 
   const [headerLine] = lines;
-  return headerLine === undefined
-    ? { headers: [], rows: [] }
-    : {
-        headers: splitCsvLine(headerLine).map((h) => h.trim()),
-        rows: lines
-          .slice(1)
-          .map((line) => splitCsvLine(line).map((f) => f.trim())),
-      };
+  if (headerLine === undefined) return { headers: [], rows: [] };
+  return {
+    headers: splitCsvLine(headerLine).map((h) => h.trim()),
+    rows: lines.slice(1).map((line) => splitCsvLine(line).map((f) => f.trim())),
+  };
 };
 
 export const hasRequiredHeaders = (

--- a/src/lib/csv/validateCsvRow.ts
+++ b/src/lib/csv/validateCsvRow.ts
@@ -135,29 +135,31 @@ const buildValidRow = (record: Record<string, string>): CsvValidationResult => {
     (s) => s === (record.dollSize?.trim() ?? ""),
   );
 
-  return category !== undefined && dollSize !== undefined
-    ? {
-        ok: true,
-        data: {
-          name: record.name?.trim() ?? "",
-          category,
-          dollSize,
-          colors: parseArrayField(record.colors),
-          tags: parseArrayField(record.tags),
-          brand: record.brand?.trim() ?? "",
-          confidenceDecayDays: parseDecayDays(record.confidenceDecayDays),
+  if (category === undefined || dollSize === undefined) {
+    return {
+      ok: false,
+      errors: [
+        {
+          row: 0,
+          field: "internal",
+          message: "Unexpected validation error",
         },
-      }
-    : {
-        ok: false,
-        errors: [
-          {
-            row: 0,
-            field: "internal",
-            message: "Unexpected validation error",
-          },
-        ],
-      };
+      ],
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      name: record.name?.trim() ?? "",
+      category,
+      dollSize,
+      colors: parseArrayField(record.colors),
+      tags: parseArrayField(record.tags),
+      brand: record.brand?.trim() ?? "",
+      confidenceDecayDays: parseDecayDays(record.confidenceDecayDays),
+    },
+  };
 };
 
 export const validateCsvRow = ({

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -61,14 +61,13 @@ export class DollWardrobeDB extends Dexie {
       })
       .upgrade(async (tx) => {
         const table = tx.table("garments");
-        /* eslint-disable functional/no-conditional-statements, no-param-reassign, functional/immutable-data -- Dexie modify callback requires in-place mutation */
+        /* eslint-disable no-param-reassign, functional/immutable-data -- Dexie modify callback requires in-place mutation */
         await table.toCollection().modify((g: Record<string, unknown>) => {
-          if (g.dollSize !== undefined && g.dollSizes === undefined) {
-            g.dollSizes = [g.dollSize];
-            delete g.dollSize;
-          }
+          if (g.dollSize === undefined || g.dollSizes !== undefined) return;
+          g.dollSizes = [g.dollSize];
+          delete g.dollSize;
         });
-        /* eslint-enable functional/no-conditional-statements, no-param-reassign, functional/immutable-data */
+        /* eslint-enable no-param-reassign, functional/immutable-data */
       });
     this.version(4)
       .stores({
@@ -91,16 +90,12 @@ export class DollWardrobeDB extends Dexie {
             ) {
               return false;
             }
-            if (!isRecord(item.payload)) {
-              return false;
-            }
+            if (!isRecord(item.payload)) return false;
             const payload = item.payload;
             return typeof payload.dollSize === "string";
           })
           .modify((item: Record<string, unknown>) => {
-            if (!isRecord(item.payload)) {
-              return;
-            }
+            if (!isRecord(item.payload)) return;
             const payload = item.payload;
             payload.dollSizes = [payload.dollSize];
             delete payload.dollSize;
@@ -118,13 +113,12 @@ export class DollWardrobeDB extends Dexie {
       })
       .upgrade(async (tx) => {
         const casesTable = tx.table("storageCases");
-        /* eslint-disable functional/no-conditional-statements, no-param-reassign, @typescript-eslint/prefer-destructuring -- Dexie modify callback requires in-place mutation */
+        /* eslint-disable no-param-reassign, @typescript-eslint/prefer-destructuring -- Dexie modify callback requires in-place mutation */
         await casesTable.toCollection().modify((c: Record<string, unknown>) => {
-          if (c.type === undefined) {
-            c.type = STORAGE_CASE_TYPE.GRID;
-          }
+          if (c.type !== undefined) return;
+          c.type = STORAGE_CASE_TYPE.GRID;
         });
-        /* eslint-enable functional/no-conditional-statements, no-param-reassign, @typescript-eslint/prefer-destructuring */
+        /* eslint-enable no-param-reassign, @typescript-eslint/prefer-destructuring */
       });
     this.version(6).stores({
       garments: "id, userId, locationId, status, category, archivedAt",
@@ -160,22 +154,20 @@ export class DollWardrobeDB extends Dexie {
           DOLL_SIZE_MIGRATION[size] ?? size;
 
         const garmentsTable = tx.table("garments");
-        /* eslint-disable functional/no-conditional-statements, no-param-reassign, @typescript-eslint/prefer-destructuring -- Dexie modify callback requires in-place mutation; destructuring loses type guard narrowing */
+        /* eslint-disable no-param-reassign, @typescript-eslint/prefer-destructuring, functional/no-conditional-statements -- Dexie modify callback requires in-place mutation; destructuring loses type guard narrowing; payload mutation needs sequential independent guards */
         await garmentsTable
           .toCollection()
           .modify((g: Record<string, unknown>) => {
-            if (Array.isArray(g.dollSizes)) {
-              g.dollSizes = g.dollSizes
-                .filter((s: unknown): s is string => typeof s === "string")
-                .map(replaceDollSize);
-            }
+            if (!Array.isArray(g.dollSizes)) return;
+            g.dollSizes = g.dollSizes
+              .filter((s: unknown): s is string => typeof s === "string")
+              .map(replaceDollSize);
           });
 
         const dollsTable = tx.table("dolls");
         await dollsTable.toCollection().modify((d: Record<string, unknown>) => {
-          if (typeof d.bodySize === "string") {
-            d.bodySize = replaceDollSize(d.bodySize);
-          }
+          if (typeof d.bodySize !== "string") return;
+          d.bodySize = replaceDollSize(d.bodySize);
         });
 
         const syncTable = tx.table("syncQueue");
@@ -189,9 +181,7 @@ export class DollWardrobeDB extends Dexie {
               item.type === SYNC_ACTION_TYPE.DOLL_UPDATE,
           )
           .modify((item: Record<string, unknown>) => {
-            if (!isRecord(item.payload)) {
-              return;
-            }
+            if (!isRecord(item.payload)) return;
             const payload = item.payload;
             if (Array.isArray(payload.dollSizes)) {
               payload.dollSizes = payload.dollSizes
@@ -202,7 +192,7 @@ export class DollWardrobeDB extends Dexie {
               payload.bodySize = replaceDollSize(payload.bodySize);
             }
           });
-        /* eslint-enable functional/no-conditional-statements, no-param-reassign, @typescript-eslint/prefer-destructuring */
+        /* eslint-enable no-param-reassign, @typescript-eslint/prefer-destructuring, functional/no-conditional-statements */
       });
     this.version(9)
       .stores({
@@ -218,7 +208,7 @@ export class DollWardrobeDB extends Dexie {
         const NEW_BLUE = "hsl(210, 55%, 55%)";
 
         const garmentsTable = tx.table("garments");
-        /* eslint-disable functional/no-conditional-statements, no-param-reassign, @typescript-eslint/prefer-destructuring -- Dexie modify callback requires in-place mutation; destructuring loses type guard narrowing */
+        /* eslint-disable no-param-reassign, @typescript-eslint/prefer-destructuring -- Dexie modify callback requires in-place mutation; destructuring loses type guard narrowing */
         await garmentsTable
           .toCollection()
           .filter(
@@ -226,11 +216,10 @@ export class DollWardrobeDB extends Dexie {
               Array.isArray(g.colors) && g.colors.includes(OLD_BLUE),
           )
           .modify((g: Record<string, unknown>) => {
-            if (Array.isArray(g.colors)) {
-              g.colors = g.colors.map((c: unknown) =>
-                c === OLD_BLUE ? NEW_BLUE : c,
-              );
-            }
+            if (!Array.isArray(g.colors)) return;
+            g.colors = g.colors.map((c: unknown) =>
+              c === OLD_BLUE ? NEW_BLUE : c,
+            );
           });
 
         const syncTable = tx.table("syncQueue");
@@ -242,17 +231,14 @@ export class DollWardrobeDB extends Dexie {
               item.type === SYNC_ACTION_TYPE.GARMENT_UPDATE,
           )
           .modify((item: Record<string, unknown>) => {
-            if (!isRecord(item.payload)) {
-              return;
-            }
+            if (!isRecord(item.payload)) return;
             const payload = item.payload;
-            if (Array.isArray(payload.colors)) {
-              payload.colors = payload.colors.map((c: unknown) =>
-                c === OLD_BLUE ? NEW_BLUE : c,
-              );
-            }
+            if (!Array.isArray(payload.colors)) return;
+            payload.colors = payload.colors.map((c: unknown) =>
+              c === OLD_BLUE ? NEW_BLUE : c,
+            );
           });
-        /* eslint-enable functional/no-conditional-statements, no-param-reassign, @typescript-eslint/prefer-destructuring */
+        /* eslint-enable no-param-reassign, @typescript-eslint/prefer-destructuring */
       });
     this.version(10)
       .stores({
@@ -265,21 +251,14 @@ export class DollWardrobeDB extends Dexie {
       })
       .upgrade(async (tx) => {
         const locationsTable = tx.table("storageLocations");
-        /* eslint-disable functional/no-conditional-statements, no-param-reassign -- Dexie modify callback requires in-place mutation */
+        /* eslint-disable no-param-reassign -- Dexie modify callback requires in-place mutation */
         await locationsTable
           .toCollection()
           .modify((l: Record<string, unknown>) => {
-            if (l.confirmAllCount === undefined) {
-              l.confirmAllCount = 0;
-            }
-            if (l.correctionCount === undefined) {
-              l.correctionCount = 0;
-            }
-            if (l.lastVisitedAt === undefined) {
-              l.lastVisitedAt = undefined;
-            }
+            l.confirmAllCount ??= 0;
+            l.correctionCount ??= 0;
           });
-        /* eslint-enable functional/no-conditional-statements, no-param-reassign */
+        /* eslint-enable no-param-reassign */
       });
   }
 }
@@ -289,9 +268,7 @@ const holder = new Map<string, DollWardrobeDB>();
 /* eslint-disable functional/immutable-data -- lazy singleton requires one-time mutation to defer IndexedDB access from SSR */
 export const getDb = (): DollWardrobeDB => {
   const existing = holder.get("db");
-  if (existing !== undefined) {
-    return existing;
-  }
+  if (existing !== undefined) return existing;
   const instance = new DollWardrobeDB();
   holder.set("db", instance);
   return instance;

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -250,15 +250,15 @@ export class DollWardrobeDB extends Dexie {
         dolls: "id, userId, bodySize, archivedAt",
       })
       .upgrade(async (tx) => {
-        const locationsTable = tx.table("storageLocations");
-        /* eslint-disable no-param-reassign -- Dexie modify callback requires in-place mutation */
-        await locationsTable
-          .toCollection()
-          .modify((l: Record<string, unknown>) => {
-            l.confirmAllCount ??= 0;
-            l.correctionCount ??= 0;
-          });
-        /* eslint-enable no-param-reassign */
+        const locationsTable =
+          tx.table<Record<string, unknown>>("storageLocations");
+        const records = await locationsTable.toArray();
+        const updated = records.map((l) => ({
+          ...l,
+          confirmAllCount: l.confirmAllCount ?? 0,
+          correctionCount: l.correctionCount ?? 0,
+        }));
+        await locationsTable.bulkPut(updated);
       });
   }
 }

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -154,7 +154,7 @@ export class DollWardrobeDB extends Dexie {
           DOLL_SIZE_MIGRATION[size] ?? size;
 
         const garmentsTable = tx.table("garments");
-        /* eslint-disable no-param-reassign, @typescript-eslint/prefer-destructuring, functional/no-conditional-statements -- Dexie modify callback requires in-place mutation; destructuring loses type guard narrowing; payload mutation needs sequential independent guards */
+        /* eslint-disable no-param-reassign, @typescript-eslint/prefer-destructuring, functional/no-conditional-statements -- Dexie modify callback requires in-place mutation; destructuring loses type guard narrowing; payload may carry dollSizes AND bodySize so cannot early-return after the first guard */
         await garmentsTable
           .toCollection()
           .modify((g: Record<string, unknown>) => {

--- a/src/lib/wardrobe-analytics.ts
+++ b/src/lib/wardrobe-analytics.ts
@@ -161,14 +161,13 @@ export const classifyColor = (colorString: string): ColorName =>
   COLOR_NAME_MAP.get(colorString) ??
   classifyParsed(parseHsl(colorString) ?? parseHex(colorString));
 
-const classifyParsed = (parsed: ParsedHsl | undefined): ColorName =>
-  parsed === undefined
-    ? "black"
-    : parsed.s < ACHROMATIC_SATURATION_THRESHOLD
-      ? parsed.l < ACHROMATIC_LIGHTNESS_MIDPOINT
-        ? "black"
-        : "white"
-      : findClosestHuePreset(parsed.h);
+const classifyParsed = (parsed: ParsedHsl | undefined): ColorName => {
+  if (parsed === undefined) return "black";
+  if (parsed.s < ACHROMATIC_SATURATION_THRESHOLD) {
+    return parsed.l < ACHROMATIC_LIGHTNESS_MIDPOINT ? "black" : "white";
+  }
+  return findClosestHuePreset(parsed.h);
+};
 
 const COLOR_NAME_TO_HSL: Readonly<Record<ColorName, string>> = {
   black: PRESET_COLORS[0],

--- a/src/stores/dashboardAtoms.ts
+++ b/src/stores/dashboardAtoms.ts
@@ -31,24 +31,26 @@ const toStaleLocation = ({
 }): StaleLocation | undefined => {
   const referenceAt = location.lastVisitedAt ?? location.createdAt;
   const daysSinceLastVisit = Math.floor((now - referenceAt) / MS_PER_DAY);
-  const uncertainItemCount =
-    daysSinceLastVisit < STALE_LOCATION_THRESHOLD_DAYS
-      ? 0
-      : getItemsNeedingReview(activeGarments, location.id, {
-          lastLocationVisitedAt: location.lastVisitedAt,
-        }).length;
-  return daysSinceLastVisit >= STALE_LOCATION_THRESHOLD_DAYS &&
-    uncertainItemCount > 0
-    ? {
-        locationId: location.id,
-        caseId: location.caseId,
-        locationLabel: location.customName ?? location.label,
-        caseName: storageCase.name,
-        uncertainItemCount,
-        daysSinceLastVisit,
-        neverVisited: location.lastVisitedAt === undefined,
-      }
-    : undefined;
+  if (daysSinceLastVisit < STALE_LOCATION_THRESHOLD_DAYS) return undefined;
+
+  const { length: uncertainItemCount } = getItemsNeedingReview(
+    activeGarments,
+    location.id,
+    {
+      lastLocationVisitedAt: location.lastVisitedAt,
+    },
+  );
+  if (uncertainItemCount === 0) return undefined;
+
+  return {
+    locationId: location.id,
+    caseId: location.caseId,
+    locationLabel: location.customName ?? location.label,
+    caseName: storageCase.name,
+    uncertainItemCount,
+    daysSinceLastVisit,
+    neverVisited: location.lastVisitedAt === undefined,
+  };
 };
 
 export const staleLocationsSuspenseAtom = atom(

--- a/src/stores/locationAtoms.ts
+++ b/src/stores/locationAtoms.ts
@@ -79,42 +79,45 @@ const buildLocations = ({
   readonly input: AddStorageCaseInput;
   readonly caseId: string;
   readonly now: number;
-}): readonly StorageLocation[] =>
-  input.type === "unit"
-    ? [
-        {
-          id: createId(),
-          userId: input.userId,
-          caseId,
-          label: input.name,
-          customName: undefined,
-          description: undefined,
-          row: 0,
-          col: 0,
-          lastVisitedAt: undefined,
-          confirmAllCount: 0,
-          correctionCount: 0,
-          createdAt: now,
-        },
-      ]
-    : Array.from({ length: input.rows * input.cols }, (_, i) => {
-        const row = Math.floor(i / input.cols);
-        const col = i % input.cols;
-        return {
-          id: createId(),
-          userId: input.userId,
-          caseId,
-          label: generateLabel({ row, col }),
-          customName: undefined,
-          description: undefined,
-          row,
-          col,
-          lastVisitedAt: undefined,
-          confirmAllCount: 0,
-          correctionCount: 0,
-          createdAt: now,
-        };
-      });
+}): readonly StorageLocation[] => {
+  if (input.type === "unit") {
+    return [
+      {
+        id: createId(),
+        userId: input.userId,
+        caseId,
+        label: input.name,
+        customName: undefined,
+        description: undefined,
+        row: 0,
+        col: 0,
+        lastVisitedAt: undefined,
+        confirmAllCount: 0,
+        correctionCount: 0,
+        createdAt: now,
+      },
+    ];
+  }
+
+  return Array.from({ length: input.rows * input.cols }, (_, i) => {
+    const row = Math.floor(i / input.cols);
+    const col = i % input.cols;
+    return {
+      id: createId(),
+      userId: input.userId,
+      caseId,
+      label: generateLabel({ row, col }),
+      customName: undefined,
+      description: undefined,
+      row,
+      col,
+      lastVisitedAt: undefined,
+      confirmAllCount: 0,
+      correctionCount: 0,
+      createdAt: now,
+    };
+  });
+};
 
 export const addStorageCaseWithLocationsAtom = atom(
   undefined,

--- a/src/stores/pendingArchiveAtoms.ts
+++ b/src/stores/pendingArchiveAtoms.ts
@@ -87,6 +87,7 @@ const cancelArchiveAtom = atom(
     const pending = get(pendingArchivesAtom).find(
       (p) => p.id === id && p.entityType === entityType,
     );
+
     if (pending === undefined) return;
     clearTimeout(pending.timerId);
     set(dismissToastAtom, pending.toastId);

--- a/src/stores/pendingArchiveAtoms.ts
+++ b/src/stores/pendingArchiveAtoms.ts
@@ -87,7 +87,6 @@ const cancelArchiveAtom = atom(
     const pending = get(pendingArchivesAtom).find(
       (p) => p.id === id && p.entityType === entityType,
     );
-
     if (pending === undefined) return;
     clearTimeout(pending.timerId);
     set(dismissToastAtom, pending.toastId);


### PR DESCRIPTION
## Summary

PR #183 で `functional/no-conditional-statements` ルールに `{ allowReturningBranches: true }` が設定されたことを受け、ガード句として書ける箇所をすべて整理。

### A. 不要 disable の削除
- `src/lib/db/dexie.ts`（7 箇所）— 各 `eslint-disable` リストから `functional/no-conditional-statements` のみ除去。modify コールバックを早期リターン化、v10 は `??=` で 1 行に圧縮し no-op の `lastVisitedAt = undefined` を削除。`no-param-reassign` / `functional/immutable-data` / `prefer-destructuring` は Dexie の in-place mutation 要件のため残置

### B. 早期リターンを避けて書かれた三項ネスト等の簡素化
- `src/lib/csv/parseCsv.ts` — `parseCsv` の headerLine 欠落分岐を if 早期リターンに
- `src/stores/dashboardAtoms.ts` — `toStaleLocation` の三項ネストを 2 つのガード句にフラット化
- `src/lib/auth.ts` — `permissionsToScope` と `toMillis` を if 早期リターン展開（特に `toMillis` は 4 段ネスト三項を 4 ガード句に）
- `src/lib/csv/validateCsvRow.ts` — `buildValidRow` のエラーケースを早期リターンに
- `src/lib/wardrobe-analytics.ts` — `classifyParsed` の三重ネスト三項を平坦化
- `src/stores/locationAtoms.ts` — `buildLocations` の `unit`/`grid` 分岐を 2 アーム early return に

### 変更しなかった箇所
- `(get(triggerAtom), await fn())` カンマ演算子パターン（`storageCasesAtom` 等）— jotai リフレッシュトリガーの一貫したイディオムなので不一致を避ける
- 1 行三項（`parseHsl`, `parseHexDigits` 等）と関数型 spread 検証（`validateCsvRow.ts` の各 validator）— 既に簡潔
- v8 dexie syncQueue modify 内の 2 連続 if — 順次独立した副作用のため `functional/no-conditional-statements` の disable を残置

挙動変更なし。

## Test plan

- [x] `pnpm lint` → 0 errors / 142 warnings（PR #183 と同一）
- [x] `pnpm test:coverage` → 119 files / 1137 tests pass、branches 81.66%（≥80%）
- [x] `pnpm precheck`（lint + format:check + i18n:check）通過
- [x] ファイル単位 `npx tsc-files --noEmit -p tsconfig.app.json` で型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)