### PR TITLE
feat(ui): UI 統一(2/4) — ボタン直書きを共通コンポーネントへ置換

### DIFF
--- a/src/app/coordinates/page.tsx
+++ b/src/app/coordinates/page.tsx
@@ -11,6 +11,7 @@ import { coordinatesAtom } from "@/stores/coordinateAtoms";
 import { garmentsAtom } from "@/stores/garmentAtoms";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import CoordinateCard from "@/components/coordinate/CoordinateCard";
+import { buttonClassName } from "@/components/ui/Button";
 import EmptyState from "@/components/ui/EmptyState";
 import FAB from "@/components/ui/FAB";
 import Skeleton from "@/components/ui/Skeleton";
@@ -57,7 +58,7 @@ const CoordinatesPage = () => (
       </h2>
       <Link
         href="/coordinates/new"
-        className="hidden items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-text-inverse transition-colors hover:bg-primary-600 lg:inline-flex"
+        className={`hidden lg:inline-flex ${buttonClassName({ variant: "primary", size: "md" })}`}
       >
         <Plus className="size-4" />
         <Trans>新規作成</Trans>

--- a/src/app/dolls/[id]/page.tsx
+++ b/src/app/dolls/[id]/page.tsx
@@ -10,6 +10,7 @@ import DollDetail from "@/components/doll/DollDetail";
 import CompatibleGarmentList from "@/components/doll/CompatibleGarmentList";
 import PageHeader from "@/components/ui/PageHeader";
 import Skeleton from "@/components/ui/Skeleton";
+import TextButton from "@/components/ui/TextButton";
 
 const DollDetailContent = () => {
   const params = useParams();
@@ -23,12 +24,9 @@ const DollDetailContent = () => {
         <p className="text-sm text-text-secondary">
           <Trans>ドールが見つかりません</Trans>
         </p>
-        <button
-          onClick={() => router.push("/dolls")}
-          className="text-sm font-medium text-primary-500"
-        >
+        <TextButton onClick={() => router.push("/dolls")}>
           <Trans>一覧に戻る</Trans>
-        </button>
+        </TextButton>
       </div>
     );
   }

--- a/src/app/dolls/page.tsx
+++ b/src/app/dolls/page.tsx
@@ -19,6 +19,7 @@ import DollGrid from "@/components/doll/DollGrid";
 import DollList from "@/components/doll/DollList";
 import Pagination from "@/components/ui/Pagination";
 import usePagination from "@/hooks/usePagination";
+import { buttonClassName } from "@/components/ui/Button";
 import ChipGroup from "@/components/ui/ChipGroup";
 import EmptyState from "@/components/ui/EmptyState";
 import FAB from "@/components/ui/FAB";
@@ -295,7 +296,7 @@ const DollsPage = () => (
       </h2>
       <Link
         href="/dolls/new"
-        className="hidden items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-text-inverse transition-colors hover:bg-primary-600 lg:inline-flex"
+        className={`hidden lg:inline-flex ${buttonClassName({ variant: "primary", size: "md" })}`}
       >
         <Plus className="size-4" />
         <Trans>ドールを登録</Trans>

--- a/src/app/garments/page.tsx
+++ b/src/app/garments/page.tsx
@@ -33,6 +33,7 @@ import GarmentGrid from "@/components/garment/GarmentGrid";
 import GarmentList from "@/components/garment/GarmentList";
 import Pagination from "@/components/ui/Pagination";
 import usePagination from "@/hooks/usePagination";
+import { buttonClassName } from "@/components/ui/Button";
 import ChipGroup from "@/components/ui/ChipGroup";
 import EmptyState from "@/components/ui/EmptyState";
 import FAB from "@/components/ui/FAB";
@@ -389,21 +390,21 @@ const GarmentsPage = () => (
       <div className="hidden items-center gap-2 lg:flex">
         <Link
           href="/garments/import"
-          className="inline-flex items-center gap-2 rounded-lg border border-border-default px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-overlay"
+          className={buttonClassName({ variant: "outline", size: "md" })}
         >
           <Upload className="size-4" />
           <Trans>CSVインポート</Trans>
         </Link>
         <Link
           href="/garments/bulk"
-          className="inline-flex items-center gap-2 rounded-lg border border-border-default px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-overlay"
+          className={buttonClassName({ variant: "outline", size: "md" })}
         >
           <Camera className="size-4" />
           <Trans>連続撮影</Trans>
         </Link>
         <Link
           href="/garments/new"
-          className="inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-text-inverse transition-colors hover:bg-primary-600"
+          className={buttonClassName({ variant: "primary", size: "md" })}
         >
           <Plus className="size-4" />
           <Trans>服を登録</Trans>

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -21,6 +21,7 @@ import StorageCaseCard from "@/components/location/StorageCaseCard";
 import StorageCaseForm from "@/components/location/StorageCaseForm";
 import StorageCaseEditForm from "@/components/location/StorageCaseEditForm";
 import BottomSheet from "@/components/ui/BottomSheet";
+import Button from "@/components/ui/Button";
 import ConfirmSheet from "@/components/ui/ConfirmSheet";
 import EmptyState from "@/components/ui/EmptyState";
 import FAB from "@/components/ui/FAB";
@@ -88,13 +89,10 @@ const LocationsContent = () => {
   return (
     <>
       <div className="hidden justify-end lg:flex">
-        <button
-          onClick={() => setIsCreateOpen(true)}
-          className="inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-text-inverse transition-colors hover:bg-primary-600"
-        >
+        <Button onClick={() => setIsCreateOpen(true)}>
           <Plus className="size-4" />
           <Trans>ケースを追加</Trans>
-        </button>
+        </Button>
       </div>
       {cases.length === 0 ? (
         <EmptyState

--- a/src/app/nfc-write/page.tsx
+++ b/src/app/nfc-write/page.tsx
@@ -17,6 +17,7 @@ import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import Button from "@/components/ui/Button";
 import Select from "@/components/ui/Select";
 import Skeleton from "@/components/ui/Skeleton";
+import TextButton from "@/components/ui/TextButton";
 import { garmentsAtom } from "@/stores/garmentAtoms";
 import { storageCasesAtom, storageLocationsAtom } from "@/stores/locationAtoms";
 import {
@@ -39,8 +40,6 @@ type SelectOption = {
   readonly value: string;
   readonly label: string;
 };
-
-const BACK_BUTTON_CLASS = "flex items-center gap-1 text-sm text-text-secondary";
 
 const NfcUnsupported = () => (
   <div className="flex flex-col items-center gap-4 py-12 text-center">
@@ -107,10 +106,12 @@ const SelectItemStep = ({
 
   return (
     <div className="flex flex-col gap-4">
-      <button type="button" className={BACK_BUTTON_CLASS} onClick={onBack}>
-        <ArrowLeft className="size-4" />
-        <Trans>戻る</Trans>
-      </button>
+      <TextButton variant="muted" onClick={onBack}>
+        <span className="inline-flex items-center gap-1">
+          <ArrowLeft className="size-4" />
+          <Trans>戻る</Trans>
+        </span>
+      </TextButton>
       <Select
         label={i18n._(
           targetType === "garment"
@@ -147,10 +148,12 @@ const ReadyToWriteStep = ({
   onBack,
 }: ReadyToWriteStepProps) => (
   <div className="flex flex-col gap-4">
-    <button type="button" className={BACK_BUTTON_CLASS} onClick={onBack}>
-      <ArrowLeft className="size-4" />
-      <Trans>戻る</Trans>
-    </button>
+    <TextButton variant="muted" onClick={onBack}>
+      <span className="inline-flex items-center gap-1">
+        <ArrowLeft className="size-4" />
+        <Trans>戻る</Trans>
+      </span>
+    </TextButton>
     <div className="rounded-xl border border-border-default bg-surface-overlay p-4">
       <p className="text-sm text-text-secondary">
         <Trans>書き込み対象</Trans>

--- a/src/components/coordinate/CoordinateBuilder.tsx
+++ b/src/components/coordinate/CoordinateBuilder.tsx
@@ -15,6 +15,7 @@ import {
 import { GARMENT_CATEGORY_LABEL } from "@/lib/i18n-labels";
 import type { Coordinate, Garment } from "@/types";
 import Button from "@/components/ui/Button";
+import IconButton from "@/components/ui/IconButton";
 import Input from "@/components/ui/Input";
 import Textarea from "@/components/ui/Textarea";
 import SearchInput from "@/components/ui/SearchInput";
@@ -99,32 +100,27 @@ const SelectedGarmentsList = ({
             </div>
           </div>
           <div className="flex items-center gap-1 border-l border-primary-200/60 pl-2">
-            <button
-              type="button"
-              aria-label={t`上へ`}
+            <IconButton
+              icon={ArrowUp}
+              label={t`上へ`}
+              size="sm"
               onClick={() => onMoveUp(garment.id)}
               disabled={index === 0}
-              className="flex size-8 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-primary-100 disabled:opacity-30 disabled:hover:bg-transparent"
-            >
-              <ArrowUp className="size-4" />
-            </button>
-            <button
-              type="button"
-              aria-label={t`下へ`}
+            />
+            <IconButton
+              icon={ArrowDown}
+              label={t`下へ`}
+              size="sm"
               onClick={() => onMoveDown(garment.id)}
               disabled={index === lastIndex}
-              className="flex size-8 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-primary-100 disabled:opacity-30 disabled:hover:bg-transparent"
-            >
-              <ArrowDown className="size-4" />
-            </button>
-            <button
-              type="button"
-              aria-label={t`削除`}
+            />
+            <IconButton
+              icon={RemoveIcon}
+              label={t`削除`}
+              size="sm"
+              variant="danger"
               onClick={() => onRemove(garment.id)}
-              className="flex size-8 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-red-50 hover:text-danger"
-            >
-              <RemoveIcon className="size-4" />
-            </button>
+            />
           </div>
         </li>
       ))}

--- a/src/components/garment/GarmentForm.tsx
+++ b/src/components/garment/GarmentForm.tsx
@@ -7,7 +7,6 @@ import { createId } from "@paralleldrive/cuid2";
 import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
-import clsx from "clsx";
 import { Loader2 } from "lucide-react";
 import { addGarmentAtom, updateGarmentAtom } from "@/stores/garmentAtoms";
 import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
@@ -31,6 +30,7 @@ import { useBrandSuggestions } from "@/hooks/useBrandSuggestions";
 import Input from "@/components/ui/Input";
 import Select from "@/components/ui/Select";
 import Button from "@/components/ui/Button";
+import Chip from "@/components/ui/Chip";
 import TagInput from "@/components/ui/TagInput";
 import ColorPicker from "@/components/ui/ColorPicker";
 import AutocompleteInput from "@/components/ui/AutocompleteInput";
@@ -273,23 +273,17 @@ const GarmentForm = ({ garment }: Props) => {
           {sizeOptions.map(({ value, label }) => {
             const selected = isDollSize(value) && dollSizes.includes(value);
             return (
-              <button
+              <Chip
                 key={value}
-                type="button"
+                selected={selected}
                 onClick={() => {
                   if (isDollSize(value)) {
                     toggleDollSize(value);
                   }
                 }}
-                className={clsx(
-                  "rounded-full border px-3 py-2 text-xs font-medium transition-colors",
-                  selected
-                    ? "border-primary-500 bg-primary-500 text-text-inverse"
-                    : "border-border-default bg-surface-overlay text-text-secondary hover:bg-primary-50",
-                )}
               >
                 {label}
-              </button>
+              </Chip>
             );
           })}
         </div>

--- a/src/components/garment/bulk/BulkMetadataForm.tsx
+++ b/src/components/garment/bulk/BulkMetadataForm.tsx
@@ -15,6 +15,7 @@ import {
   getMetadataForItem,
 } from "@/stores/bulkCaptureAtoms";
 import Button from "@/components/ui/Button";
+import TextButton from "@/components/ui/TextButton";
 import BulkMetadataFormFields from "./BulkMetadataFormFields";
 
 const BulkMetadataForm = () => {
@@ -90,14 +91,14 @@ const BulkMetadataForm = () => {
       </div>
 
       {!isFirst && (
-        <button
-          type="button"
-          onClick={handleApplyPrevious}
-          className="flex items-center justify-center gap-2 text-sm text-primary-500 hover:text-primary-600"
-        >
-          <Copy className="size-4" />
-          <Trans>前の値を適用</Trans>
-        </button>
+        <div className="flex justify-center">
+          <TextButton onClick={handleApplyPrevious}>
+            <span className="inline-flex items-center gap-2">
+              <Copy className="size-4" />
+              <Trans>前の値を適用</Trans>
+            </span>
+          </TextButton>
+        </div>
       )}
 
       <BulkMetadataFormFields

--- a/src/components/scan/OpportunisticReviewDialog.test.tsx
+++ b/src/components/scan/OpportunisticReviewDialog.test.tsx
@@ -131,7 +131,7 @@ describe("OpportunisticReviewDialog", () => {
     if (firstNaiButton === undefined) return;
     fireEvent.click(firstNaiButton);
 
-    expect(firstNaiButton).toHaveClass("bg-red-500");
+    expect(firstNaiButton).toHaveAttribute("aria-pressed", "true");
   });
 
   it("個別選択モードで「確定する」が正しいconfirmationsを渡す", async () => {

--- a/src/components/scan/ReviewItemRow.tsx
+++ b/src/components/scan/ReviewItemRow.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { Trans } from "@lingui/react/macro";
-import clsx from "clsx";
 import { getConfidence, getConfidenceLabel } from "@/lib/confidence";
 import ConfidenceBar from "@/components/confidence/ConfidenceBar";
 import ConfidenceBadge from "@/components/confidence/ConfidenceBadge";
+import Button from "@/components/ui/Button";
 import type { Garment } from "@/types";
 
 type ReviewMode = "overview" | "individual";
@@ -36,30 +36,24 @@ const ReviewItemRow = ({
       <ConfidenceBar confidence={confidence} />
       {mode === "individual" && onToggle !== undefined && (
         <div className="flex gap-2">
-          <button
-            type="button"
+          <Button
+            variant={isConfirmed === true ? "primary" : "secondary"}
+            size="sm"
+            fullWidth
+            aria-pressed={isConfirmed === true}
             onClick={() => onToggle(garment.id, true)}
-            className={clsx(
-              "flex-1 rounded-lg py-1.5 text-xs font-medium transition-colors",
-              isConfirmed === true
-                ? "bg-primary-500 text-text-inverse"
-                : "bg-primary-50 text-text-secondary",
-            )}
           >
             <Trans>ある</Trans>
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant={isConfirmed === false ? "danger-solid" : "danger"}
+            size="sm"
+            fullWidth
+            aria-pressed={isConfirmed === false}
             onClick={() => onToggle(garment.id, false)}
-            className={clsx(
-              "flex-1 rounded-lg py-1.5 text-xs font-medium transition-colors",
-              isConfirmed === false
-                ? "bg-red-500 text-white"
-                : "bg-red-50 text-text-secondary",
-            )}
           >
             <Trans>ない</Trans>
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/src/components/scan/ScanSessionPanel.tsx
+++ b/src/components/scan/ScanSessionPanel.tsx
@@ -9,6 +9,7 @@ import {
   resetScanSessionAtom,
 } from "@/stores/scanSessionAtoms";
 import Button from "@/components/ui/Button";
+import TextButton from "@/components/ui/TextButton";
 
 type Props = {
   readonly locationName: string | undefined;
@@ -49,13 +50,12 @@ const ScanSessionPanel = ({ locationName, onConfirmAll }: Props) => {
             </p>
           </div>
         </div>
-        <button
-          onClick={() => resetSession()}
-          className="flex items-center gap-1 text-xs text-text-tertiary transition-colors hover:text-text-secondary"
-        >
-          <RotateCcw className="size-3" />
-          <Trans>リセット</Trans>
-        </button>
+        <TextButton variant="muted" onClick={() => resetSession()}>
+          <span className="inline-flex items-center gap-1">
+            <RotateCcw className="size-3" />
+            <Trans>リセット</Trans>
+          </span>
+        </TextButton>
       </div>
 
       {scannedIds.length > 0 && (

--- a/src/components/ui/ChipGroup.tsx
+++ b/src/components/ui/ChipGroup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import clsx from "clsx";
+import Chip from "@/components/ui/Chip";
 
 type ChipOption<T extends string> = {
   readonly value: T;
@@ -20,19 +20,14 @@ const ChipGroup = <T extends string>({
 }: Props<T>) => (
   <div className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-1 lg:mx-0 lg:flex-wrap lg:overflow-visible lg:px-0">
     {options.map((option) => (
-      <button
-        key={option.value}
-        type="button"
-        onClick={() => onSelect(option.value)}
-        className={clsx(
-          "shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
-          value === option.value
-            ? "bg-primary-500 text-text-inverse"
-            : "border border-border-default bg-surface-overlay text-text-secondary hover:bg-primary-50",
-        )}
-      >
-        {option.label}
-      </button>
+      <div key={option.value} className="shrink-0">
+        <Chip
+          selected={value === option.value}
+          onClick={() => onSelect(option.value)}
+        >
+          {option.label}
+        </Chip>
+      </div>
     ))}
   </div>
 );

--- a/src/components/ui/FilterToggleButton.tsx
+++ b/src/components/ui/FilterToggleButton.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { SlidersHorizontal } from "lucide-react";
-import clsx from "clsx";
 import { Trans } from "@lingui/react/macro";
+import Button from "@/components/ui/Button";
 
 type Props = {
   readonly isOpen: boolean;
@@ -10,25 +10,23 @@ type Props = {
   readonly activeCount: number;
 };
 
-const FilterToggleButton = ({ isOpen, onToggle, activeCount }: Props) => (
-  <button
-    type="button"
-    onClick={onToggle}
-    className={clsx(
-      "relative flex h-10 items-center gap-1.5 rounded-lg border px-3 text-xs font-medium transition-colors",
-      isOpen || activeCount > 0
-        ? "border-primary-400 bg-primary-50 text-primary-700"
-        : "border-border-default bg-surface-overlay text-text-secondary hover:bg-surface-hover",
-    )}
-  >
-    <SlidersHorizontal className="size-4" />
-    <Trans>フィルター</Trans>
-    {activeCount > 0 && (
-      <span className="flex size-4 items-center justify-center rounded-full bg-primary-500 text-[10px] font-bold text-text-inverse">
-        {activeCount}
-      </span>
-    )}
-  </button>
-);
+const FilterToggleButton = ({ isOpen, onToggle, activeCount }: Props) => {
+  const isActive = isOpen || activeCount > 0;
+  return (
+    <Button
+      variant={isActive ? "secondary" : "outline"}
+      size="md"
+      onClick={onToggle}
+    >
+      <SlidersHorizontal className="size-4" />
+      <Trans>フィルター</Trans>
+      {activeCount > 0 && (
+        <span className="flex size-4 items-center justify-center rounded-full bg-primary-500 text-[10px] font-bold text-text-inverse">
+          {activeCount}
+        </span>
+      )}
+    </Button>
+  );
+};
 
 export default FilterToggleButton;

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import clsx from "clsx";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 import { PAGE_SIZES } from "@/lib/constants";
 import type { PageSize } from "@/lib/constants";
+import Button from "@/components/ui/Button";
+import IconButton from "@/components/ui/IconButton";
+import PageButton from "@/components/ui/PageButton";
 
 const ELLIPSIS = "ellipsis" as const;
 type PageItem = number | typeof ELLIPSIS;
@@ -90,55 +92,36 @@ const Pagination = ({ pagination, onChangePage, onChangePageSize }: Props) => {
       {totalPages > 1 && (
         <>
           <div className="flex items-center justify-center gap-2 lg:hidden">
-            <button
-              type="button"
+            <IconButton
+              icon={ChevronLeft}
+              label={i18n._(t`前のページ`)}
+              size="md"
               onClick={() => onChangePage(currentPage - 1)}
               disabled={isFirstPage}
-              aria-label={i18n._(t`前のページ`)}
-              className={clsx(
-                "inline-flex size-9 items-center justify-center rounded-lg transition-colors",
-                isFirstPage
-                  ? "pointer-events-none opacity-50"
-                  : "text-text-secondary hover:bg-primary-50",
-              )}
-            >
-              <ChevronLeft className="size-4" />
-            </button>
+            />
             <span className="text-sm text-text-secondary">
               {currentPage} / {totalPages}
             </span>
-            <button
-              type="button"
+            <IconButton
+              icon={ChevronRight}
+              label={i18n._(t`次のページ`)}
+              size="md"
               onClick={() => onChangePage(currentPage + 1)}
               disabled={isLastPage}
-              aria-label={i18n._(t`次のページ`)}
-              className={clsx(
-                "inline-flex size-9 items-center justify-center rounded-lg transition-colors",
-                isLastPage
-                  ? "pointer-events-none opacity-50"
-                  : "text-text-secondary hover:bg-primary-50",
-              )}
-            >
-              <ChevronRight className="size-4" />
-            </button>
+            />
           </div>
 
           <div className="hidden items-center justify-center gap-1 lg:flex">
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => onChangePage(currentPage - 1)}
               disabled={isFirstPage}
               aria-label={i18n._(t`前のページ`)}
-              className={clsx(
-                "inline-flex h-8 items-center gap-1 rounded-lg px-2 text-xs font-medium transition-colors",
-                isFirstPage
-                  ? "pointer-events-none opacity-50"
-                  : "text-text-secondary hover:bg-primary-50",
-              )}
             >
               <ChevronLeft className="size-3.5" />
               <Trans>前へ</Trans>
-            </button>
+            </Button>
 
             {visiblePages.map((item, i) =>
               item === ELLIPSIS ? (
@@ -150,38 +133,25 @@ const Pagination = ({ pagination, onChangePage, onChangePageSize }: Props) => {
                   ...
                 </span>
               ) : (
-                <button
+                <PageButton
                   key={item}
-                  type="button"
-                  onClick={() => onChangePage(item)}
-                  aria-current={item === currentPage ? "page" : undefined}
-                  className={clsx(
-                    "inline-flex size-8 items-center justify-center rounded-lg text-xs font-medium transition-colors",
-                    item === currentPage
-                      ? "bg-primary-500 text-text-inverse"
-                      : "border border-border-default bg-surface-overlay text-text-secondary hover:bg-primary-50",
-                  )}
-                >
-                  {item}
-                </button>
+                  page={item}
+                  currentPage={currentPage}
+                  onClick={onChangePage}
+                />
               ),
             )}
 
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => onChangePage(currentPage + 1)}
               disabled={isLastPage}
               aria-label={i18n._(t`次のページ`)}
-              className={clsx(
-                "inline-flex h-8 items-center gap-1 rounded-lg px-2 text-xs font-medium transition-colors",
-                isLastPage
-                  ? "pointer-events-none opacity-50"
-                  : "text-text-secondary hover:bg-primary-50",
-              )}
             >
               <Trans>次へ</Trans>
               <ChevronRight className="size-3.5" />
-            </button>
+            </Button>
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary
- Pagination / ChipGroup / FilterToggleButton / ReviewItemRow / 各ページの追加ボタン / CoordinateBuilder のアイコンボタン / GarmentForm のドールサイズ pill / 各画面の戻るボタンなどを、PR-A で整備した Button / IconButton / Chip / PageButton / TextButton に置換
- 直書きの `rounded-md` / `bg-red-500` / `size-9 vs size-8` 不一致 / `px-4 py-2 vs h-12 px-6` の不一致を解消

## 関連
- 基盤: #193 (PR-A)
- 計画: `/Users/butaosuinu/.claude/plans/ui-vast-feather.md` の PR-B

## Test plan
- [x] pnpm precheck
- [x] pnpm test:coverage (branches >= 80%)
- [x] pnpm build

🤖 Generated with [Claude Code](https://claude.com/claude-code)