### PR TITLE
fix(auth): RequireAuth が /signin リダイレクト時に redirect クエリを付与

### DIFF
--- a/src/components/auth/RequireAuth.test.tsx
+++ b/src/components/auth/RequireAuth.test.tsx
@@ -37,9 +37,32 @@ describe("RequireAuth", () => {
     );
 
     await waitFor(() => {
-      expect(router.replace).toHaveBeenCalledWith("/signin");
+      expect(router.replace).toHaveBeenCalledWith(
+        "/signin?redirect=%2Fdashboard",
+      );
     });
     expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument();
+  });
+
+  it("未認証時、検索クエリを含む現在 URL が redirect クエリに保持される", async () => {
+    server.use(unauthenticatedHandler);
+    const { router } = setupNextNavigation({
+      pathname: "/garments",
+      searchParams: new URLSearchParams("q=red"),
+    });
+
+    await renderWithProviders(
+      <RequireAuth>
+        <p data-testid="protected-content">秘匿ページ</p>
+      </RequireAuth>,
+    );
+
+    const expectedRedirect = `/signin?redirect=${encodeURIComponent(
+      `/garments?${new URLSearchParams("q=red").toString()}`,
+    )}`;
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith(expectedRedirect);
+    });
   });
 
   it("未認証 + オフラインのとき案内文が表示され redirect しない", async () => {

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, type ReactNode } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useAtomValue } from "jotai";
 import { Trans } from "@lingui/react/macro";
 import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
@@ -18,10 +18,13 @@ type Props = {
 const RequireAuth = ({ children }: Props) => {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { user, isLoading, hasError } = useAtomValue(authSessionUnwrappedAtom);
   const [isOnline, setIsOnline] = useState(true);
   const [isMounted, setIsMounted] = useState(false);
   const isPublicPath = PUBLIC_PATHS.has(pathname);
+  const search = searchParams.toString();
+  const redirectTo = search === "" ? pathname : `${pathname}?${search}`;
 
   useEffect(() => {
     setIsMounted(true);
@@ -47,9 +50,18 @@ const RequireAuth = ({ children }: Props) => {
       return;
     }
     if (isOnline) {
-      router.replace("/signin");
+      router.replace(`/signin?redirect=${encodeURIComponent(redirectTo)}`);
     }
-  }, [isPublicPath, isMounted, isLoading, user, hasError, isOnline, router]);
+  }, [
+    isPublicPath,
+    isMounted,
+    isLoading,
+    user,
+    hasError,
+    isOnline,
+    redirectTo,
+    router,
+  ]);
 
   if (isPublicPath) {
     return <>{children}</>;


### PR DESCRIPTION
## Summary

- 未認証ユーザーが `/dashboard` 等の保護ページに直接アクセスした際、`RequireAuth` が `redirect` クエリ無しの `/signin` に送っていたため、ログイン後に意図画面へ戻れない問題を修正
- LP CTA (`MarketingCTA.tsx`) と同形式で `/signin?redirect=${encodeURIComponent(pathname + search)}` を組み立て、戻り先を保持
- 受け取り側 (`signin/page.tsx` の `sanitizeRedirect`) が既に open redirect / 自己参照を弾くため、送る側のみの最小修正

## Test plan

- [x] `pnpm vitest run src/components/auth/RequireAuth.test.tsx`（既存 redirect 期待値を `%2Fdashboard` 付きに更新 + 検索クエリ保持の新規ケース追加 / 8 件 pass）
- [x] `pnpm vitest run 'src/app/(public)/signin/page.test.tsx'`（受け取り側の `sanitizeRedirect` 動作に影響なし / 11 件 pass）
- [x] `pnpm test`（1243 件 pass）
- [x] `pnpm precheck`（typecheck / lint / format / i18n / 0 errors）
- [ ] 手動確認: ログアウト状態で `/dashboard` 直アクセス → URL が `/signin?redirect=%2Fdashboard` になり、ログイン後 `/dashboard` に戻る

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)