### PR TITLE
fix(ui): Button/IconButton の type を button にデフォルト化

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -62,11 +62,13 @@ const Button = ({
   variant = "primary",
   size = "md",
   fullWidth = false,
+  type = "button",
   children,
   disabled,
   ...rest
 }: Props) => (
   <button
+    type={type}
     className={buttonClassName({
       variant,
       size,

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -55,10 +55,12 @@ const IconButton = ({
   label,
   size = "md",
   variant = "default",
+  type = "button",
   disabled,
   ...rest
 }: Props) => (
   <button
+    type={type}
     aria-label={label}
     className={iconButtonClassName({
       size,

--- a/src/components/ui/__tests__/Button.test.tsx
+++ b/src/components/ui/__tests__/Button.test.tsx
@@ -65,6 +65,38 @@ describe("Button", () => {
       "bg-danger",
     );
   });
+
+  it("既定で type=button が付与される（フォーム内でも submit しない）", () => {
+    render(<Button>ラベル</Button>);
+    expect(screen.getByRole("button", { name: "ラベル" })).toHaveAttribute(
+      "type",
+      "button",
+    );
+  });
+
+  it("type=submit を明示的に渡せる", () => {
+    render(<Button type="submit">送信</Button>);
+    expect(screen.getByRole("button", { name: "送信" })).toHaveAttribute(
+      "type",
+      "submit",
+    );
+  });
+
+  it("フォーム内でクリックしても onSubmit が走らない（既定 type=button）", async () => {
+    const handleSubmit = vi.fn((e: { preventDefault: () => void }) =>
+      e.preventDefault(),
+    );
+    const handleClick = vi.fn();
+    render(
+      <form onSubmit={handleSubmit}>
+        <Button onClick={handleClick}>操作</Button>
+      </form>,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "操作" }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
 });
 
 describe("buttonClassName", () => {

--- a/src/components/ui/__tests__/IconButton.test.tsx
+++ b/src/components/ui/__tests__/IconButton.test.tsx
@@ -47,6 +47,38 @@ describe("IconButton", () => {
     render(<IconButton icon={Pencil} label="編集" disabled />);
     expect(screen.getByRole("button", { name: "編集" })).toBeDisabled();
   });
+
+  it("既定で type=button が付与される（フォーム内でも submit しない）", () => {
+    render(<IconButton icon={Pencil} label="編集" />);
+    expect(screen.getByRole("button", { name: "編集" })).toHaveAttribute(
+      "type",
+      "button",
+    );
+  });
+
+  it("type=submit を明示的に渡せる", () => {
+    render(<IconButton icon={Pencil} label="送信" type="submit" />);
+    expect(screen.getByRole("button", { name: "送信" })).toHaveAttribute(
+      "type",
+      "submit",
+    );
+  });
+
+  it("フォーム内でクリックしても onSubmit が走らない（既定 type=button）", async () => {
+    const handleSubmit = vi.fn((e: { preventDefault: () => void }) =>
+      e.preventDefault(),
+    );
+    const handleClick = vi.fn();
+    render(
+      <form onSubmit={handleSubmit}>
+        <IconButton icon={Pencil} label="編集" onClick={handleClick} />
+      </form>,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "編集" }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
 });
 
 describe("iconButtonClassName", () => {


### PR DESCRIPTION
## Summary
PR #196 で `IconButton` をフォーム内（`CoordinateBuilder` の上へ／下へ／削除）に配置した際、HTML default の `type="submit"` が効いてしまい、クリックで意図せずコーデが保存されるリグレッションが発生していた。

`Button` / `IconButton` の両方で `type` prop の既定値を `"button"` に固定する。submit が必要な呼び出し側（フォームの登録ボタン等、計 11 箇所）はすべて既に `type="submit"` を明示済みのため影響なし。

## 関連
- Reported on: #196 ([Codex review](https://github.com/butaosuinu/Dollrobe/pull/196#discussion_r3213605382), [self-review](https://github.com/butaosuinu/Dollrobe/pull/196#discussion_r3213608175))

## 修正方針
コメントで提案された 2 案のうち「`IconButton` 側で `type="button"` をデフォルトにする（同類の問題を一括で塞げる。`Button` も同様に検討推奨）」を採用。`Chip` / `TextButton` / `PageButton` は元から hardcode 済みなので変更不要。

## 検証
- `Button.test.tsx` / `IconButton.test.tsx` に「既定で type=button が付与される」「type=submit を明示的に渡せる」「フォーム内でクリックしても onSubmit が走らない」のテストを追加（計 6 件）
- `pnpm precheck`: 0 errors
- `pnpm test`: 1237/1237 passed
- `pnpm test:coverage`: branches 82.02%
- `pnpm build`: success

## Test plan
- [x] pnpm precheck
- [x] pnpm test:coverage (branches >= 80%)
- [x] pnpm build
- [x] フォーム内 IconButton クリック時の onSubmit 非発火を unit test で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)