### PR TITLE
feat(ui): UI 統一(3/4) — Card/SectionCard/FormShell をフォーム/カードへ適用

### DIFF
--- a/src/app/(public)/signin/page.tsx
+++ b/src/app/(public)/signin/page.tsx
@@ -39,7 +39,7 @@ const SignInInner = () => {
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-md flex-col gap-7 px-5 pb-10 pt-6 lg:gap-8 lg:pt-10">
+    <div className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 pb-10 pt-6 lg:pt-10">
       <header className="flex flex-col items-center gap-2 pt-2 text-center">
         <div className="flex size-12 items-center justify-center rounded-2xl bg-primary-100 text-primary-700 ring-1 ring-inset ring-primary-200">
           <Shirt className="size-6" />

--- a/src/app/(public)/signup/page.tsx
+++ b/src/app/(public)/signup/page.tsx
@@ -26,7 +26,7 @@ const SignUpPage = () => {
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-md flex-col gap-7 px-5 pb-10 pt-6 lg:gap-8 lg:pt-10">
+    <div className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 pb-10 pt-6 lg:pt-10">
       <header className="flex flex-col items-center gap-2 pt-2 text-center">
         <div className="flex size-12 items-center justify-center rounded-2xl bg-primary-100 text-primary-700 ring-1 ring-inset ring-primary-200">
           <Sparkles className="size-6" />

--- a/src/app/nfc-write/page.tsx
+++ b/src/app/nfc-write/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
 import Select from "@/components/ui/Select";
 import Skeleton from "@/components/ui/Skeleton";
 import TextButton from "@/components/ui/TextButton";
@@ -62,26 +63,30 @@ const SelectTypeStep = ({ onSelect }: SelectTypeStepProps) => (
     <p className="text-sm text-text-secondary">
       <Trans>書き込む対象を選択してください</Trans>
     </p>
-    <button
-      type="button"
-      className="flex items-center gap-3 rounded-xl border border-border-default bg-surface-overlay p-4 transition-colors hover:border-primary-400"
+    <Card
+      clickable
+      hoverable
+      padding="md"
       onClick={() => onSelect("garment")}
+      className="flex items-center gap-3"
     >
       <Shirt className="size-6 text-primary-500" />
       <span className="font-medium text-text-primary">
         <Trans>服</Trans>
       </span>
-    </button>
-    <button
-      type="button"
-      className="flex items-center gap-3 rounded-xl border border-border-default bg-surface-overlay p-4 transition-colors hover:border-primary-400"
+    </Card>
+    <Card
+      clickable
+      hoverable
+      padding="md"
       onClick={() => onSelect("location")}
+      className="flex items-center gap-3"
     >
       <MapPin className="size-6 text-primary-500" />
       <span className="font-medium text-text-primary">
         <Trans>収納場所</Trans>
       </span>
-    </button>
+    </Card>
   </div>
 );
 

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -10,7 +10,7 @@ import DeleteAccountSection from "@/components/settings/account/DeleteAccountSec
 import EmailChangeForm from "@/components/settings/account/EmailChangeForm";
 import PasswordChangeForm from "@/components/settings/account/PasswordChangeForm";
 import ProfileForm from "@/components/settings/account/ProfileForm";
-import SectionCard from "@/components/settings/account/SectionCard";
+import SectionCard from "@/components/ui/SectionCard";
 
 const AccountSettingsPage = () => {
   const router = useRouter();

--- a/src/components/auth/EmailPasswordForm.tsx
+++ b/src/components/auth/EmailPasswordForm.tsx
@@ -9,6 +9,7 @@ import { signInEmailSchema, signInWithEmail } from "@/lib/auth";
 import { refreshAuthAtom } from "@/stores/authAtoms";
 import Button from "@/components/ui/Button";
 import ErrorAlert from "@/components/ui/ErrorAlert";
+import FormShell from "@/components/ui/FormShell";
 import Input from "@/components/ui/Input";
 
 type FieldErrors = {
@@ -63,7 +64,7 @@ const EmailPasswordForm = ({ redirect }: Props = {}) => {
   };
 
   return (
-    <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
+    <FormShell gap="md" onSubmit={handleSubmit} noValidate>
       <Input
         type="email"
         label={t`メールアドレス`}
@@ -95,7 +96,7 @@ const EmailPasswordForm = ({ redirect }: Props = {}) => {
       >
         {isSubmitting ? <Trans>ログイン中…</Trans> : <Trans>ログイン</Trans>}
       </Button>
-    </form>
+    </FormShell>
   );
 };
 

--- a/src/components/coordinate/CoordinateBuilder.tsx
+++ b/src/components/coordinate/CoordinateBuilder.tsx
@@ -15,6 +15,8 @@ import {
 import { GARMENT_CATEGORY_LABEL } from "@/lib/i18n-labels";
 import type { Coordinate, Garment } from "@/types";
 import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import FormShell from "@/components/ui/FormShell";
 import IconButton from "@/components/ui/IconButton";
 import Input from "@/components/ui/Input";
 import Textarea from "@/components/ui/Textarea";
@@ -139,15 +141,14 @@ const GarmentTile = ({
 }) => {
   const { i18n } = useLingui();
   return (
-    <button
-      type="button"
+    <Card
+      clickable
+      padding="sm"
       onClick={() => onToggle(garment.id)}
-      aria-pressed={selected}
+      ariaPressed={selected}
       className={clsx(
-        "flex w-full flex-col items-stretch gap-1 rounded-lg border p-2 text-left transition-colors",
-        selected
-          ? "border-primary-500 bg-primary-50"
-          : "border-border-default bg-surface-overlay hover:bg-primary-50",
+        "flex flex-col items-stretch gap-1 transition-colors",
+        selected ? "border-primary-500 bg-primary-50" : "hover:bg-primary-50",
       )}
     >
       <div className="flex aspect-square w-full items-center justify-center overflow-hidden rounded-md bg-primary-50">
@@ -165,7 +166,7 @@ const GarmentTile = ({
       <span className="w-full truncate text-[10px] text-text-tertiary">
         {i18n._(GARMENT_CATEGORY_LABEL[garment.category])}
       </span>
-    </button>
+    </Card>
   );
 };
 
@@ -354,7 +355,7 @@ const CoordinateBuilder = ({
   const s = useCoordinateBuilder({ initial, onSubmit });
 
   return (
-    <form onSubmit={s.handleSubmit} className="flex flex-col gap-5">
+    <FormShell gap="md" onSubmit={s.handleSubmit}>
       <Input
         label={t`コーデ名`}
         placeholder={t`お出かけコーデ`}
@@ -427,7 +428,7 @@ const CoordinateBuilder = ({
           {submitLabel}
         </Button>
       </div>
-    </form>
+    </FormShell>
   );
 };
 

--- a/src/components/doll/DollForm.tsx
+++ b/src/components/doll/DollForm.tsx
@@ -17,6 +17,7 @@ import { useImageUpload } from "@/hooks/useImageUpload";
 import Input from "@/components/ui/Input";
 import Select from "@/components/ui/Select";
 import Button from "@/components/ui/Button";
+import FormShell from "@/components/ui/FormShell";
 import Textarea from "@/components/ui/Textarea";
 import ImageUpload from "@/components/garment/ImageUpload";
 
@@ -156,7 +157,7 @@ const DollForm = ({ doll }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+    <FormShell gap="md" onSubmit={handleSubmit}>
       <ImageUpload
         imagePreview={imagePreview}
         uploadState={uploadState}
@@ -230,7 +231,7 @@ const DollForm = ({ doll }: Props) => {
           <Trans>登録する</Trans>
         )}
       </Button>
-    </form>
+    </FormShell>
   );
 };
 

--- a/src/components/garment/GarmentForm.tsx
+++ b/src/components/garment/GarmentForm.tsx
@@ -35,6 +35,7 @@ import TagInput from "@/components/ui/TagInput";
 import ColorPicker from "@/components/ui/ColorPicker";
 import AutocompleteInput from "@/components/ui/AutocompleteInput";
 import Textarea from "@/components/ui/Textarea";
+import FormShell from "@/components/ui/FormShell";
 import ImageUpload from "@/components/garment/ImageUpload";
 
 type Props = {
@@ -229,7 +230,7 @@ const GarmentForm = ({ garment }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+    <FormShell gap="md" onSubmit={handleSubmit}>
       <ImageUpload
         imagePreview={imagePreview}
         uploadState={uploadState}
@@ -341,7 +342,7 @@ const GarmentForm = ({ garment }: Props) => {
           <Trans>登録する</Trans>
         )}
       </Button>
-    </form>
+    </FormShell>
   );
 };
 

--- a/src/components/location/StorageCaseForm.tsx
+++ b/src/components/location/StorageCaseForm.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/constants";
 import Input from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
+import FormShell from "@/components/ui/FormShell";
 import Textarea from "@/components/ui/Textarea";
 
 type CreateCaseInput =
@@ -94,7 +95,7 @@ const StorageCaseForm = ({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+    <FormShell gap="md" onSubmit={handleSubmit}>
       <div className="flex flex-col gap-1.5">
         <span className="text-sm font-medium text-text-secondary">
           <Trans>タイプ</Trans>
@@ -173,7 +174,7 @@ const StorageCaseForm = ({
           <Trans>作成</Trans>
         </Button>
       </div>
-    </form>
+    </FormShell>
   );
 };
 

--- a/src/components/settings/account/SectionCard.tsx
+++ b/src/components/settings/account/SectionCard.tsx
@@ -1,3 +1,0 @@
-import SectionCard from "@/components/ui/SectionCard";
-
-export default SectionCard;

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -34,6 +34,8 @@ type ClickableProps = BaseProps & {
   readonly onClick?: React.MouseEventHandler<HTMLButtonElement>;
   readonly disabled?: boolean;
   readonly type?: "button" | "submit";
+  readonly ariaPressed?: boolean;
+  readonly ariaLabel?: string;
 };
 
 type Props = StaticProps | ClickableProps;
@@ -77,6 +79,8 @@ const Card = (props: Props) => {
         type={props.type ?? "button"}
         onClick={props.onClick}
         disabled={props.disabled}
+        aria-pressed={props.ariaPressed}
+        aria-label={props.ariaLabel}
         className={cardClassName({
           hoverable,
           padding,

--- a/src/components/ui/FormShell.tsx
+++ b/src/components/ui/FormShell.tsx
@@ -9,6 +9,7 @@ type Props = {
   >;
   readonly children: React.ReactNode;
   readonly className?: string;
+  readonly noValidate?: boolean;
 };
 
 const GAP_STYLES: Record<FormGap, string> = {
@@ -17,9 +18,16 @@ const GAP_STYLES: Record<FormGap, string> = {
   lg: "gap-6",
 };
 
-const FormShell = ({ gap = "md", onSubmit, children, className }: Props) => (
+const FormShell = ({
+  gap = "md",
+  onSubmit,
+  children,
+  className,
+  noValidate,
+}: Props) => (
   <form
     onSubmit={onSubmit}
+    noValidate={noValidate}
     className={clsx("flex flex-col", GAP_STYLES[gap], className)}
   >
     {children}


### PR DESCRIPTION
## Summary
- フォームコンテナの直書き `<form className="flex flex-col gap-4">` を `<FormShell>` に統一（GarmentForm / CoordinateBuilder / DollForm / EmailPasswordForm / StorageCaseForm）
- `src/components/settings/account/SectionCard.tsx` を削除し import 元を `@/components/ui/SectionCard` に切替（PR-A で用意した足場の物理化）
- 選択カード（nfc-write の選択肢、CoordinateBuilder の GarmentTile）を `<Card clickable>` に統一
- 認証画面の外側 gap-7 を gap-6 に整理
- 既存挙動を保つための最小拡張: `FormShell` に `noValidate`、`Card` の clickable に `ariaPressed` / `ariaLabel` prop を追加

## 関連
- 基盤: #193 (PR-A)
- 計画: `/Users/butaosuinu/.claude/plans/ui-vast-feather.md` の PR-C

## Test plan
- [x] pnpm precheck（0 errors / warnings のみ）
- [x] pnpm test（132 / 132 ファイル, 1231 / 1231 テスト pass）
- [x] pnpm test:coverage（branches 82.14% >= 80%）
- [x] pnpm build

🤖 Generated with [Claude Code](https://claude.com/claude-code)