### PR TITLE
fix(branding): LP のサービス名表記を Dollrobe に統一

### DIFF
--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable lingui/no-unlocalized-strings -- static OG image (ja_JP) */
 import { ImageResponse } from "next/og";
 
-export const alt = "Doll Wardrobe — QR で、ドール服の収納を半自動管理";
+export const alt = "Dollrobe — QR で、ドール服の収納を半自動管理";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -62,7 +62,7 @@ const OpengraphImage = () =>
             letterSpacing: -1.5,
           }}
         >
-          DW
+          DR
         </div>
         <div
           style={{
@@ -72,7 +72,7 @@ const OpengraphImage = () =>
             letterSpacing: -1,
           }}
         >
-          Doll Wardrobe
+          Dollrobe
         </div>
       </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import LandingAuthRedirect from "@/components/marketing/LandingAuthRedirect";
 /* eslint-disable lingui/no-unlocalized-strings -- OG/Twitter metadata is static
    ja_JP; per-locale variants would need full SSR routing which is out of scope */
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "";
-const OG_TITLE = "Doll Wardrobe — ドール服が、どこにあるか分かる";
+const OG_TITLE = "Dollrobe — ドール服が、どこにあるか分かる";
 const OG_DESCRIPTION =
   "QR と NFC でドール服の収納を半自動管理する PWA。手入力なし、スキャンするだけで在庫が最新に。";
 
@@ -21,7 +21,7 @@ export const generateMetadata = (): Metadata => ({
   openGraph: {
     title: OG_TITLE,
     description: OG_DESCRIPTION,
-    siteName: "Doll Wardrobe",
+    siteName: "Dollrobe",
     locale: "ja_JP",
     type: "website",
   },

--- a/src/components/marketing/Logo.tsx
+++ b/src/components/marketing/Logo.tsx
@@ -12,7 +12,7 @@ const Logo = ({ size = 40, className }: Props) => (
     xmlns="http://www.w3.org/2000/svg"
     className={className}
     role="img"
-    aria-label="Doll Wardrobe"
+    aria-label="Dollrobe"
   >
     <defs>
       <linearGradient id="logoGradient" x1="0" y1="0" x2="40" y2="40">

--- a/src/components/marketing/MarketingFooter.tsx
+++ b/src/components/marketing/MarketingFooter.tsx
@@ -37,9 +37,8 @@ const MarketingFooter = () => (
       <div className="mt-20 flex flex-col items-start gap-8 border-t border-border-default/60 pt-10 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center gap-3">
           <Logo size={32} />
-          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- brand name */}
           <span className="font-display text-base font-bold text-primary-700">
-            Doll Wardrobe
+            Dollrobe
           </span>
         </div>
 
@@ -49,7 +48,7 @@ const MarketingFooter = () => (
       </div>
 
       {/* eslint-disable-next-line lingui/no-unlocalized-strings -- copyright + brand name */}
-      <p className="mt-8 text-xs text-text-tertiary">© 2026 Doll Wardrobe</p>
+      <p className="mt-8 text-xs text-text-tertiary">© 2026 Dollrobe</p>
     </div>
   </footer>
 );

--- a/src/components/marketing/MarketingHeader.tsx
+++ b/src/components/marketing/MarketingHeader.tsx
@@ -14,9 +14,8 @@ const MarketingHeader = () => (
         className="flex items-center gap-2.5 transition-opacity hover:opacity-80"
       >
         <Logo size={32} />
-        {/* eslint-disable-next-line lingui/no-unlocalized-strings -- brand name */}
         <span className="font-display text-lg font-bold tracking-tight text-primary-700">
-          Doll Wardrobe
+          Dollrobe
         </span>
       </Link>
       <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

- 未ログイン時の LP / OG メタデータに残っていた **"Doll Wardrobe"** 表記を正式名 **"Dollrobe"** に統一
- OG 画像左上のロゴバッジ内テキストを `DW` → `DR`（Dollrobe の頭2文字）に変更
- ブランド名が単一英単語になったことで Lingui の `no-unlocalized-strings` ルールが反応しなくなったため、ヘッダー / フッターの不要になった `eslint-disable-next-line` 注釈を削除

ダッシュボード・ログインページ・`APP_NAME` 定数等は既に Dollrobe 表記だったが、LP（PR #189 由来）のみ旧称が残っていたためブランド一貫性を回復させる。

## 修正対象

| ファイル | 変更 |
| --- | --- |
| `src/app/page.tsx` | OG タイトル / `siteName` |
| `src/app/opengraph-image.tsx` | alt / 表示テキスト / ロゴバッジ `DW` → `DR` |
| `src/components/marketing/MarketingHeader.tsx` | ヘッダーのブランド名 |
| `src/components/marketing/MarketingFooter.tsx` | フッターのブランド名 / コピーライト |
| `src/components/marketing/Logo.tsx` | SVG `aria-label` |

## 触らなかったもの

- IndexedDB クラス / DB 名（`DollWardrobeDB` / `"DollWardrobe"`）— 既存ユーザーのデータを破壊するため
- `wrangler.toml` の `doll-wardrobe-api` — 内部 API 名、ユーザーには見えない
- QR スキームの `dwg://` プレフィックス — 既発行 QR との互換性のため

## Test plan

- [x] `npx tsc-files --noEmit -p tsconfig.app.json` 通過
- [x] `npx eslint` 通過
- [x] `pnpm precheck` 通過（既存の magic-number warning のみ、今回の変更とは無関係）
- [ ] `pnpm dev` でブラウザ表示確認: ヘッダー / フッター / コピーライトが「Dollrobe」表記
- [ ] DevTools で `<title>` / `og:title` / `og:site_name` が「Dollrobe」になっていることを確認
- [ ] `/opengraph-image` 直接アクセスでロゴバッジが `DR` / 中央テキストが `Dollrobe` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)