### PR TITLE
feat(ui): UI 基盤拡張 — Button/IconButton/Card 拡張と新規パーツ追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,7 +32,7 @@
   --color-text-tertiary: oklch(0.6 0.01 285);
   --color-text-inverse: oklch(0.98 0 0);
 
-  /* === Confidence === */
+  /* === Confidence / Status === */
   --color-confirmed: oklch(0.72 0.19 142);
   --color-uncertain: oklch(0.8 0.18 84);
   --color-unknown: oklch(0.63 0.24 29);

--- a/src/components/settings/account/SectionCard.tsx
+++ b/src/components/settings/account/SectionCard.tsx
@@ -1,21 +1,3 @@
-type Props = {
-  readonly title: React.ReactNode;
-  readonly description?: React.ReactNode;
-  readonly children: React.ReactNode;
-};
-
-const SectionCard = ({ title, description, children }: Props) => (
-  <section className="rounded-2xl border border-border-default bg-surface-overlay p-5">
-    <header className="mb-4 flex flex-col gap-1">
-      <h3 className="font-display text-base font-bold text-text-primary">
-        {title}
-      </h3>
-      {description !== undefined && (
-        <p className="text-xs text-text-tertiary">{description}</p>
-      )}
-    </header>
-    {children}
-  </section>
-);
+import SectionCard from "@/components/ui/SectionCard";
 
 export default SectionCard;

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -15,9 +15,9 @@ type Props = {
 const VARIANT_STYLES: Record<BadgeVariant, string> = {
   default: "bg-gray-100 text-text-secondary",
   primary: "bg-primary-100 text-primary-700",
-  confirmed: "bg-emerald-50 text-emerald-700",
-  uncertain: "bg-amber-50 text-amber-700",
-  unknown: "bg-orange-50 text-orange-700",
+  confirmed: "bg-confirmed/10 text-success",
+  uncertain: "bg-uncertain/15 text-text-primary",
+  unknown: "bg-unknown/10 text-danger",
 };
 
 const Badge = ({ variant = "default", children }: Props) => (

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,6 +1,12 @@
 import clsx from "clsx";
 
-type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "ghost"
+  | "danger"
+  | "outline"
+  | "danger-solid";
 type ButtonSize = "sm" | "md" | "lg";
 
 type Props = {
@@ -17,7 +23,11 @@ const VARIANT_STYLES: Record<ButtonVariant, string> = {
     "bg-primary-100 text-primary-700 hover:bg-primary-200 active:bg-primary-300",
   ghost:
     "bg-transparent text-text-secondary hover:bg-primary-50 active:bg-primary-100",
-  danger: "bg-red-50 text-danger hover:bg-red-100 active:bg-red-200",
+  danger: "bg-danger/10 text-danger hover:bg-danger/15 active:bg-danger/25",
+  outline:
+    "border border-border-default bg-surface-overlay text-text-secondary hover:bg-primary-50 hover:text-primary-700",
+  "danger-solid":
+    "bg-danger text-text-inverse hover:opacity-90 active:opacity-80",
 };
 
 const SIZE_STYLES: Record<ButtonSize, string> = {
@@ -25,6 +35,28 @@ const SIZE_STYLES: Record<ButtonSize, string> = {
   md: "h-10 px-4 text-sm",
   lg: "h-12 px-6 text-base",
 };
+
+type ButtonClassNameOptions = {
+  readonly variant?: ButtonVariant;
+  readonly size?: ButtonSize;
+  readonly fullWidth?: boolean;
+  readonly disabled?: boolean;
+};
+
+export const buttonClassName = ({
+  variant = "primary",
+  size = "md",
+  fullWidth = false,
+  disabled = false,
+}: ButtonClassNameOptions = {}) =>
+  clsx(
+    "inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors",
+    "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+    VARIANT_STYLES[variant],
+    SIZE_STYLES[size],
+    fullWidth && "w-full",
+    disabled && "opacity-50",
+  );
 
 const Button = ({
   variant = "primary",
@@ -35,14 +67,12 @@ const Button = ({
   ...rest
 }: Props) => (
   <button
-    className={clsx(
-      "inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors",
-      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
-      VARIANT_STYLES[variant],
-      SIZE_STYLES[size],
-      fullWidth && "w-full",
-      disabled && "opacity-50",
-    )}
+    className={buttonClassName({
+      variant,
+      size,
+      fullWidth,
+      disabled: disabled === true,
+    })}
     disabled={disabled}
     {...rest}
   >

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,22 +1,108 @@
 import clsx from "clsx";
 
-type Props = {
+type CardPadding = "sm" | "md" | "lg";
+type CardRadius = "md" | "lg";
+
+const PADDING_STYLES: Record<CardPadding, string> = {
+  sm: "p-3",
+  md: "p-4",
+  lg: "p-5",
+};
+
+const RADIUS_STYLES: Record<CardRadius, string> = {
+  md: "rounded-xl",
+  lg: "rounded-2xl",
+};
+
+type BaseProps = {
   readonly children: React.ReactNode;
   readonly hoverable?: boolean;
+  readonly padding?: CardPadding;
+  readonly radius?: CardRadius;
   readonly className?: string;
 };
 
-const Card = ({ children, hoverable = false, className }: Props) => (
-  <div
-    className={clsx(
-      "rounded-xl border border-border-default bg-surface-overlay p-4 shadow-card",
-      hoverable &&
-        "transition-all hover:-translate-y-0.5 hover:shadow-md active:translate-y-0",
-      className,
-    )}
-  >
-    {children}
-  </div>
-);
+type StaticProps = BaseProps & {
+  readonly clickable?: false;
+  readonly onClick?: never;
+  readonly disabled?: never;
+  readonly type?: never;
+};
+
+type ClickableProps = BaseProps & {
+  readonly clickable: true;
+  readonly onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  readonly disabled?: boolean;
+  readonly type?: "button" | "submit";
+};
+
+type Props = StaticProps | ClickableProps;
+
+const cardClassName = ({
+  hoverable,
+  padding,
+  radius,
+  clickable,
+  className,
+}: {
+  readonly hoverable: boolean;
+  readonly padding: CardPadding;
+  readonly radius: CardRadius;
+  readonly clickable: boolean;
+  readonly className: string | undefined;
+}) =>
+  clsx(
+    "border border-border-default bg-surface-overlay shadow-card",
+    PADDING_STYLES[padding],
+    RADIUS_STYLES[radius],
+    hoverable &&
+      "transition-all hover:-translate-y-0.5 hover:shadow-md active:translate-y-0",
+    clickable &&
+      "text-left w-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+    className,
+  );
+
+const Card = (props: Props) => {
+  const {
+    children,
+    hoverable = false,
+    padding = "md",
+    radius = "md",
+    className,
+  } = props;
+
+  if (props.clickable === true) {
+    return (
+      <button
+        type={props.type ?? "button"}
+        onClick={props.onClick}
+        disabled={props.disabled}
+        className={cardClassName({
+          hoverable,
+          padding,
+          radius,
+          clickable: true,
+          className,
+        })}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className={cardClassName({
+        hoverable,
+        padding,
+        radius,
+        clickable: false,
+        className,
+      })}
+    >
+      {children}
+    </div>
+  );
+};
 
 export default Card;

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -1,0 +1,29 @@
+import clsx from "clsx";
+
+type Props = {
+  readonly selected: boolean;
+  readonly onClick?: () => void;
+  readonly children: React.ReactNode;
+  readonly disabled?: boolean;
+};
+
+const Chip = ({ selected, onClick, children, disabled = false }: Props) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    aria-pressed={selected}
+    className={clsx(
+      "rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+      selected
+        ? "bg-primary-500 text-text-inverse"
+        : "border border-border-default bg-surface-overlay text-text-secondary hover:bg-primary-50",
+      disabled && "pointer-events-none opacity-50",
+    )}
+  >
+    {children}
+  </button>
+);
+
+export default Chip;

--- a/src/components/ui/ErrorAlert.tsx
+++ b/src/components/ui/ErrorAlert.tsx
@@ -5,7 +5,7 @@ type Props = {
 const ErrorAlert = ({ children }: Props) => (
   <p
     role="alert"
-    className="rounded-lg border border-danger/30 bg-red-50/70 px-3 py-2 text-xs text-danger"
+    className="rounded-lg border border-danger/30 bg-danger/8 px-3 py-2 text-xs text-danger"
   >
     {children}
   </p>

--- a/src/components/ui/FormShell.tsx
+++ b/src/components/ui/FormShell.tsx
@@ -1,0 +1,29 @@
+import clsx from "clsx";
+
+type FormGap = "sm" | "md" | "lg";
+
+type Props = {
+  readonly gap?: FormGap;
+  readonly onSubmit: NonNullable<
+    React.FormHTMLAttributes<HTMLFormElement>["onSubmit"]
+  >;
+  readonly children: React.ReactNode;
+  readonly className?: string;
+};
+
+const GAP_STYLES: Record<FormGap, string> = {
+  sm: "gap-3",
+  md: "gap-4",
+  lg: "gap-6",
+};
+
+const FormShell = ({ gap = "md", onSubmit, children, className }: Props) => (
+  <form
+    onSubmit={onSubmit}
+    className={clsx("flex flex-col", GAP_STYLES[gap], className)}
+  >
+    {children}
+  </form>
+);
+
+export default FormShell;

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -1,28 +1,54 @@
 import clsx from "clsx";
 import type { LucideIcon } from "lucide-react";
 
+type IconButtonSize = "xs" | "sm" | "md" | "lg";
+type IconButtonVariant = "default" | "primary" | "danger";
+
 type Props = {
   readonly icon: LucideIcon;
   readonly label: string;
-  readonly size?: "sm" | "md";
-  readonly variant?: "default" | "primary" | "danger";
+  readonly size?: IconButtonSize;
+  readonly variant?: IconButtonVariant;
 } & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "className">;
 
 const SIZE_STYLES = {
+  xs: "size-7",
   sm: "size-8",
-  md: "size-10",
-} as const;
+  md: "size-9",
+  lg: "size-10",
+} as const satisfies Record<IconButtonSize, string>;
 
 const VARIANT_STYLES = {
   default: "text-text-secondary hover:bg-primary-50 active:bg-primary-100",
   primary: "text-primary-500 hover:bg-primary-50 active:bg-primary-100",
-  danger: "text-danger hover:bg-red-50 active:bg-red-100",
-} as const;
+  danger: "text-danger hover:bg-danger/15 active:bg-danger/25",
+} as const satisfies Record<IconButtonVariant, string>;
 
 const ICON_SIZES = {
+  xs: "size-3.5",
   sm: "size-4",
-  md: "size-5",
-} as const;
+  md: "size-4",
+  lg: "size-5",
+} as const satisfies Record<IconButtonSize, string>;
+
+type IconButtonClassNameOptions = {
+  readonly size?: IconButtonSize;
+  readonly variant?: IconButtonVariant;
+  readonly disabled?: boolean;
+};
+
+export const iconButtonClassName = ({
+  size = "md",
+  variant = "default",
+  disabled = false,
+}: IconButtonClassNameOptions = {}) =>
+  clsx(
+    "inline-flex items-center justify-center rounded-lg transition-colors",
+    "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+    SIZE_STYLES[size],
+    VARIANT_STYLES[variant],
+    disabled && "pointer-events-none opacity-50",
+  );
 
 const IconButton = ({
   icon: Icon,
@@ -34,13 +60,11 @@ const IconButton = ({
 }: Props) => (
   <button
     aria-label={label}
-    className={clsx(
-      "inline-flex items-center justify-center rounded-lg transition-colors",
-      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
-      SIZE_STYLES[size],
-      VARIANT_STYLES[variant],
-      disabled && "pointer-events-none opacity-50",
-    )}
+    className={iconButtonClassName({
+      size,
+      variant,
+      disabled: disabled === true,
+    })}
     disabled={disabled}
     {...rest}
   >

--- a/src/components/ui/PageButton.tsx
+++ b/src/components/ui/PageButton.tsx
@@ -1,0 +1,29 @@
+import clsx from "clsx";
+
+type Props = {
+  readonly page: number;
+  readonly currentPage: number;
+  readonly onClick: (page: number) => void;
+};
+
+const PageButton = ({ page, currentPage, onClick }: Props) => {
+  const active = page === currentPage;
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(page)}
+      aria-current={active ? "page" : undefined}
+      className={clsx(
+        "size-8 rounded-lg text-xs font-medium transition-colors",
+        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+        active
+          ? "bg-primary-500 text-text-inverse"
+          : "border border-border-default bg-surface-overlay text-text-secondary hover:bg-primary-50",
+      )}
+    >
+      {page}
+    </button>
+  );
+};
+
+export default PageButton;

--- a/src/components/ui/SectionCard.tsx
+++ b/src/components/ui/SectionCard.tsx
@@ -1,0 +1,21 @@
+type Props = {
+  readonly title: React.ReactNode;
+  readonly description?: React.ReactNode;
+  readonly children: React.ReactNode;
+};
+
+const SectionCard = ({ title, description, children }: Props) => (
+  <section className="rounded-2xl border border-border-default bg-surface-overlay p-5">
+    <header className="mb-4 flex flex-col gap-1">
+      <h3 className="font-display text-base font-bold text-text-primary">
+        {title}
+      </h3>
+      {description !== undefined && (
+        <p className="text-xs text-text-tertiary">{description}</p>
+      )}
+    </header>
+    {children}
+  </section>
+);
+
+export default SectionCard;

--- a/src/components/ui/TextButton.tsx
+++ b/src/components/ui/TextButton.tsx
@@ -1,0 +1,39 @@
+import clsx from "clsx";
+
+type TextButtonVariant = "primary" | "secondary" | "muted";
+
+type Props = {
+  readonly variant?: TextButtonVariant;
+  readonly onClick: () => void;
+  readonly children: React.ReactNode;
+  readonly disabled?: boolean;
+};
+
+const VARIANT_STYLES: Record<TextButtonVariant, string> = {
+  primary: "text-primary-500 hover:text-primary-600",
+  secondary: "text-text-secondary hover:text-text-primary",
+  muted: "text-text-tertiary hover:text-text-secondary",
+};
+
+const TextButton = ({
+  variant = "primary",
+  onClick,
+  children,
+  disabled = false,
+}: Props) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    className={clsx(
+      "text-sm font-medium transition-colors",
+      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+      VARIANT_STYLES[variant],
+      disabled && "pointer-events-none opacity-50",
+    )}
+  >
+    {children}
+  </button>
+);
+
+export default TextButton;

--- a/src/components/ui/__tests__/Button.test.tsx
+++ b/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Button, { buttonClassName } from "@/components/ui/Button";
+
+const VARIANTS = [
+  "primary",
+  "secondary",
+  "ghost",
+  "danger",
+  "outline",
+  "danger-solid",
+] as const;
+
+const SIZES = ["sm", "md", "lg"] as const;
+
+describe("Button", () => {
+  describe("variant × size の組み合わせ", () => {
+    VARIANTS.forEach((variant) => {
+      SIZES.forEach((size) => {
+        it(`variant=${variant} size=${size} がボタンとしてレンダリングされる`, () => {
+          render(
+            <Button variant={variant} size={size}>
+              ラベル
+            </Button>,
+          );
+          expect(
+            screen.getByRole("button", { name: "ラベル" }),
+          ).toBeInTheDocument();
+        });
+      });
+    });
+  });
+
+  it("disabled が反映される", () => {
+    render(<Button disabled>ラベル</Button>);
+    expect(screen.getByRole("button", { name: "ラベル" })).toBeDisabled();
+  });
+
+  it("fullWidth で w-full クラスが付与される", () => {
+    render(<Button fullWidth>ラベル</Button>);
+    expect(screen.getByRole("button", { name: "ラベル" })).toHaveClass(
+      "w-full",
+    );
+  });
+
+  it("クリックで onClick が呼ばれる", async () => {
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>ラベル</Button>);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "ラベル" }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("outline variant が border クラスを含む", () => {
+    render(<Button variant="outline">外枠</Button>);
+    expect(screen.getByRole("button", { name: "外枠" })).toHaveClass(
+      "border-border-default",
+    );
+  });
+
+  it("danger-solid variant が bg-danger を含む", () => {
+    render(<Button variant="danger-solid">削除</Button>);
+    expect(screen.getByRole("button", { name: "削除" })).toHaveClass(
+      "bg-danger",
+    );
+  });
+});
+
+describe("buttonClassName", () => {
+  it("単体で呼び出せて clsx 由来の文字列を返す", () => {
+    const className = buttonClassName({ variant: "primary", size: "md" });
+    expect(typeof className).toBe("string");
+    expect(className).toContain("rounded-lg");
+    expect(className).toContain("bg-primary-500");
+    expect(className).toContain("h-10");
+  });
+
+  it("引数なしで既定値が適用される", () => {
+    const className = buttonClassName();
+    expect(className).toContain("bg-primary-500");
+    expect(className).toContain("h-10");
+  });
+
+  it("fullWidth で w-full が含まれる", () => {
+    expect(buttonClassName({ fullWidth: true })).toContain("w-full");
+  });
+
+  it("disabled で opacity-50 が含まれる", () => {
+    expect(buttonClassName({ disabled: true })).toContain("opacity-50");
+  });
+});

--- a/src/components/ui/__tests__/Card.test.tsx
+++ b/src/components/ui/__tests__/Card.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Card from "@/components/ui/Card";
+
+describe("Card", () => {
+  it("既定で div としてレンダリングされ、p-4 と rounded-xl を持つ", () => {
+    render(
+      <Card>
+        <span>子要素</span>
+      </Card>,
+    );
+    const card = screen.getByText("子要素").parentElement;
+    expect(card?.tagName).toBe("DIV");
+    expect(card).toHaveClass("p-4");
+    expect(card).toHaveClass("rounded-xl");
+  });
+
+  it("padding=sm で p-3 が付く", () => {
+    render(
+      <Card padding="sm">
+        <span>小</span>
+      </Card>,
+    );
+    expect(screen.getByText("小").parentElement).toHaveClass("p-3");
+  });
+
+  it("padding=lg で p-5 が付く", () => {
+    render(
+      <Card padding="lg">
+        <span>大</span>
+      </Card>,
+    );
+    expect(screen.getByText("大").parentElement).toHaveClass("p-5");
+  });
+
+  it("radius=lg で rounded-2xl が付く", () => {
+    render(
+      <Card radius="lg">
+        <span>2xl</span>
+      </Card>,
+    );
+    expect(screen.getByText("2xl").parentElement).toHaveClass("rounded-2xl");
+  });
+
+  it("hoverable で hover transition class が付く", () => {
+    render(
+      <Card hoverable>
+        <span>ホバー</span>
+      </Card>,
+    );
+    expect(screen.getByText("ホバー").parentElement).toHaveClass(
+      "transition-all",
+    );
+  });
+
+  it("clickable=true のとき button としてレンダリングされる", () => {
+    render(<Card clickable>選択可能</Card>);
+    const button = screen.getByRole("button", { name: "選択可能" });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveClass("text-left");
+    expect(button).toHaveClass("w-full");
+    expect(button).toHaveClass("focus-visible:outline-primary-500");
+  });
+
+  it("clickable=true のとき onClick が呼ばれる", async () => {
+    const handleClick = vi.fn();
+    render(
+      <Card clickable onClick={handleClick}>
+        選択
+      </Card>,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "選択" }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("clickable=true で disabled が反映される", () => {
+    render(
+      <Card clickable disabled>
+        選択
+      </Card>,
+    );
+    expect(screen.getByRole("button", { name: "選択" })).toBeDisabled();
+  });
+
+  it("className が結合される", () => {
+    render(
+      <Card className="custom-class">
+        <span>カスタム</span>
+      </Card>,
+    );
+    expect(screen.getByText("カスタム").parentElement).toHaveClass(
+      "custom-class",
+    );
+  });
+});

--- a/src/components/ui/__tests__/Chip.test.tsx
+++ b/src/components/ui/__tests__/Chip.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Chip from "@/components/ui/Chip";
+
+describe("Chip", () => {
+  it("selected=true のとき aria-pressed=true が付与される", () => {
+    render(
+      <Chip selected onClick={() => undefined}>
+        SD
+      </Chip>,
+    );
+    const button = screen.getByRole("button", { name: "SD", pressed: true });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("selected=false のとき aria-pressed=false が付与される", () => {
+    render(
+      <Chip selected={false} onClick={() => undefined}>
+        SD
+      </Chip>,
+    );
+    const button = screen.getByRole("button", { name: "SD", pressed: false });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("クリックで onClick が呼ばれる", async () => {
+    const handleClick = vi.fn();
+    render(
+      <Chip selected={false} onClick={handleClick}>
+        SD
+      </Chip>,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "SD" }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disabled で button が無効化される", () => {
+    render(
+      <Chip selected={false} disabled>
+        SD
+      </Chip>,
+    );
+    expect(screen.getByRole("button", { name: "SD" })).toBeDisabled();
+  });
+
+  it("onClick 未指定でもレンダリングできる", () => {
+    render(<Chip selected={false}>SD</Chip>);
+    expect(screen.getByRole("button", { name: "SD" })).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/__tests__/FormShell.test.tsx
+++ b/src/components/ui/__tests__/FormShell.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FormShell from "@/components/ui/FormShell";
+
+describe("FormShell", () => {
+  it("既定で gap-4 クラスを持つ form をレンダリングする", () => {
+    render(
+      <FormShell onSubmit={() => undefined}>
+        <button type="submit">送信</button>
+      </FormShell>,
+    );
+    const form = screen.getByRole("button", { name: "送信" }).closest("form");
+    expect(form).toHaveClass("gap-4");
+    expect(form).toHaveClass("flex");
+    expect(form).toHaveClass("flex-col");
+  });
+
+  it("gap=sm で gap-3 が付く", () => {
+    render(
+      <FormShell gap="sm" onSubmit={() => undefined}>
+        <button type="submit">送信</button>
+      </FormShell>,
+    );
+    const form = screen.getByRole("button", { name: "送信" }).closest("form");
+    expect(form).toHaveClass("gap-3");
+  });
+
+  it("gap=lg で gap-6 が付く", () => {
+    render(
+      <FormShell gap="lg" onSubmit={() => undefined}>
+        <button type="submit">送信</button>
+      </FormShell>,
+    );
+    const form = screen.getByRole("button", { name: "送信" }).closest("form");
+    expect(form).toHaveClass("gap-6");
+  });
+
+  it("submit で onSubmit が呼ばれる", async () => {
+    const handleSubmit = vi.fn((event: React.SyntheticEvent) => {
+      event.preventDefault();
+    });
+    render(
+      <FormShell onSubmit={handleSubmit}>
+        <button type="submit">送信</button>
+      </FormShell>,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "送信" }));
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("className が結合される", () => {
+    render(
+      <FormShell className="max-w-md" onSubmit={() => undefined}>
+        <button type="submit">送信</button>
+      </FormShell>,
+    );
+    const form = screen.getByRole("button", { name: "送信" }).closest("form");
+    expect(form).toHaveClass("max-w-md");
+  });
+});

--- a/src/components/ui/__tests__/IconButton.test.tsx
+++ b/src/components/ui/__tests__/IconButton.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Pencil } from "lucide-react";
+import IconButton, { iconButtonClassName } from "@/components/ui/IconButton";
+
+const SIZES = ["xs", "sm", "md", "lg"] as const;
+const VARIANTS = ["default", "primary", "danger"] as const;
+
+const SIZE_CLASS = {
+  xs: "size-7",
+  sm: "size-8",
+  md: "size-9",
+  lg: "size-10",
+} as const;
+
+describe("IconButton", () => {
+  describe("size × variant の組み合わせ", () => {
+    SIZES.forEach((size) => {
+      VARIANTS.forEach((variant) => {
+        it(`size=${size} variant=${variant} がレンダリングされる`, () => {
+          render(
+            <IconButton
+              icon={Pencil}
+              label="編集"
+              size={size}
+              variant={variant}
+            />,
+          );
+          const button = screen.getByRole("button", { name: "編集" });
+          expect(button).toBeInTheDocument();
+          expect(button).toHaveClass(SIZE_CLASS[size]);
+        });
+      });
+    });
+  });
+
+  it("クリックで onClick が呼ばれる", async () => {
+    const handleClick = vi.fn();
+    render(<IconButton icon={Pencil} label="編集" onClick={handleClick} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "編集" }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disabled が反映される", () => {
+    render(<IconButton icon={Pencil} label="編集" disabled />);
+    expect(screen.getByRole("button", { name: "編集" })).toBeDisabled();
+  });
+});
+
+describe("iconButtonClassName", () => {
+  it("単体で呼び出せて文字列を返す", () => {
+    const className = iconButtonClassName({ size: "md", variant: "default" });
+    expect(typeof className).toBe("string");
+    expect(className).toContain("rounded-lg");
+    expect(className).toContain("size-9");
+  });
+
+  it("引数なしで既定値が適用される", () => {
+    const className = iconButtonClassName();
+    expect(className).toContain("size-9");
+  });
+
+  it("disabled で opacity-50 が含まれる", () => {
+    expect(iconButtonClassName({ disabled: true })).toContain("opacity-50");
+  });
+});

--- a/src/components/ui/__tests__/PageButton.test.tsx
+++ b/src/components/ui/__tests__/PageButton.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import PageButton from "@/components/ui/PageButton";
+
+describe("PageButton", () => {
+  it("page === currentPage のとき aria-current=page が付与される", () => {
+    render(<PageButton page={3} currentPage={3} onClick={() => undefined} />);
+    expect(screen.getByRole("button", { name: "3" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("page !== currentPage のとき aria-current が付かない", () => {
+    render(<PageButton page={2} currentPage={3} onClick={() => undefined} />);
+    expect(screen.getByRole("button", { name: "2" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("クリックで page 番号が onClick に渡る", async () => {
+    const handleClick = vi.fn();
+    render(<PageButton page={5} currentPage={1} onClick={handleClick} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "5" }));
+    expect(handleClick).toHaveBeenCalledWith(5);
+  });
+});

--- a/src/components/ui/__tests__/TextButton.test.tsx
+++ b/src/components/ui/__tests__/TextButton.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TextButton from "@/components/ui/TextButton";
+
+describe("TextButton", () => {
+  it("primary variant が text-primary-500 を含む", () => {
+    render(
+      <TextButton variant="primary" onClick={() => undefined}>
+        編集
+      </TextButton>,
+    );
+    expect(screen.getByRole("button", { name: "編集" })).toHaveClass(
+      "text-primary-500",
+    );
+  });
+
+  it("secondary variant が text-text-secondary を含む", () => {
+    render(
+      <TextButton variant="secondary" onClick={() => undefined}>
+        戻る
+      </TextButton>,
+    );
+    expect(screen.getByRole("button", { name: "戻る" })).toHaveClass(
+      "text-text-secondary",
+    );
+  });
+
+  it("muted variant が text-text-tertiary を含む", () => {
+    render(
+      <TextButton variant="muted" onClick={() => undefined}>
+        キャンセル
+      </TextButton>,
+    );
+    expect(screen.getByRole("button", { name: "キャンセル" })).toHaveClass(
+      "text-text-tertiary",
+    );
+  });
+
+  it("variant 未指定で primary が既定", () => {
+    render(<TextButton onClick={() => undefined}>既定</TextButton>);
+    expect(screen.getByRole("button", { name: "既定" })).toHaveClass(
+      "text-primary-500",
+    );
+  });
+
+  it("クリックで onClick が呼ばれる", async () => {
+    const handleClick = vi.fn();
+    render(<TextButton onClick={handleClick}>クリック</TextButton>);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "クリック" }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disabled で無効化される", () => {
+    render(
+      <TextButton onClick={() => undefined} disabled>
+        無効
+      </TextButton>,
+    );
+    expect(screen.getByRole("button", { name: "無効" })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- Button.tsx に variant `outline` / `danger-solid` を追加、`danger` を `--color-danger` トークンに統一、`buttonClassName` を export
- IconButton.tsx の size を `xs/sm/md/lg` の 4 段階に拡張、`danger` をトークン化、`iconButtonClassName` を export
- Card.tsx に `padding` / `radius` / `clickable` prop を追加（既定値は現状互換）
- 新規: `Chip` / `PageButton` / `TextButton` / `FormShell` / `SectionCard`（後者は `settings/account/SectionCard` から re-export 経由で物理移動の足場）
- Badge / ErrorAlert を `--color-confirmed/uncertain/unknown/danger` トークン表現に統一
- 後続 PR-B/C/D でこの基盤を使って利用箇所を置換する

## IconButton 新 size 体系
| size | 寸法 | 用途 |
|------|------|------|
| xs | size-7 | コンパクトなインライン操作 |
| sm | size-8 | BottomSheet / Dialog の閉じるボタン |
| md | size-9 | PageHeader 戻る / 一般的なヘッダーアイコン |
| lg | size-10 | 大きめのアクション |

## Test plan
- [x] pnpm precheck
- [x] pnpm test:coverage (branches >= 80%)
- [x] pnpm build
- [ ] 手動 e2e（Wave 2 完了後に実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)