### PR TITLE
feat(ui): UI 統一(4/4) — 色トークン化と IconButton 仕上げ

### DIFF
--- a/src/app/nfc-write/page.tsx
+++ b/src/app/nfc-write/page.tsx
@@ -207,7 +207,7 @@ const ResultStep = ({ writeResult, onWriteAnother }: ResultStepProps) => (
   <div className="flex flex-col items-center gap-4 py-8">
     {writeResult.ok ? (
       <>
-        <CheckCircle2 className="size-16 text-green-500" />
+        <CheckCircle2 className="size-16 text-success" />
         <p className="text-sm font-medium text-text-primary">
           <Trans>NFC タグへの書き込みが完了しました</Trans>
         </p>

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -8,6 +8,8 @@ import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import { authSessionUnwrappedAtom, signOutAtom } from "@/stores/authAtoms";
 import ConfirmSheet from "@/components/ui/ConfirmSheet";
+import IconButton, { iconButtonClassName } from "@/components/ui/IconButton";
+import { buttonClassName } from "@/components/ui/Button";
 
 const UserMenu = () => {
   const authState = useAtomValue(authSessionUnwrappedAtom);
@@ -27,7 +29,7 @@ const UserMenu = () => {
     return (
       <Link
         href="/signin"
-        className="rounded-lg px-3 py-1.5 text-sm font-medium text-text-secondary hover:bg-primary-50 hover:text-text-primary"
+        className={buttonClassName({ variant: "ghost", size: "sm" })}
       >
         <Trans>ログイン</Trans>
       </Link>
@@ -47,19 +49,17 @@ const UserMenu = () => {
       )}
       <Link
         href="/settings/account"
-        className="p-1 text-text-tertiary hover:text-text-primary"
         aria-label={t`設定`}
+        className={iconButtonClassName({ size: "sm" })}
       >
         <Settings className="size-4" />
       </Link>
-      <button
-        type="button"
+      <IconButton
+        icon={LogOut}
+        label={t`ログアウト`}
+        size="sm"
         onClick={() => setIsConfirmOpen(true)}
-        className="p-1 text-text-tertiary hover:text-text-primary"
-        aria-label={t`ログアウト`}
-      >
-        <LogOut className="size-4" />
-      </button>
+      />
       <ConfirmSheet
         isOpen={isConfirmOpen}
         onClose={() => setIsConfirmOpen(false)}

--- a/src/components/confidence/ConfidenceStats.tsx
+++ b/src/components/confidence/ConfidenceStats.tsx
@@ -41,12 +41,12 @@ const ConfidenceStats = ({ garments }: Props) => {
     {
       label: msg`確定`,
       value: counts.confirmed,
-      accent: "bg-emerald-50 text-emerald-700",
+      accent: "bg-confirmed/10 text-success",
     },
     {
       label: msg`要確認`,
       value: counts.uncertain + counts.unknown,
-      accent: "bg-amber-50 text-amber-700",
+      accent: "bg-uncertain/15 text-text-primary",
     },
   ];
 

--- a/src/components/coordinate/CoordinateBuilder.tsx
+++ b/src/components/coordinate/CoordinateBuilder.tsx
@@ -406,7 +406,7 @@ const CoordinateBuilder = ({
       {s.submitError !== undefined && (
         <p
           role="alert"
-          className="rounded-lg border border-danger/30 bg-red-50 px-3 py-2 text-sm text-danger"
+          className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger"
         >
           {s.submitError}
         </p>

--- a/src/components/digest/DigestCard.tsx
+++ b/src/components/digest/DigestCard.tsx
@@ -8,6 +8,7 @@ import { msg } from "@lingui/core/macro";
 import type { Digest } from "@/types";
 import Card from "@/components/ui/Card";
 import Badge from "@/components/ui/Badge";
+import IconButton from "@/components/ui/IconButton";
 import { markDigestReadAtom } from "@/stores/digestAtoms";
 
 type Props = {
@@ -52,19 +53,13 @@ const DigestCard = ({ digest }: Props) => {
               <Trans>未読</Trans>
             </Badge>
           )}
-          <button
-            type="button"
+          <IconButton
+            icon={digest.isRead ? Eye : EyeOff}
+            label={i18n._(digest.isRead ? msg`既読済み` : msg`既読にする`)}
+            size="sm"
             onClick={handleMarkRead}
             disabled={digest.isRead}
-            className="text-text-tertiary transition-colors hover:text-text-primary disabled:cursor-default disabled:opacity-50"
-            aria-label={i18n._(digest.isRead ? msg`既読済み` : msg`既読にする`)}
-          >
-            {digest.isRead ? (
-              <Eye className="size-4" />
-            ) : (
-              <EyeOff className="size-4" />
-            )}
-          </button>
+          />
         </div>
       </div>
 

--- a/src/components/garment/GarmentCard.tsx
+++ b/src/components/garment/GarmentCard.tsx
@@ -45,7 +45,7 @@ const GarmentCard = ({ garment }: Props) => {
           )}
         </div>
         {isCheckedOut && (
-          <div className="absolute right-2 top-2 rounded-full bg-amber-500 px-2 py-0.5 text-[10px] font-bold text-white">
+          <div className="absolute right-2 top-2 rounded-full bg-uncertain px-2 py-0.5 text-[10px] font-bold text-text-inverse">
             <Trans>取り出し中</Trans>
           </div>
         )}

--- a/src/components/garment/ImageUpload.tsx
+++ b/src/components/garment/ImageUpload.tsx
@@ -121,7 +121,7 @@ const ImageUpload = ({ imagePreview, uploadState, onFileSelect }: Props) => {
         disabled={isProcessing}
       />
       {uploadState.status === "error" && (
-        <p className="text-sm text-red-500">{uploadState.message}</p>
+        <p className="text-sm text-danger">{uploadState.message}</p>
       )}
     </div>
   );

--- a/src/components/location/StorageCell.tsx
+++ b/src/components/location/StorageCell.tsx
@@ -27,9 +27,9 @@ const getWorstConfidence = (
 };
 
 const CELL_BG = {
-  confirmed: "bg-emerald-50 border-emerald-200",
-  uncertain: "bg-amber-50 border-amber-200",
-  unknown: "bg-orange-50 border-orange-200",
+  confirmed: "bg-confirmed/10 border-confirmed/30",
+  uncertain: "bg-uncertain/15 border-uncertain/40",
+  unknown: "bg-unknown/10 border-unknown/30",
   empty: "bg-surface-raised border-border-default",
 } as const;
 

--- a/src/components/settings/LocaleSelector.tsx
+++ b/src/components/settings/LocaleSelector.tsx
@@ -11,6 +11,7 @@ import {
   type Locale,
 } from "@/i18n/types";
 import clsx from "clsx";
+import IconButton from "@/components/ui/IconButton";
 
 const LocaleSelector = () => {
   const currentLocale = useAtomValue(localeAtom);
@@ -40,14 +41,12 @@ const LocaleSelector = () => {
 
   return (
     <div ref={ref} className="relative">
-      <button
-        type="button"
+      <IconButton
+        icon={Globe}
+        label={t`言語`}
+        size="md"
         onClick={() => setIsOpen((prev) => !prev)}
-        className="flex size-8 items-center justify-center rounded-lg text-text-tertiary transition-colors hover:bg-primary-50 hover:text-text-secondary"
-        aria-label={t`言語`}
-      >
-        <Globe className="size-4" />
-      </button>
+      />
 
       {isOpen && (
         <div className="absolute right-0 top-full z-50 mt-1 min-w-[120px] overflow-hidden rounded-lg border border-border-default bg-surface-overlay shadow-md">

--- a/src/components/settings/account/DeleteAccountSection.tsx
+++ b/src/components/settings/account/DeleteAccountSection.tsx
@@ -66,10 +66,10 @@ const DeleteAccountSection = ({ currentEmail, hasPassword }: Props) => {
   return (
     <section
       aria-labelledby="danger-zone-title"
-      className="mt-4 rounded-2xl border border-danger/20 bg-red-50/40 p-5"
+      className="mt-4 rounded-2xl border border-danger/20 bg-danger/8 p-5"
     >
       <header className="mb-4 flex items-start gap-3">
-        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-red-100 text-danger">
+        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-danger/15 text-danger">
           <AlertTriangle className="size-4" />
         </div>
         <div className="flex flex-col gap-1">

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -3,6 +3,9 @@
 import { useRef } from "react";
 import { X } from "lucide-react";
 import clsx from "clsx";
+import { t } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import IconButton from "@/components/ui/IconButton";
 
 type Props = {
   readonly isOpen: boolean;
@@ -13,6 +16,7 @@ type Props = {
 
 const BottomSheet = ({ isOpen, onClose, title, children }: Props) => {
   const sheetRef = useRef<HTMLDivElement>(null);
+  const { i18n } = useLingui();
 
   if (!isOpen) return undefined;
 
@@ -39,13 +43,12 @@ const BottomSheet = ({ isOpen, onClose, title, children }: Props) => {
         {title !== undefined && (
           <div className="flex items-center justify-between border-b border-border-default px-4 pb-3">
             <h3 className="font-display text-base font-bold">{title}</h3>
-            <button
+            <IconButton
+              icon={X}
+              label={i18n._(t`閉じる`)}
+              size="sm"
               onClick={onClose}
-              className="flex size-8 items-center justify-center rounded-lg text-text-tertiary transition-colors hover:bg-primary-50"
-              aria-label="閉じる"
-            >
-              <X className="size-4" />
-            </button>
+            />
           </div>
         )}
         <div className="overflow-y-auto px-4 pb-8 pt-3">{children}</div>

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import clsx from "clsx";
+import IconButton, { iconButtonClassName } from "@/components/ui/IconButton";
 
 type Props = {
   readonly title: React.ReactNode;
@@ -29,18 +30,17 @@ const PageHeader = ({
       <Link
         href={backHref}
         aria-label={backLabel}
-        className="flex size-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-primary-50"
+        className={iconButtonClassName({ size: "md" })}
       >
-        <ArrowLeft className="size-5" />
+        <ArrowLeft className="size-4" />
       </Link>
     ) : onBack !== undefined ? (
-      <button
+      <IconButton
+        icon={ArrowLeft}
+        label={backLabel ?? ""}
+        size="md"
         onClick={onBack}
-        aria-label={backLabel}
-        className="flex size-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-primary-50"
-      >
-        <ArrowLeft className="size-5" />
-      </button>
+      />
     ) : undefined;
 
   return (

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2083,6 +2083,10 @@ msgstr "Please select"
 msgid "選択中の服"
 msgstr "Selected garments"
 
+#: src/components/ui/BottomSheet.tsx
+msgid "閉じる"
+msgstr "Close"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "関連する服がありません（削除された可能性があります）"
 msgstr "No linked garments (they may have been deleted)."

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -2083,6 +2083,10 @@ msgstr "選択してください"
 msgid "選択中の服"
 msgstr "選択中の服"
 
+#: src/components/ui/BottomSheet.tsx
+msgid "閉じる"
+msgstr "閉じる"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "関連する服がありません（削除された可能性があります）"
 msgstr "関連する服がありません（削除された可能性があります）"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -2083,6 +2083,10 @@ msgstr "선택해 주세요"
 msgid "選択中の服"
 msgstr "선택된 옷"
 
+#: src/components/ui/BottomSheet.tsx
+msgid "閉じる"
+msgstr "닫기"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "関連する服がありません（削除された可能性があります）"
 msgstr "관련된 옷이 없습니다 (삭제되었을 수 있습니다)."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2083,6 +2083,10 @@ msgstr "请选择"
 msgid "選択中の服"
 msgstr "已选衣服"
 
+#: src/components/ui/BottomSheet.tsx
+msgid "閉じる"
+msgstr "关闭"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "関連する服がありません（削除された可能性があります）"
 msgstr "没有关联的衣服（可能已被删除）。"


### PR DESCRIPTION
## Summary
- 直書きの `text-red-*` / `bg-amber-*` / `text-green-*` などを `--color-confirmed/uncertain/unknown/danger/success` トークンベースに置換（ConfidenceStats / StorageCell / DeleteAccountSection / CoordinateBuilder alert / nfc-write / ImageUpload / GarmentCard）
- PageHeader / BottomSheet / UserMenu / LocaleSelector / DigestCard のアイコンボタンを `<IconButton>` または `iconButtonClassName(...)` で統一
- BottomSheet 閉じるボタンの aria-label を Lingui 化、新規エントリを en/ko/zh で翻訳

## 関連
- 基盤: #193 (PR-A)
- 計画: \`/Users/butaosuinu/.claude/plans/ui-vast-feather.md\` の PR-D

## Test plan
- [x] pnpm precheck (i18n:check 含む)
- [x] pnpm test:coverage (branches >= 80%)
- [x] pnpm build

🤖 Generated with [Claude Code](https://claude.com/claude-code)