### PR TITLE
fix(garment): ドールサイズチップを未選択スタートに変更し SD 二重付与を解消

### DIFF
--- a/src/components/garment/GarmentForm.test.tsx
+++ b/src/components/garment/GarmentForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test/mocks/server";
@@ -83,11 +83,58 @@ describe("GarmentForm", () => {
       expect(garments[0]?.id).toMatch(/^[a-z0-9]+$/);
       expect(garments[0]?.userId).toBe("user-1");
       expect(garments[0]?.category).toBe("tops");
-      expect(garments[0]?.dollSizes).toEqual(["SD"]);
+      expect(garments[0]?.dollSizes).toEqual([]);
       expect(garments[0]?.status).toBe("stored");
     });
     await waitFor(() => {
       expect(navHandle.router.push).toHaveBeenCalledWith("/garments");
+    });
+  });
+
+  it("初期表示ではどのドールサイズ Chip も選択されていない", async () => {
+    await renderWithProviders(<GarmentForm />);
+
+    const group = await screen.findByRole("group", { name: "ドールサイズ" });
+    const sizeButtons = within(group).getAllByRole("button");
+    expect(sizeButtons.length).toBeGreaterThan(0);
+    sizeButtons.forEach((btn) => {
+      expect(btn).toHaveAttribute("aria-pressed", "false");
+    });
+  });
+
+  it("サイズ Chip をクリックすると aria-pressed が切り替わり、再クリックで解除できる", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<GarmentForm />);
+
+    const group = await screen.findByRole("group", { name: "ドールサイズ" });
+    const sdButton = within(group).getByRole("button", { name: "SD (~57cm)" });
+
+    expect(sdButton).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(sdButton);
+    expect(sdButton).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(sdButton);
+    expect(sdButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("選んだサイズだけが保存される（SD+MSD を選択）", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<GarmentForm />);
+
+    const group = await screen.findByRole("group", { name: "ドールサイズ" });
+    await user.type(screen.getByLabelText("名前"), "二刀流ドレス");
+    await user.click(within(group).getByRole("button", { name: "SD (~57cm)" }));
+    await user.click(
+      within(group).getByRole("button", { name: "MSD (~43cm)" }),
+    );
+    await user.click(screen.getByRole("button", { name: "登録する" }));
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await waitFor(async () => {
+      const garments = await db.garments.toArray();
+      expect(garments[0]?.dollSizes).toEqual(["SD", "MSD"]);
     });
   });
 

