### PR TITLE
fix(ui): Card の {...rest} 展開で className/非DOM props がリーク・上書きするバグを修正

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -65,45 +65,53 @@ const cardClassName = ({
   );
 
 const Card = (props: Props) => {
-  const {
-    children,
-    hoverable = false,
-    padding = "md",
-    radius = "md",
-    className,
-  } = props;
+  const merged = cardClassName({
+    hoverable: props.hoverable ?? false,
+    padding: props.padding ?? "md",
+    radius: props.radius ?? "md",
+    clickable: props.clickable === true,
+    className: props.className,
+  });
 
   if (props.clickable === true) {
-    const { clickable: _c, type = "button", ...rest } = props;
+    const {
+      clickable,
+      hoverable,
+      padding,
+      radius,
+      className,
+      children,
+      type = "button",
+      ...rest
+    } = props;
+    void clickable;
+    void hoverable;
+    void padding;
+    void radius;
+    void className;
     return (
-      <button
-        type={type}
-        className={cardClassName({
-          hoverable,
-          padding,
-          radius,
-          clickable: true,
-          className,
-        })}
-        {...rest}
-      >
+      <button {...rest} type={type} className={merged}>
         {children}
       </button>
     );
   }
 
-  const { clickable: _c, ...rest } = props;
+  const {
+    clickable,
+    hoverable,
+    padding,
+    radius,
+    className,
+    children,
+    ...rest
+  } = props;
+  void clickable;
+  void hoverable;
+  void padding;
+  void radius;
+  void className;
   return (
-    <div
-      className={cardClassName({
-        hoverable,
-        padding,
-        radius,
-        clickable: false,
-        className,
-      })}
-      {...rest}
-    >
+    <div {...rest} className={merged}>
       {children}
     </div>
   );

--- a/src/components/ui/__tests__/Card.test.tsx
+++ b/src/components/ui/__tests__/Card.test.tsx
@@ -94,4 +94,73 @@ describe("Card", () => {
       "custom-class",
     );
   });
+
+  it("static: className を渡しても base class が保持される", () => {
+    render(
+      <Card className="custom-class">
+        <span>静的</span>
+      </Card>,
+    );
+    const card = screen.getByText("静的").parentElement;
+    expect(card).toHaveClass("custom-class");
+    expect(card).toHaveClass("border-border-default");
+    expect(card).toHaveClass("bg-surface-overlay");
+    expect(card).toHaveClass("shadow-card");
+    expect(card).toHaveClass("p-4");
+    expect(card).toHaveClass("rounded-xl");
+  });
+
+  it("clickable: className を渡しても base class が保持される", () => {
+    render(
+      <Card clickable padding="sm" className="custom-class">
+        選択カード
+      </Card>,
+    );
+    const button = screen.getByRole("button", { name: "選択カード" });
+    expect(button).toHaveClass("custom-class");
+    expect(button).toHaveClass("border-border-default");
+    expect(button).toHaveClass("text-left");
+    expect(button).toHaveClass("w-full");
+    expect(button).toHaveClass("focus-visible:outline-primary-500");
+    expect(button).toHaveClass("p-3");
+  });
+
+  it("static: 非 DOM props (padding/radius/hoverable) が DOM 属性にリークしない", () => {
+    render(
+      <Card padding="lg" radius="lg" hoverable>
+        <span>非リーク</span>
+      </Card>,
+    );
+    const card = screen.getByText("非リーク").parentElement;
+    expect(card).not.toHaveAttribute("padding");
+    expect(card).not.toHaveAttribute("radius");
+    expect(card).not.toHaveAttribute("hoverable");
+    expect(card).not.toHaveAttribute("clickable");
+  });
+
+  it("clickable: 非 DOM props が DOM 属性にリークしない", () => {
+    render(
+      <Card clickable padding="lg" radius="lg" hoverable>
+        ボタン
+      </Card>,
+    );
+    const button = screen.getByRole("button", { name: "ボタン" });
+    expect(button).not.toHaveAttribute("padding");
+    expect(button).not.toHaveAttribute("radius");
+    expect(button).not.toHaveAttribute("hoverable");
+    expect(button).not.toHaveAttribute("clickable");
+  });
+
+  it("clickable: 標準 aria-* 属性は ...rest 経由でそのまま伝わる", () => {
+    render(
+      <Card clickable aria-pressed aria-label="aria伝播テスト">
+        子
+      </Card>,
+    );
+    const button = screen.getByRole("button", {
+      name: "aria伝播テスト",
+      pressed: true,
+    });
+    expect(button).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
PR #198 で導入した `Card.tsx` の `{...rest}` 展開には 2 つの regression があった:

1. `{...rest}` が `className={cardClassName(...)}` の **後** に展開されており、ユーザーが渡した `className` が `rest` に残ったまま flow した結果、JSX の後勝ちルールにより計算済み `className` を上書きしていた  
   → `GarmentCard` / `DigestBanner` / `CoordinateBuilder` の `GarmentTile` で `border` / `shadow-card` / `p-*` / `rounded-*` / `text-left w-full` / focus-ring 等の base style が消失していた
2. Card 専用の非 DOM props (`hoverable` / `padding` / `radius` / `clickable`) が `rest` 経由で DOM 要素にリーク → `<button hoverable padding="sm">` のような不正属性として出力されていた（React が warning を発する）

## 関連
- Reported on: #198 ([Codex review](https://github.com/butaosuinu/Dollrobe/pull/198#discussion_r3213726825), [self-review](https://github.com/butaosuinu/Dollrobe/pull/198#discussion_r3213728339))

## 修正方針
コメントの提案に従い、両ブランチで以下を実施:
- Card 専用 props (`clickable` / `hoverable` / `padding` / `radius` / `className` / `children`) を destructure で `rest` から除外
- `{...rest}` を **先に** 展開し、計算済み `className` / `type` を後で明示上書き

## 追加テスト（5 件）
- `static: className を渡しても base class が保持される`
- `clickable: className を渡しても base class が保持される`
- `static: 非 DOM props (padding/radius/hoverable) が DOM 属性にリークしない`
- `clickable: 非 DOM props が DOM 属性にリークしない`
- `clickable: 標準 aria-* 属性は ...rest 経由でそのまま伝わる`

既存の `Card.test.tsx` の "className が結合される" は `toHaveClass("custom-class")` しか検証しておらず本 regression を検出できなかったので、base class 保持を assert するテストを追加。

## 検証
- `pnpm precheck`: 0 errors
- `pnpm test`: 1242 tests passed (5 件追加)
- `pnpm test:coverage`: branches 82.04%（>= 80% クリア）
- `pnpm build`: success

## Test plan
- [x] pnpm precheck
- [x] pnpm test:coverage (branches >= 80%)
- [x] pnpm build
- [x] regression テストが PR #198 の Card.tsx で fail することを手元で確認（base class 消失パターン）

🤖 Generated with [Claude Code](https://claude.com/claude-code)