### PR TITLE
chore(ui): UI 統一の cleanup（focus-ring 集約・aria 標準化等）

### DIFF
--- a/src/app/coordinates/page.tsx
+++ b/src/app/coordinates/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAtomValue } from "jotai";
 import { Plus, Sparkles } from "lucide-react";
+import clsx from "clsx";
 import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import { coordinatesAtom } from "@/stores/coordinateAtoms";
@@ -58,7 +59,10 @@ const CoordinatesPage = () => (
       </h2>
       <Link
         href="/coordinates/new"
-        className={`hidden lg:inline-flex ${buttonClassName({ variant: "primary", size: "md" })}`}
+        className={clsx(
+          "hidden lg:inline-flex",
+          buttonClassName({ variant: "primary", size: "md" }),
+        )}
       >
         <Plus className="size-4" />
         <Trans>新規作成</Trans>

--- a/src/app/dolls/page.tsx
+++ b/src/app/dolls/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAtomValue } from "jotai";
 import { Plus, User, Archive } from "lucide-react";
+import clsx from "clsx";
 import { Trans } from "@lingui/react/macro";
 import { msg, t } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
@@ -296,7 +297,10 @@ const DollsPage = () => (
       </h2>
       <Link
         href="/dolls/new"
-        className={`hidden lg:inline-flex ${buttonClassName({ variant: "primary", size: "md" })}`}
+        className={clsx(
+          "hidden lg:inline-flex",
+          buttonClassName({ variant: "primary", size: "md" }),
+        )}
       >
         <Plus className="size-4" />
         <Trans>ドールを登録</Trans>

--- a/src/app/nfc-write/page.tsx
+++ b/src/app/nfc-write/page.tsx
@@ -112,10 +112,8 @@ const SelectItemStep = ({
   return (
     <div className="flex flex-col gap-4">
       <TextButton variant="muted" onClick={onBack}>
-        <span className="inline-flex items-center gap-1">
-          <ArrowLeft className="size-4" />
-          <Trans>戻る</Trans>
-        </span>
+        <ArrowLeft className="size-4" />
+        <Trans>戻る</Trans>
       </TextButton>
       <Select
         label={i18n._(
@@ -154,18 +152,16 @@ const ReadyToWriteStep = ({
 }: ReadyToWriteStepProps) => (
   <div className="flex flex-col gap-4">
     <TextButton variant="muted" onClick={onBack}>
-      <span className="inline-flex items-center gap-1">
-        <ArrowLeft className="size-4" />
-        <Trans>戻る</Trans>
-      </span>
+      <ArrowLeft className="size-4" />
+      <Trans>戻る</Trans>
     </TextButton>
-    <div className="rounded-xl border border-border-default bg-surface-overlay p-4">
+    <Card padding="md">
       <p className="text-sm text-text-secondary">
         <Trans>書き込み対象</Trans>
       </p>
       <p className="font-medium text-text-primary">{selectedName}</p>
       <p className="mt-1 font-mono text-xs text-text-tertiary">{scheme}</p>
-    </div>
+    </Card>
     <Button variant="primary" size="lg" fullWidth onClick={onStartWrite}>
       <SmartphoneNfc className="size-5" />
       <Trans>書き込む</Trans>

--- a/src/components/coordinate/CoordinateBuilder.tsx
+++ b/src/components/coordinate/CoordinateBuilder.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/constants";
 import { GARMENT_CATEGORY_LABEL } from "@/lib/i18n-labels";
 import type { Coordinate, Garment } from "@/types";
+import Badge from "@/components/ui/Badge";
 import Button from "@/components/ui/Button";
 import Card from "@/components/ui/Card";
 import FormShell from "@/components/ui/FormShell";
@@ -145,7 +146,7 @@ const GarmentTile = ({
       clickable
       padding="sm"
       onClick={() => onToggle(garment.id)}
-      ariaPressed={selected}
+      aria-pressed={selected}
       className={clsx(
         "flex flex-col items-stretch gap-1 transition-colors",
         selected ? "border-primary-500 bg-primary-50" : "hover:bg-primary-50",
@@ -380,9 +381,7 @@ const CoordinateBuilder = ({
             <p className="text-sm font-medium text-text-secondary">
               <Trans>選択中の服</Trans>
             </p>
-            <span className="rounded-full bg-primary-100 px-2 py-0.5 text-xs font-semibold text-primary-700">
-              {s.selectedGarments.length}
-            </span>
+            <Badge variant="primary">{s.selectedGarments.length}</Badge>
           </div>
           <SelectedGarmentsList
             selectedGarments={s.selectedGarments}

--- a/src/components/dashboard/StaleLocationItem.tsx
+++ b/src/components/dashboard/StaleLocationItem.tsx
@@ -3,7 +3,9 @@
 import { useRouter } from "next/navigation";
 import { Clock, ChevronRight } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
+import clsx from "clsx";
 import type { StaleLocation } from "@/stores/dashboardAtoms";
+import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
 
 type Props = {
   readonly item: StaleLocation;
@@ -29,7 +31,10 @@ const StaleLocationItem = ({ item }: Props) => {
     <button
       type="button"
       onClick={handleClick}
-      className="flex w-full items-center gap-3 rounded-xl border border-border-default bg-surface-overlay p-4 text-left transition-shadow hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+      className={clsx(
+        "flex w-full items-center gap-3 rounded-xl border border-border-default bg-surface-overlay p-4 text-left transition-shadow hover:shadow-md",
+        FOCUS_RING_CLASS,
+      )}
     >
       <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary-50">
         <Clock className="size-5 text-primary-500" />

--- a/src/components/garment/bulk/BulkMetadataForm.tsx
+++ b/src/components/garment/bulk/BulkMetadataForm.tsx
@@ -93,10 +93,8 @@ const BulkMetadataForm = () => {
       {!isFirst && (
         <div className="flex justify-center">
           <TextButton onClick={handleApplyPrevious}>
-            <span className="inline-flex items-center gap-2">
-              <Copy className="size-4" />
-              <Trans>前の値を適用</Trans>
-            </span>
+            <Copy className="size-4" />
+            <Trans>前の値を適用</Trans>
           </TextButton>
         </div>
       )}

--- a/src/components/location/StorageCell.tsx
+++ b/src/components/location/StorageCell.tsx
@@ -3,6 +3,7 @@ import { Trans } from "@lingui/react/macro";
 import type { Garment, StorageLocation } from "@/types";
 import { getConfidence, getConfidenceLabel } from "@/lib/confidence";
 import { GARMENT_STATUS } from "@/lib/constants";
+import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
 
 type Props = {
   readonly location: StorageLocation;
@@ -43,7 +44,7 @@ const StorageCell = ({ location, garments, onClick, isSelected }: Props) => {
       className={clsx(
         "flex flex-col items-center justify-center rounded-lg border p-2 transition-all",
         "hover:shadow-sm active:scale-95",
-        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+        FOCUS_RING_CLASS,
         CELL_BG[status],
         isSelected === true && "ring-2 ring-primary-500",
       )}

--- a/src/components/marketing/MarketingCTA.tsx
+++ b/src/components/marketing/MarketingCTA.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import clsx from "clsx";
+import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
 
 type Props = {
   readonly href?: string;
@@ -38,7 +39,7 @@ const MarketingCTA = ({
     href={href}
     className={clsx(
       "inline-flex items-center justify-center gap-2 rounded-full font-display font-bold transition-all",
-      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+      FOCUS_RING_CLASS,
       VARIANT_STYLES[variant],
       SIZE_STYLES[size],
       className,

--- a/src/components/scan/ScanSessionPanel.tsx
+++ b/src/components/scan/ScanSessionPanel.tsx
@@ -51,10 +51,8 @@ const ScanSessionPanel = ({ locationName, onConfirmAll }: Props) => {
           </div>
         </div>
         <TextButton variant="muted" onClick={() => resetSession()}>
-          <span className="inline-flex items-center gap-1">
-            <RotateCcw className="size-3" />
-            <Trans>リセット</Trans>
-          </span>
+          <RotateCcw className="size-3" />
+          <Trans>リセット</Trans>
         </TextButton>
       </div>
 

--- a/src/components/settings/account/DeleteAccountSection.tsx
+++ b/src/components/settings/account/DeleteAccountSection.tsx
@@ -66,7 +66,7 @@ const DeleteAccountSection = ({ currentEmail, hasPassword }: Props) => {
   return (
     <section
       aria-labelledby="danger-zone-title"
-      className="mt-4 rounded-2xl border border-danger/20 bg-danger/8 p-5"
+      className="mt-4 rounded-2xl border border-danger/20 bg-danger/10 p-5"
     >
       <header className="mb-4 flex items-start gap-3">
         <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-danger/15 text-danger">

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
 
 type ButtonVariant =
   | "primary"
@@ -51,7 +52,7 @@ export const buttonClassName = ({
 }: ButtonClassNameOptions = {}) =>
   clsx(
     "inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors",
-    "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+    FOCUS_RING_CLASS,
     VARIANT_STYLES[variant],
     SIZE_STYLES[size],
     fullWidth && "w-full",
@@ -73,7 +74,7 @@ const Button = ({
       variant,
       size,
       fullWidth,
-      disabled: disabled === true,
+      disabled: Boolean(disabled),
     })}
     disabled={disabled}
     {...rest}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
 
 type CardPadding = "sm" | "md" | "lg";
 type CardRadius = "md" | "lg";
@@ -24,19 +25,19 @@ type BaseProps = {
 
 type StaticProps = BaseProps & {
   readonly clickable?: false;
-  readonly onClick?: never;
-  readonly disabled?: never;
-  readonly type?: never;
-};
+} & Omit<
+    React.HTMLAttributes<HTMLDivElement>,
+    "className" | "children" | keyof BaseProps
+  >;
 
 type ClickableProps = BaseProps & {
   readonly clickable: true;
-  readonly onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  readonly disabled?: boolean;
-  readonly type?: "button" | "submit";
-  readonly ariaPressed?: boolean;
-  readonly ariaLabel?: string;
-};
+} & Omit<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    "className" | "children" | "type" | keyof BaseProps
+  > & {
+    readonly type?: "button" | "submit";
+  };
 
 type Props = StaticProps | ClickableProps;
 
@@ -59,8 +60,7 @@ const cardClassName = ({
     RADIUS_STYLES[radius],
     hoverable &&
       "transition-all hover:-translate-y-0.5 hover:shadow-md active:translate-y-0",
-    clickable &&
-      "text-left w-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+    clickable && clsx("text-left w-full", FOCUS_RING_CLASS),
     className,
   );
 
@@ -74,13 +74,10 @@ const Card = (props: Props) => {
   } = props;
 
   if (props.clickable === true) {
+    const { clickable: _c, type = "button", ...rest } = props;
     return (
       <button
-        type={props.type ?? "button"}
-        onClick={props.onClick}
-        disabled={props.disabled}
-        aria-pressed={props.ariaPressed}
-        aria-label={props.ariaLabel}
+        type={type}
         className={cardClassName({
           hoverable,
           padding,
@@ -88,12 +85,14 @@ const Card = (props: Props) => {
           clickable: true,
           className,
         })}
+        {...rest}
       >
         {children}
       </button>
     );
   }
 
+  const { clickable: _c, ...rest } = props;
   return (
     <div
       className={cardClassName({
@@ -103,6 +102,7 @@ const Card = (props: Props) => {
         clickable: false,
         className,
       })}
+      {...rest}
     >
       {children}
     </div>

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -1,25 +1,34 @@
 import clsx from "clsx";
+import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
 
 type Props = {
   readonly selected: boolean;
   readonly onClick?: () => void;
   readonly children: React.ReactNode;
   readonly disabled?: boolean;
+  readonly className?: string;
 };
 
-const Chip = ({ selected, onClick, children, disabled = false }: Props) => (
+const Chip = ({
+  selected,
+  onClick,
+  children,
+  disabled = false,
+  className,
+}: Props) => (
   <button
     type="button"
     onClick={onClick}
     disabled={disabled}
     aria-pressed={selected}
     className={clsx(
-      "rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
-      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+      "shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+      FOCUS_RING_CLASS,
       selected
         ? "bg-primary-500 text-text-inverse"
         : "border border-border-default bg-surface-overlay text-text-secondary hover:bg-primary-50",
       disabled && "pointer-events-none opacity-50",
+      className,
     )}
   >
     {children}

--- a/src/components/ui/ChipGroup.tsx
+++ b/src/components/ui/ChipGroup.tsx
@@ -20,14 +20,13 @@ const ChipGroup = <T extends string>({
 }: Props<T>) => (
   <div className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-1 lg:mx-0 lg:flex-wrap lg:overflow-visible lg:px-0">
     {options.map((option) => (
-      <div key={option.value} className="shrink-0">
-        <Chip
-          selected={value === option.value}
-          onClick={() => onSelect(option.value)}
-        >
-          {option.label}
-        </Chip>
-      </div>
+      <Chip
+        key={option.value}
+        selected={value === option.value}
+        onClick={() => onSelect(option.value)}
+      >
+        {option.label}
+      </Chip>
     ))}
   </div>
 );

--- a/src/components/ui/ColorPicker.tsx
+++ b/src/components/ui/ColorPicker.tsx
@@ -3,6 +3,7 @@
 import { Plus, X } from "lucide-react";
 import clsx from "clsx";
 import { PRESET_COLORS } from "@/lib/color/presets";
+import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
 
 type Props = {
   readonly label?: string;
@@ -58,7 +59,7 @@ const ColorPicker = ({ label, colors, onChangeColors }: Props) => {
             }}
             className={clsx(
               "size-7 rounded-full border border-border-default transition-transform hover:scale-110",
-              "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+              FOCUS_RING_CLASS,
             )}
             style={{ backgroundColor: color }}
             aria-label={`${color}を追加`}

--- a/src/components/ui/ErrorAlert.tsx
+++ b/src/components/ui/ErrorAlert.tsx
@@ -5,7 +5,7 @@ type Props = {
 const ErrorAlert = ({ children }: Props) => (
   <p
     role="alert"
-    className="rounded-lg border border-danger/30 bg-danger/8 px-3 py-2 text-xs text-danger"
+    className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger"
   >
     {children}
   </p>

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import type { LucideIcon } from "lucide-react";
+import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
 
 type IconButtonSize = "xs" | "sm" | "md" | "lg";
 type IconButtonVariant = "default" | "primary" | "danger";
@@ -44,7 +45,7 @@ export const iconButtonClassName = ({
 }: IconButtonClassNameOptions = {}) =>
   clsx(
     "inline-flex items-center justify-center rounded-lg transition-colors",
-    "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+    FOCUS_RING_CLASS,
     SIZE_STYLES[size],
     VARIANT_STYLES[variant],
     disabled && "pointer-events-none opacity-50",
@@ -65,7 +66,7 @@ const IconButton = ({
     className={iconButtonClassName({
       size,
       variant,
-      disabled: disabled === true,
+      disabled: Boolean(disabled),
     })}
     disabled={disabled}
     {...rest}

--- a/src/components/ui/PageButton.tsx
+++ b/src/components/ui/PageButton.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
 
 type Props = {
   readonly page: number;
@@ -15,7 +16,7 @@ const PageButton = ({ page, currentPage, onClick }: Props) => {
       aria-current={active ? "page" : undefined}
       className={clsx(
         "size-8 rounded-lg text-xs font-medium transition-colors",
-        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+        FOCUS_RING_CLASS,
         active
           ? "bg-primary-500 text-text-inverse"
           : "border border-border-default bg-surface-overlay text-text-secondary hover:bg-primary-50",

--- a/src/components/ui/TextButton.tsx
+++ b/src/components/ui/TextButton.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
 
 type TextButtonVariant = "primary" | "secondary" | "muted";
 
@@ -26,8 +27,8 @@ const TextButton = ({
     onClick={onClick}
     disabled={disabled}
     className={clsx(
-      "text-sm font-medium transition-colors",
-      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500",
+      "inline-flex items-center gap-1 text-sm font-medium transition-colors",
+      FOCUS_RING_CLASS,
       VARIANT_STYLES[variant],
       disabled && "pointer-events-none opacity-50",
     )}

--- a/src/lib/uiClasses.ts
+++ b/src/lib/uiClasses.ts
@@ -1,0 +1,2 @@
+export const FOCUS_RING_CLASS =
+  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500";


### PR DESCRIPTION
## Summary
`/simplify` による 3 並列 code review (#193〜#197 全差分対象) で出た P1/P2 のうち、value ある 10 項目を 1 PR で対応。P0 はゼロ。

## 対応した修正
1. **focus-ring 文字列の集約** — `src/lib/uiClasses.ts` の `FOCUS_RING_CLASS` 定数として 1 箇所に集約。Button / IconButton / Card / Chip / PageButton / TextButton / ColorPicker / StorageCell / StaleLocationItem / MarketingCTA の 10 ファイルから参照。デザイントークン変更時の漏れを防ぐ
2. **Card の aria 標準化** — 独自命名の `ariaPressed` / `ariaLabel` を廃止し、`HTMLButtonElement`/`HTMLDivElement` の標準 `aria-*` を `...rest` で受け流す形に変更（leak abstraction 解消、`CoordinateBuilder` の利用側も `aria-pressed` に）
3. **disabled 冗長比較簡素化** — `disabled === true` → `Boolean(disabled)`（Button / IconButton）
4. **bg-danger 不揃い解消** — `bg-danger/8` → `bg-danger/10`（ErrorAlert / DeleteAccountSection）。`/10` 系列に統一
5. **ChipGroup ラッパ削除** — 内側 `<div class="shrink-0">` を消し、Chip 内部に `shrink-0` を吸収（DOM ノード削減）
6. **Chip に className prop** を追加（柔軟性向上）
7. **TextButton 内部に inline-flex** — `inline-flex items-center gap-1` を持たせ、呼び出し側 4 箇所 (`nfc-write` ×2 / `BulkMetadataForm` / `ScanSessionPanel`) の span ラッパを削除
8. **CoordinateBuilder のカウント badge** — 直書きの `<span class="rounded-full bg-primary-100...">` を `<Badge variant="primary">` に
9. **buttonClassName テンプレートリテラル統一** — `coordinates/page.tsx`, `dolls/page.tsx` の `\`hidden lg:inline-flex ${buttonClassName(...)}\`` を `clsx("hidden lg:inline-flex", buttonClassName(...))` に
10. **nfc-write info box** — `<div class="rounded-xl border ... p-4">` を `<Card padding="md">` に統一

## スキップ (理由付きで noted)
- 定数オブジェクト宣言スタイルの揺れ (`Record<...>` / `as const satisfies` / `Object.freeze`) — 影響範囲大、別タスク推奨
- React.memo 化 (GarmentTile / ReviewItemRow) — 100 ユーザー規模では過剰最適化
- 既存コードの三項ネスト (`GarmentForm` / `DollForm` / `nfc-write`) — PR 範囲外、別タスク
- form 内・外の生 `<button>` への type=button 適用 — 既存コードの範囲外、別タスク
- `StorageCaseForm` の生 button 重複 — 既存コード由来、別タスク
- `ImageUpload` の near-duplicate ProgressOverlay — 既存コード由来
- テスト `SIZE_CLASS` マッピング — テストの独立性のため許容
- `Pagination` の表示件数 select の `Select` 化 — UX 微調整必要、別タスク
- `SectionCard` を `Card` ベースに書き直し — `<section>` semantics と `shadow-card` 差を保持するため見送り

## 検証
- `pnpm precheck`: 0 errors
- `pnpm test`: 1237 tests passed
- `pnpm test:coverage`: branches 82.02%（>= 80% クリア）
- `pnpm build`: success

## Test plan
- [x] pnpm precheck
- [x] pnpm test:coverage (branches >= 80%)
- [x] pnpm build

🤖 Generated with [Claude Code](https://claude.com/claude-code)