--- a/src/components/garment/GarmentForm.tsx
+++ b/src/components/garment/GarmentForm.tsx
@@ -58,7 +58,7 @@ type FormValues = {
 const DEFAULT_FORM_VALUES: FormValues = {
   name: "",
   category: "tops",
-  dollSizes: ["SD"],
+  dollSizes: [],
   colors: [],
   tags: [],
   brand: "",
@@ -163,11 +163,7 @@ const GarmentForm = ({ garment }: Props) => {
 
   const toggleDollSize = (size: DollSize) => {
     setDollSizes((prev) =>
-      prev.includes(size)
-        ? prev.length > 1
-          ? prev.filter((s) => s !== size)
-          : prev
-        : [...prev, size],
+      prev.includes(size) ? prev.filter((s) => s !== size) : [...prev, size],
     );
   };
 

--- a/workers/src/db/validation.ts
+++ b/workers/src/db/validation.ts
@@ -118,7 +118,7 @@ export const createGarmentInputSchema = garmentInsertSchema
     updatedAt: true,
   })
   .extend({
-    dollSizes: z.array(dollSizeSchema).min(1),
+    dollSizes: z.array(dollSizeSchema),
     colors: z.array(z.string()).default([]),
     tags: z.array(z.string()).default([]),
     imageUrl: z.url().optional(),
@@ -145,7 +145,7 @@ export const updateGarmentInputSchema = z.object({
   id: cuidSchema,
   name: z.string().min(1).max(GARMENT_NAME_MAX_LENGTH).optional(),
   category: garmentCategorySchema.optional(),
-  dollSizes: z.array(dollSizeSchema).min(1).optional(),
+  dollSizes: z.array(dollSizeSchema).optional(),
   colors: z.array(z.string()).optional(),
   tags: z.array(z.string()).optional(),
   imageUrl: z.url().optional(),
@@ -184,7 +184,7 @@ export const bulkCreateGarmentItemSchema = garmentInsertSchema
     locationId: true,
   })
   .extend({
-    dollSizes: z.array(dollSizeSchema).min(1),
+    dollSizes: z.array(dollSizeSchema),
     colors: z.array(z.string()).default([]),
     tags: z.array(z.string()).default([]),
     brand: z.string().max(GARMENT_NAME_MAX_LENGTH).optional(),

--- a/workers/src/repositories/garment-repository.ts
+++ b/workers/src/repositories/garment-repository.ts
@@ -43,10 +43,10 @@ const validateGarmentRow = (
   }
 
   const validDollSizes = row.dollSizes.filter(isDollSize);
-  if (validDollSizes.length === 0) {
+  if (validDollSizes.length !== row.dollSizes.length) {
     throw new TRPCError({
       code: "INTERNAL_SERVER_ERROR",
-      message: `Invalid or empty dollSizes: ${JSON.stringify(row.dollSizes)}`,
+      message: `Invalid dollSizes: ${JSON.stringify(row.dollSizes)}`,
     });
   }
 

--- a/workers/src/test/garment-crud.scenario.test.ts
+++ b/workers/src/test/garment-crud.scenario.test.ts
@@ -30,6 +30,19 @@ describe("服 CRUD シナリオ", () => {
       expect(fetched.confidenceDecayDays).toBe(30);
     });
 
+    it("空の dollSizes で作成しても get/list で 500 にならない", async () => {
+      const caller = getCaller();
+      const created = await caller.garment.create(
+        createTestGarmentInput({ dollSizes: [] }),
+      );
+
+      const fetched = await caller.garment.get({ id: created.id });
+      expect(fetched.dollSizes).toEqual([]);
+
+      const listed = await caller.garment.list({});
+      expect(listed.find((g) => g.id === created.id)?.dollSizes).toEqual([]);
+    });
+
     it("locationId なしで作成すると status が checked_out になる", async () => {
       const caller = getCaller();
       const created = await caller.garment.create(createTestGarmentInput());


### PR DESCRIPTION
## Summary
- `/garments/new` と `/garments/<id>/edit` のドールサイズ Chip で SD が `aria-pressed="true"` で初期選択され、ユーザーが他サイズを選んでも SD と二重に保存されるバグを修正。
- `DEFAULT_FORM_VALUES.dollSizes` を `["SD"]` → `[]` に変更し、`toggleDollSize` の「最後の 1 つは削除不可」制約も外して未選択へ戻せるようにした。
- クライアントの未選択許可とサーバー側 Zod の整合性を取るため、`workers/src/db/validation.ts` の `dollSizes` 3 箇所から `.min(1)` を外した。

Closes #204

## Test plan
- [x] `pnpm vitest run src/components/garment/GarmentForm.test.tsx` — 16 件 pass（既存テスト更新 + 新規 3 件追加）
  - 初期表示でどのサイズ Chip も `aria-pressed="false"` であること
  - SD Chip 再クリックで解除できること
  - SD + MSD を選んで登録すると `dollSizes: ["SD", "MSD"]` で保存されること
- [x] `pnpm vitest run workers/src/test/garment-crud.scenario.test.ts workers/src/trpc/routers/garment.test.ts` — 35 件 pass（既存 workers テストに回帰なし）
- [x] `pnpm precheck` — typecheck / lint / format / i18n すべて pass
- [x] `pnpm test:coverage` — 1245 件 pass、branch coverage 82.06%（閾値 80% 超）

🤖 Generated with [Claude Code](https://claude.com/claude-code)