### PR TITLE
test(stores): syncAtoms / pendingArchiveAtoms の atom 全モックを実 atom + Dexie に置換

### DIFF
--- a/src/stores/pendingArchiveAtoms.test.ts
+++ b/src/stores/pendingArchiveAtoms.test.ts
@@ -1,13 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { atom, createStore } from "jotai";
+import { createStore } from "jotai";
 import type { Atom } from "jotai";
 import { getDb } from "@/lib/db/dexie";
 import { SYNC_ACTION_TYPE } from "@/lib/constants";
 import { createTestDoll, createTestGarment } from "@/test/factories";
+import { setupCuid2 } from "@/test/mocks/modules/cuid2";
+import {
+  pendingArchivesAtom,
+  requestArchiveAtom,
+} from "@/stores/pendingArchiveAtoms";
+import { toastsAtom } from "@/stores/toastAtoms";
 
 const ARCHIVE_DELAY_MS = 5000;
 const FIXED_NOW = new Date("2025-06-15T00:00:00Z").getTime();
-const TOAST_ID = "toast-id-1";
 const FLUSH_TIMEOUT_MS = 1000;
 const FLUSH_POLL_INTERVAL_MS = 5;
 
@@ -28,80 +33,27 @@ const waitForCondition = async (check: () => boolean): Promise<boolean> => {
 
 const flushArchive = async (
   store: Store,
-  pendingArchivesAtom: Atom<ReadonlyArray<{ readonly id: string }>>,
+  pending: Atom<ReadonlyArray<{ readonly id: string }>>,
 ) => {
   // setTimeout コールバックを起動する
   vi.advanceTimersByTime(ARCHIVE_DELAY_MS);
   // Dexie の async 操作を解決させるため real timers に戻す
   vi.useRealTimers();
-  const drained = await waitForCondition(
-    () => store.get(pendingArchivesAtom).length === 0,
-  );
+  const drained = await waitForCondition(() => store.get(pending).length === 0);
   expect(drained, "pendingArchives drained").toBe(true);
 };
 
-// eslint-disable-next-line functional/no-mixed-types -- toast action callback is inherent to the toast model
-type ToastAction = {
-  readonly label: string;
-  readonly onClick: () => void;
-};
-
-type ToastAddParams = {
-  readonly message: string;
-  readonly action?: ToastAction;
-  readonly durationMs?: number;
-};
-
-const toastSpies = vi.hoisted(() => ({
-  add: vi.fn<(params: ToastAddParams) => string>(),
-  dismiss: vi.fn<(id: string) => void>(),
-}));
-
-const refreshSpies = vi.hoisted(() => ({
-  garments: vi.fn<() => void>(),
-  dolls: vi.fn<() => void>(),
-}));
-
-vi.mock("@/stores/toastAtoms", () => {
-  const addToastAtom = atom(undefined, (_get, _set, params: ToastAddParams) => {
-    toastSpies.add(params);
-    return TOAST_ID;
-  });
-  const dismissToastAtom = atom(undefined, (_get, _set, id: string) => {
-    toastSpies.dismiss(id);
-  });
-  return { addToastAtom, dismissToastAtom };
-});
-
-vi.mock("@/stores/garmentAtoms", () => {
-  const refreshGarmentsAtom = atom(undefined, () => {
-    refreshSpies.garments();
-  });
-  return { refreshGarmentsAtom };
-});
-
-vi.mock("@/stores/dollAtoms", () => {
-  const refreshDollsAtom = atom(undefined, () => {
-    refreshSpies.dolls();
-  });
-  return { refreshDollsAtom };
-});
-
-const importAtoms = async () => await import("@/stores/pendingArchiveAtoms");
-
-const getLastToastAction = (): ToastAction | undefined => {
-  const lastCall = toastSpies.add.mock.calls.at(-1);
-  return lastCall?.[0]?.action;
-};
+const lastToastAction = (
+  store: Store,
+): { readonly onClick: () => void } | undefined =>
+  store.get(toastsAtom).at(-1)?.action;
 
 describe("pendingArchiveAtoms", () => {
   beforeEach(() => {
+    // 複数 toast が共存するテストで cuid 衝突を避けるため sequential を使う
+    setupCuid2({ mode: "sequential" });
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     vi.setSystemTime(FIXED_NOW);
-    toastSpies.add.mockClear();
-    toastSpies.dismiss.mockClear();
-    refreshSpies.garments.mockClear();
-    refreshSpies.dolls.mockClear();
   });
 
   afterEach(() => {
@@ -110,34 +62,32 @@ describe("pendingArchiveAtoms", () => {
 
   describe("requestArchiveAtom", () => {
     it("最初の request で toast 追加・pending 登録される", async () => {
-      const { requestArchiveAtom, pendingArchivesAtom } = await importAtoms();
       const store = createStore();
       await getDb().garments.add(createTestGarment({ id: "g-1" }));
 
       store.set(requestArchiveAtom, { id: "g-1", entityType: "garment" });
 
-      expect(toastSpies.add).toHaveBeenCalledTimes(1);
+      const toasts = store.get(toastsAtom);
+      expect(toasts).toHaveLength(1);
       const pending = store.get(pendingArchivesAtom);
       expect(pending).toHaveLength(1);
       expect(pending[0]?.id).toBe("g-1");
       expect(pending[0]?.entityType).toBe("garment");
-      expect(pending[0]?.toastId).toBe(TOAST_ID);
+      expect(pending[0]?.toastId).toBe(toasts[0]?.id);
     });
 
     it("同一 id・entityType の重複 request は無視される", async () => {
-      const { requestArchiveAtom, pendingArchivesAtom } = await importAtoms();
       const store = createStore();
       await getDb().garments.add(createTestGarment({ id: "g-1" }));
 
       store.set(requestArchiveAtom, { id: "g-1", entityType: "garment" });
       store.set(requestArchiveAtom, { id: "g-1", entityType: "garment" });
 
-      expect(toastSpies.add).toHaveBeenCalledTimes(1);
+      expect(store.get(toastsAtom)).toHaveLength(1);
       expect(store.get(pendingArchivesAtom)).toHaveLength(1);
     });
 
     it("entityType が異なれば同一 id でも別 pending として登録される", async () => {
-      const { requestArchiveAtom, pendingArchivesAtom } = await importAtoms();
       const store = createStore();
       await getDb().garments.add(createTestGarment({ id: "shared-id" }));
       await getDb().dolls.add(createTestDoll({ id: "shared-id" }));
@@ -149,13 +99,12 @@ describe("pendingArchiveAtoms", () => {
       store.set(requestArchiveAtom, { id: "shared-id", entityType: "doll" });
 
       expect(store.get(pendingArchivesAtom)).toHaveLength(2);
-      expect(toastSpies.add).toHaveBeenCalledTimes(2);
+      expect(store.get(toastsAtom)).toHaveLength(2);
     });
   });
 
   describe("timeout 経過後の自動 archive", () => {
-    it("garment: archivedAt が設定され、refreshGarmentsAtom が呼ばれる", async () => {
-      const { requestArchiveAtom, pendingArchivesAtom } = await importAtoms();
+    it("garment: archivedAt が設定され、syncQueue に GARMENT_UPDATE が積まれる", async () => {
       const store = createStore();
       await getDb().garments.add(
         createTestGarment({ id: "g-1", archivedAt: undefined }),
@@ -168,16 +117,13 @@ describe("pendingArchiveAtoms", () => {
       const stored = await getDb().garments.get("g-1");
       expect(stored?.archivedAt).toBe(archiveTime);
       expect(stored?.updatedAt).toBe(archiveTime);
-      expect(refreshSpies.garments).toHaveBeenCalledTimes(1);
-      expect(refreshSpies.dolls).not.toHaveBeenCalled();
 
       const queued = await getDb().syncQueue.toArray();
       expect(queued).toHaveLength(1);
       expect(queued[0]?.type).toBe(SYNC_ACTION_TYPE.GARMENT_UPDATE);
     });
 
-    it("doll: archivedAt が設定され、refreshDollsAtom が呼ばれる", async () => {
-      const { requestArchiveAtom, pendingArchivesAtom } = await importAtoms();
+    it("doll: archivedAt が設定され、syncQueue に DOLL_UPDATE が積まれる", async () => {
       const store = createStore();
       await getDb().dolls.add(
         createTestDoll({ id: "d-1", archivedAt: undefined }),
@@ -189,8 +135,6 @@ describe("pendingArchiveAtoms", () => {
 
       const stored = await getDb().dolls.get("d-1");
       expect(stored?.archivedAt).toBe(archiveTime);
-      expect(refreshSpies.dolls).toHaveBeenCalledTimes(1);
-      expect(refreshSpies.garments).not.toHaveBeenCalled();
 
       const queued = await getDb().syncQueue.toArray();
       expect(queued).toHaveLength(1);
@@ -198,7 +142,6 @@ describe("pendingArchiveAtoms", () => {
     });
 
     it("対象エンティティが DB に存在しない場合は syncQueue に追加されない", async () => {
-      const { requestArchiveAtom, pendingArchivesAtom } = await importAtoms();
       const store = createStore();
 
       store.set(requestArchiveAtom, {
@@ -209,44 +152,41 @@ describe("pendingArchiveAtoms", () => {
 
       const queued = await getDb().syncQueue.toArray();
       expect(queued).toHaveLength(0);
-      expect(refreshSpies.garments).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("cancel via toast action", () => {
     it("toast の onClick で cancel すると timer がクリアされ archive されない", async () => {
-      const { requestArchiveAtom, pendingArchivesAtom } = await importAtoms();
       const store = createStore();
       await getDb().garments.add(createTestGarment({ id: "g-1" }));
 
       store.set(requestArchiveAtom, { id: "g-1", entityType: "garment" });
 
-      const action = getLastToastAction();
+      const action = lastToastAction(store);
       action?.onClick();
 
-      expect(toastSpies.dismiss).toHaveBeenCalledWith(TOAST_ID);
+      expect(store.get(toastsAtom)).toHaveLength(0);
       expect(store.get(pendingArchivesAtom)).toHaveLength(0);
 
       await vi.advanceTimersByTimeAsync(ARCHIVE_DELAY_MS);
       const stored = await getDb().garments.get("g-1");
       expect(stored?.archivedAt).toBeUndefined();
-      expect(refreshSpies.garments).not.toHaveBeenCalled();
+      expect(await getDb().syncQueue.count()).toBe(0);
     });
 
-    it("pending に存在しない id の cancel では dismiss が呼ばれない", async () => {
-      const { requestArchiveAtom, pendingArchivesAtom } = await importAtoms();
+    it("pending に存在しない id の cancel では toast / pending の状態が変わらない", async () => {
       const store = createStore();
       await getDb().garments.add(createTestGarment({ id: "g-1" }));
 
       store.set(requestArchiveAtom, { id: "g-1", entityType: "garment" });
 
-      const action = getLastToastAction();
+      const action = lastToastAction(store);
       action?.onClick();
-      toastSpies.dismiss.mockClear();
+      expect(store.get(toastsAtom)).toHaveLength(0);
 
       // すでに pending に存在しないので二度目の onClick はガードされる
       action?.onClick();
-      expect(toastSpies.dismiss).not.toHaveBeenCalled();
+      expect(store.get(toastsAtom)).toHaveLength(0);
       expect(store.get(pendingArchivesAtom)).toHaveLength(0);
     });
   });

--- a/src/stores/pendingArchiveAtoms.test.ts
+++ b/src/stores/pendingArchiveAtoms.test.ts
@@ -1,9 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStore } from "jotai";
-import type { Atom } from "jotai";
 import { getDb } from "@/lib/db/dexie";
 import { SYNC_ACTION_TYPE } from "@/lib/constants";
-import { createTestDoll, createTestGarment } from "@/test/factories";
+import { createTestDoll, createTestGarment, FIXED_NOW } from "@/test/factories";
 import { setupCuid2 } from "@/test/mocks/modules/cuid2";
 import {
   pendingArchivesAtom,
@@ -12,7 +11,6 @@ import {
 import { toastsAtom } from "@/stores/toastAtoms";
 
 const ARCHIVE_DELAY_MS = 5000;
-const FIXED_NOW = new Date("2025-06-15T00:00:00Z").getTime();
 const FLUSH_TIMEOUT_MS = 1000;
 const FLUSH_POLL_INTERVAL_MS = 5;
 
@@ -31,15 +29,14 @@ const waitForCondition = async (check: () => boolean): Promise<boolean> => {
   return false;
 };
 
-const flushArchive = async (
-  store: Store,
-  pending: Atom<ReadonlyArray<{ readonly id: string }>>,
-) => {
+const flushArchive = async (store: Store) => {
   // setTimeout コールバックを起動する
   vi.advanceTimersByTime(ARCHIVE_DELAY_MS);
   // Dexie の async 操作を解決させるため real timers に戻す
   vi.useRealTimers();
-  const drained = await waitForCondition(() => store.get(pending).length === 0);
+  const drained = await waitForCondition(
+    () => store.get(pendingArchivesAtom).length === 0,
+  );
   expect(drained, "pendingArchives drained").toBe(true);
 };
 
@@ -112,7 +109,7 @@ describe("pendingArchiveAtoms", () => {
 
       store.set(requestArchiveAtom, { id: "g-1", entityType: "garment" });
       const archiveTime = FIXED_NOW + ARCHIVE_DELAY_MS;
-      await flushArchive(store, pendingArchivesAtom);
+      await flushArchive(store);
 
       const stored = await getDb().garments.get("g-1");
       expect(stored?.archivedAt).toBe(archiveTime);
@@ -131,7 +128,7 @@ describe("pendingArchiveAtoms", () => {
 
       store.set(requestArchiveAtom, { id: "d-1", entityType: "doll" });
       const archiveTime = FIXED_NOW + ARCHIVE_DELAY_MS;
-      await flushArchive(store, pendingArchivesAtom);
+      await flushArchive(store);
 
       const stored = await getDb().dolls.get("d-1");
       expect(stored?.archivedAt).toBe(archiveTime);
@@ -148,7 +145,7 @@ describe("pendingArchiveAtoms", () => {
         id: "missing-id",
         entityType: "garment",
       });
-      await flushArchive(store, pendingArchivesAtom);
+      await flushArchive(store);
 
       const queued = await getDb().syncQueue.toArray();
       expect(queued).toHaveLength(0);

--- a/src/stores/syncAtoms.test.ts
+++ b/src/stores/syncAtoms.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { atom, createStore } from "jotai";
+import { createStore } from "jotai";
 import { SYNC_ACTION_TYPE, SYNC_STATUS } from "@/lib/constants";
 import { getDb } from "@/lib/db/dexie";
 import {
@@ -15,6 +15,13 @@ import {
   trpcQuery,
   type RouterOutputs,
 } from "@/test/mocks/trpc/handlerFactory";
+import {
+  executeSyncAtom,
+  lastSyncErrorAtom,
+  pendingSyncCountAtom,
+  refreshPendingSyncCountAtom,
+  syncStatusAtom,
+} from "@/stores/syncAtoms";
 
 const pushSpy = vi.fn();
 const pullSpy = vi.fn();
@@ -52,68 +59,6 @@ const installSync = ({
   );
 };
 
-const refreshSpies = vi.hoisted(() => ({
-  coordinates: vi.fn(),
-  dolls: vi.fn(),
-  garments: vi.fn(),
-  storageCases: vi.fn(),
-  storageLocations: vi.fn(),
-}));
-
-vi.mock("@/stores/coordinateAtoms", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/stores/coordinateAtoms")
-  >("@/stores/coordinateAtoms");
-  return {
-    ...actual,
-    refreshCoordinatesAtom: atom(undefined, () => {
-      refreshSpies.coordinates();
-    }),
-  };
-});
-
-vi.mock("@/stores/dollAtoms", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/stores/dollAtoms")>(
-      "@/stores/dollAtoms",
-    );
-  return {
-    ...actual,
-    refreshDollsAtom: atom(undefined, () => {
-      refreshSpies.dolls();
-    }),
-  };
-});
-
-vi.mock("@/stores/garmentAtoms", async () => {
-  const actual = await vi.importActual<typeof import("@/stores/garmentAtoms")>(
-    "@/stores/garmentAtoms",
-  );
-  return {
-    ...actual,
-    refreshGarmentsAtom: atom(undefined, () => {
-      refreshSpies.garments();
-    }),
-  };
-});
-
-vi.mock("@/stores/locationAtoms", async () => {
-  const actual = await vi.importActual<typeof import("@/stores/locationAtoms")>(
-    "@/stores/locationAtoms",
-  );
-  return {
-    ...actual,
-    refreshStorageCasesAtom: atom(undefined, () => {
-      refreshSpies.storageCases();
-    }),
-    refreshStorageLocationsAtom: atom(undefined, () => {
-      refreshSpies.storageLocations();
-    }),
-  };
-});
-
-const importSyncAtoms = async () => await import("@/stores/syncAtoms");
-
 const emptyServerState = () => ({
   garments: [],
   dolls: [],
@@ -126,11 +71,6 @@ describe("syncAtoms", () => {
   beforeEach(() => {
     pushSpy.mockReset();
     pullSpy.mockReset();
-    refreshSpies.coordinates.mockReset();
-    refreshSpies.dolls.mockReset();
-    refreshSpies.garments.mockReset();
-    refreshSpies.storageCases.mockReset();
-    refreshSpies.storageLocations.mockReset();
   });
 
   afterEach(() => {
@@ -139,10 +79,20 @@ describe("syncAtoms", () => {
 
   describe("executeSyncAtom", () => {
     it(
-      "push と pull が成功すると refresh atom がすべて呼ばれ、状態が IDLE に戻る",
+      "push と pull が成功すると syncQueue が消化され、Dexie が pull payload で置換され IDLE に戻る",
       { timeout: 15_000 },
       async () => {
-        installSync({});
+        installSync({
+          pull: {
+            resolve: {
+              garments: [createTestGarment({ id: "g-pull" })],
+              dolls: [],
+              coordinates: [],
+              storageCases: [],
+              storageLocations: [],
+            },
+          },
+        });
 
         await getDb().syncQueue.bulkAdd([
           {
@@ -153,22 +103,15 @@ describe("syncAtoms", () => {
         ]);
 
         const store = createStore();
-        const { executeSyncAtom, syncStatusAtom, lastSyncErrorAtom } =
-          await importSyncAtoms();
-
         await store.set(executeSyncAtom);
 
         expect(pushSpy).toHaveBeenCalledTimes(1);
         expect(pullSpy).toHaveBeenCalledTimes(1);
-        expect(refreshSpies.coordinates).toHaveBeenCalledTimes(1);
-        expect(refreshSpies.dolls).toHaveBeenCalledTimes(1);
-        expect(refreshSpies.garments).toHaveBeenCalledTimes(1);
-        expect(refreshSpies.storageCases).toHaveBeenCalledTimes(1);
-        expect(refreshSpies.storageLocations).toHaveBeenCalledTimes(1);
         expect(store.get(syncStatusAtom)).toBe(SYNC_STATUS.IDLE);
         expect(store.get(lastSyncErrorAtom)).toBeUndefined();
-        const remaining = await getDb().syncQueue.count();
-        expect(remaining).toBe(0);
+        expect(await getDb().syncQueue.count()).toBe(0);
+        const garments = await getDb().garments.toArray();
+        expect(garments.map((g) => g.id)).toEqual(["g-pull"]);
       },
     );
 
@@ -184,7 +127,6 @@ describe("syncAtoms", () => {
       ]);
 
       const store = createStore();
-      const { executeSyncAtom } = await importSyncAtoms();
       await store.set(executeSyncAtom);
 
       expect(pushSpy).not.toHaveBeenCalled();
@@ -196,7 +138,6 @@ describe("syncAtoms", () => {
       installSync({});
 
       const store = createStore();
-      const { executeSyncAtom, syncStatusAtom } = await importSyncAtoms();
       await store.set(executeSyncAtom);
 
       expect(pushSpy).not.toHaveBeenCalled();
@@ -204,7 +145,7 @@ describe("syncAtoms", () => {
       expect(store.get(syncStatusAtom)).toBe(SYNC_STATUS.IDLE);
     });
 
-    it("push 失敗時は ERROR 状態と lastSyncError がセットされ、refresh は呼ばれない", async () => {
+    it("push 失敗時は ERROR 状態と lastSyncError がセットされ、Dexie が pull で clear されない", async () => {
       installSync({ push: { throwError: new Error("push exploded") } });
 
       await getDb().syncQueue.bulkAdd([
@@ -214,30 +155,26 @@ describe("syncAtoms", () => {
           createdAt: FIXED_NOW,
         },
       ]);
+      // pull が走らないため、ローカルの stale エントリは残るはず
+      await getDb().garments.add(createTestGarment({ id: "stale" }));
 
       const store = createStore();
-      const { executeSyncAtom, syncStatusAtom, lastSyncErrorAtom } =
-        await importSyncAtoms();
-
       await store.set(executeSyncAtom);
 
       expect(pullSpy).not.toHaveBeenCalled();
       expect(store.get(syncStatusAtom)).toBe(SYNC_STATUS.ERROR);
       expect(store.get(lastSyncErrorAtom)).toBe("push exploded");
-      expect(refreshSpies.dolls).not.toHaveBeenCalled();
-      expect(refreshSpies.garments).not.toHaveBeenCalled();
-      expect(refreshSpies.storageCases).not.toHaveBeenCalled();
-      expect(refreshSpies.storageLocations).not.toHaveBeenCalled();
-      expect(refreshSpies.coordinates).not.toHaveBeenCalled();
+      // pull の transaction.clear() が走っていないので stale が残る
+      const garments = await getDb().garments.toArray();
+      expect(garments.map((g) => g.id)).toEqual(["stale"]);
+      // syncQueue も削除されない（push 失敗で bulkDelete 前に return）
+      expect(await getDb().syncQueue.count()).toBe(1);
     });
 
     it("push が string をスローした場合は server からの message が lastSyncError に入る", async () => {
       installSync({ push: { throwError: "boom" } });
 
       const store = createStore();
-      const { executeSyncAtom, lastSyncErrorAtom, syncStatusAtom } =
-        await importSyncAtoms();
-
       await getDb().syncQueue.bulkAdd([
         {
           type: SYNC_ACTION_TYPE.DOLL_CREATE,
@@ -252,18 +189,29 @@ describe("syncAtoms", () => {
       expect(store.get(lastSyncErrorAtom)).toBe("boom");
     });
 
-    it("pull 失敗時も ERROR 状態と lastSyncError がセットされる", async () => {
+    it("pull 失敗時も ERROR 状態と lastSyncError がセットされ、Dexie は事前 seed のまま", async () => {
       installSync({ pull: { throwError: new Error("pull broken") } });
 
-      const store = createStore();
-      const { executeSyncAtom, syncStatusAtom, lastSyncErrorAtom } =
-        await importSyncAtoms();
+      // push が成功したあと pull が失敗するパス。push 成功で syncQueue は削除される
+      await getDb().syncQueue.bulkAdd([
+        {
+          type: SYNC_ACTION_TYPE.GARMENT_CREATE,
+          payload: { id: "g-1" },
+          createdAt: FIXED_NOW,
+        },
+      ]);
+      await getDb().garments.add(createTestGarment({ id: "stale" }));
 
+      const store = createStore();
       await store.set(executeSyncAtom);
 
       expect(store.get(syncStatusAtom)).toBe(SYNC_STATUS.ERROR);
       expect(store.get(lastSyncErrorAtom)).toBe("pull broken");
-      expect(refreshSpies.dolls).not.toHaveBeenCalled();
+      // push 成功 → syncQueue は消化されている
+      expect(await getDb().syncQueue.count()).toBe(0);
+      // pull 失敗 → garments は事前 seed のまま
+      const garments = await getDb().garments.toArray();
+      expect(garments.map((g) => g.id)).toEqual(["stale"]);
     });
 
     it("pull で得たエンティティが Dexie に書き戻される", async () => {
@@ -302,7 +250,6 @@ describe("syncAtoms", () => {
       await getDb().garments.add(createTestGarment({ id: "stale" }));
 
       const store = createStore();
-      const { executeSyncAtom } = await importSyncAtoms();
       await store.set(executeSyncAtom);
 
       const garments = await getDb().garments.toArray();
@@ -324,7 +271,6 @@ describe("syncAtoms", () => {
       installSync({});
 
       const store = createStore();
-      const { executeSyncAtom, lastSyncErrorAtom } = await importSyncAtoms();
       store.set(lastSyncErrorAtom, "前回のエラー");
       expect(store.get(lastSyncErrorAtom)).toBe("前回のエラー");
 
@@ -350,16 +296,12 @@ describe("syncAtoms", () => {
       ]);
 
       const store = createStore();
-      const { pendingSyncCountAtom } = await importSyncAtoms();
       const count = await store.get(pendingSyncCountAtom);
       expect(count).toBe(2);
     });
 
     it("refreshPendingSyncCountAtom の発火後に再カウントされる", async () => {
       const store = createStore();
-      const { pendingSyncCountAtom, refreshPendingSyncCountAtom } =
-        await importSyncAtoms();
-
       expect(await store.get(pendingSyncCountAtom)).toBe(0);
 
       await getDb().syncQueue.add({
@@ -376,7 +318,6 @@ describe("syncAtoms", () => {
       vi.stubGlobal("indexedDB", undefined);
 
       const store = createStore();
-      const { pendingSyncCountAtom } = await importSyncAtoms();
       const count = await store.get(pendingSyncCountAtom);
       expect(count).toBe(0);
     });

--- a/src/stores/syncAtoms.test.ts
+++ b/src/stores/syncAtoms.test.ts
@@ -78,42 +78,38 @@ describe("syncAtoms", () => {
   });
 
   describe("executeSyncAtom", () => {
-    it(
-      "push と pull が成功すると syncQueue が消化され、Dexie が pull payload で置換され IDLE に戻る",
-      { timeout: 15_000 },
-      async () => {
-        installSync({
-          pull: {
-            resolve: {
-              garments: [createTestGarment({ id: "g-pull" })],
-              dolls: [],
-              coordinates: [],
-              storageCases: [],
-              storageLocations: [],
-            },
+    it("push と pull が成功すると syncQueue が消化され、Dexie が pull payload で置換され IDLE に戻る", async () => {
+      installSync({
+        pull: {
+          resolve: {
+            garments: [createTestGarment({ id: "g-pull" })],
+            dolls: [],
+            coordinates: [],
+            storageCases: [],
+            storageLocations: [],
           },
-        });
+        },
+      });
 
-        await getDb().syncQueue.bulkAdd([
-          {
-            type: SYNC_ACTION_TYPE.GARMENT_CREATE,
-            payload: { id: "g-1" },
-            createdAt: FIXED_NOW,
-          },
-        ]);
+      await getDb().syncQueue.bulkAdd([
+        {
+          type: SYNC_ACTION_TYPE.GARMENT_CREATE,
+          payload: { id: "g-1" },
+          createdAt: FIXED_NOW,
+        },
+      ]);
 
-        const store = createStore();
-        await store.set(executeSyncAtom);
+      const store = createStore();
+      await store.set(executeSyncAtom);
 
-        expect(pushSpy).toHaveBeenCalledTimes(1);
-        expect(pullSpy).toHaveBeenCalledTimes(1);
-        expect(store.get(syncStatusAtom)).toBe(SYNC_STATUS.IDLE);
-        expect(store.get(lastSyncErrorAtom)).toBeUndefined();
-        expect(await getDb().syncQueue.count()).toBe(0);
-        const garments = await getDb().garments.toArray();
-        expect(garments.map((g) => g.id)).toEqual(["g-pull"]);
-      },
-    );
+      expect(pushSpy).toHaveBeenCalledTimes(1);
+      expect(pullSpy).toHaveBeenCalledTimes(1);
+      expect(store.get(syncStatusAtom)).toBe(SYNC_STATUS.IDLE);
+      expect(store.get(lastSyncErrorAtom)).toBeUndefined();
+      expect(await getDb().syncQueue.count()).toBe(0);
+      const garments = await getDb().garments.toArray();
+      expect(garments.map((g) => g.id)).toEqual(["g-pull"]);
+    });
 
     it("無効な type の queue 項目は push リクエストから除外される", async () => {
       installSync({});
@@ -148,15 +144,16 @@ describe("syncAtoms", () => {
     it("push 失敗時は ERROR 状態と lastSyncError がセットされ、Dexie が pull で clear されない", async () => {
       installSync({ push: { throwError: new Error("push exploded") } });
 
-      await getDb().syncQueue.bulkAdd([
-        {
-          type: SYNC_ACTION_TYPE.GARMENT_CREATE,
-          payload: { id: "g-1" },
-          createdAt: FIXED_NOW,
-        },
+      await Promise.all([
+        getDb().syncQueue.bulkAdd([
+          {
+            type: SYNC_ACTION_TYPE.GARMENT_CREATE,
+            payload: { id: "g-1" },
+            createdAt: FIXED_NOW,
+          },
+        ]),
+        getDb().garments.add(createTestGarment({ id: "stale" })),
       ]);
-      // pull が走らないため、ローカルの stale エントリは残るはず
-      await getDb().garments.add(createTestGarment({ id: "stale" }));
 
       const store = createStore();
       await store.set(executeSyncAtom);
@@ -164,10 +161,9 @@ describe("syncAtoms", () => {
       expect(pullSpy).not.toHaveBeenCalled();
       expect(store.get(syncStatusAtom)).toBe(SYNC_STATUS.ERROR);
       expect(store.get(lastSyncErrorAtom)).toBe("push exploded");
-      // pull の transaction.clear() が走っていないので stale が残る
+      // pull が走らないので transaction.clear() が無く、push 失敗で bulkDelete 前に return するため両方残る
       const garments = await getDb().garments.toArray();
       expect(garments.map((g) => g.id)).toEqual(["stale"]);
-      // syncQueue も削除されない（push 失敗で bulkDelete 前に return）
       expect(await getDb().syncQueue.count()).toBe(1);
     });
 
@@ -189,27 +185,26 @@ describe("syncAtoms", () => {
       expect(store.get(lastSyncErrorAtom)).toBe("boom");
     });
 
-    it("pull 失敗時も ERROR 状態と lastSyncError がセットされ、Dexie は事前 seed のまま", async () => {
+    it("pull 失敗時は push 由来の syncQueue 消化までは進むが Dexie は事前 seed のまま", async () => {
       installSync({ pull: { throwError: new Error("pull broken") } });
 
-      // push が成功したあと pull が失敗するパス。push 成功で syncQueue は削除される
-      await getDb().syncQueue.bulkAdd([
-        {
-          type: SYNC_ACTION_TYPE.GARMENT_CREATE,
-          payload: { id: "g-1" },
-          createdAt: FIXED_NOW,
-        },
+      await Promise.all([
+        getDb().syncQueue.bulkAdd([
+          {
+            type: SYNC_ACTION_TYPE.GARMENT_CREATE,
+            payload: { id: "g-1" },
+            createdAt: FIXED_NOW,
+          },
+        ]),
+        getDb().garments.add(createTestGarment({ id: "stale" })),
       ]);
-      await getDb().garments.add(createTestGarment({ id: "stale" }));
 
       const store = createStore();
       await store.set(executeSyncAtom);
 
       expect(store.get(syncStatusAtom)).toBe(SYNC_STATUS.ERROR);
       expect(store.get(lastSyncErrorAtom)).toBe("pull broken");
-      // push 成功 → syncQueue は消化されている
       expect(await getDb().syncQueue.count()).toBe(0);
-      // pull 失敗 → garments は事前 seed のまま
       const garments = await getDb().garments.toArray();
       expect(garments.map((g) => g.id)).toEqual(["stale"]);
     });
@@ -252,11 +247,14 @@ describe("syncAtoms", () => {
       const store = createStore();
       await store.set(executeSyncAtom);
 
-      const garments = await getDb().garments.toArray();
-      const dolls = await getDb().dolls.toArray();
-      const coordinates = await getDb().coordinates.toArray();
-      const cases = await getDb().storageCases.toArray();
-      const locations = await getDb().storageLocations.toArray();
+      const [garments, dolls, coordinates, cases, locations] =
+        await Promise.all([
+          getDb().garments.toArray(),
+          getDb().dolls.toArray(),
+          getDb().coordinates.toArray(),
+          getDb().storageCases.toArray(),
+          getDb().storageLocations.toArray(),
+        ]);
 
       expect(garments.map((g) => g.id)).toEqual(["g-pull"]);
       expect(dolls.map((d) => d.id)).toEqual(["d-pull"]);


### PR DESCRIPTION
## Summary

- `src/stores/syncAtoms.test.ts` / `src/stores/pendingArchiveAtoms.test.ts` から atom 系の `vi.mock`（coordinateAtoms / dollAtoms / garmentAtoms / locationAtoms / toastAtoms の refresh / toast 系 atom）を全撤廃。
- 実 atom + 実 Dexie（fake-indexeddb）+ tRPC dispatcher（`trpcMutation` / `trpcQuery`）の組合せで、`push → syncQueue 消化` / `pull → Dexie 置換` / `archive → toast` / `cancel → toast dismiss` といった**観測可能な状態遷移**として「振る舞い」を検証する形に組み替え。
- 「refresh が N 回呼ばれた」という実装詳細の assert は撤廃。失敗ケースは pull 由来の Dexie clear が走らないことを Dexie 直接 verify で代替。
- pendingArchive 側は Toast の id 衝突を避けるため `setupCuid2({ mode: "sequential" })` を `beforeEach` で導入。

## Test plan

- [x] `pnpm vitest run src/stores/syncAtoms.test.ts src/stores/pendingArchiveAtoms.test.ts` — 19 tests pass
- [x] `npx tsc-files --noEmit -p tsconfig.app.json src/stores/syncAtoms.test.ts src/stores/pendingArchiveAtoms.test.ts`
- [x] `npx eslint src/stores/syncAtoms.test.ts src/stores/pendingArchiveAtoms.test.ts`
- [x] `pnpm precheck:full` — 1154/1154 tests green
- [x] `pnpm test:coverage` — branches **81.79%** (>= 80% 維持)

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)