### PR TITLE
fix(i18n): ヘッダーの設定リンクが locale 切替に追従しないバグを修正

### DIFF
--- a/src/components/auth/UserMenu.test.tsx
+++ b/src/components/auth/UserMenu.test.tsx
@@ -1,12 +1,21 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { i18n } from "@lingui/core";
+import { messages as enMessages } from "@/locales/en/messages.mjs";
 import { server } from "@/test/mocks/server";
 import { unauthenticatedHandler } from "@/test/mocks/handlers";
 import { renderWithProviders } from "@/test/testUtils";
 import UserMenu from "./UserMenu";
 
 describe("UserMenu", () => {
+  afterEach(() => {
+    act(() => {
+      i18n.load("ja", {});
+      i18n.activate("ja");
+    });
+  });
+
   it("認証済みユーザーのイニシャルが表示される", async () => {
     await renderWithProviders(<UserMenu />);
 
@@ -72,5 +81,18 @@ describe("UserMenu", () => {
         screen.queryByRole("heading", { name: "ログアウトしますか？" }),
       ).toBeNull();
     });
+  });
+
+  it("locale を en に切替えると設定リンクの aria-label が Settings になる", async () => {
+    await renderWithProviders(<UserMenu />);
+
+    expect(await screen.findByLabelText("設定")).toBeInTheDocument();
+
+    act(() => {
+      i18n.load("en", enMessages);
+      i18n.activate("en");
+    });
+
+    expect(await screen.findByLabelText("Settings")).toBeInTheDocument();
   });
 });

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -4,14 +4,14 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useAtomValue, useSetAtom } from "jotai";
 import { LogOut, Settings } from "lucide-react";
-import { Trans } from "@lingui/react/macro";
-import { t } from "@lingui/core/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { authSessionUnwrappedAtom, signOutAtom } from "@/stores/authAtoms";
 import ConfirmSheet from "@/components/ui/ConfirmSheet";
 import IconButton, { iconButtonClassName } from "@/components/ui/IconButton";
 import { buttonClassName } from "@/components/ui/Button";
 
 const UserMenu = () => {
+  const { t } = useLingui();
   const authState = useAtomValue(authSessionUnwrappedAtom);
   const signOut = useSetAtom(signOutAtom);
   const [isMounted, setIsMounted] = useState(false);


### PR DESCRIPTION
## Summary

- `src/components/auth/UserMenu.tsx` で `t` を `@lingui/core/macro` から import していたが、これは React-reactive ではないシングルトンで、コンポーネントを locale 変更に subscribe させない
- `UserMenu` は `authSessionUnwrappedAtom` にしか subscribe していないため、locale 変更時に再レンダリングされず、`t\`設定\`` の評価結果が初回レンダー時の言語のまま stale 化していた（=「設定」のまま）
- `useLingui` from `@lingui/react/macro` 経由の `t` に変更することで、`I18nProvider` 配下の locale 変更に追従するようになる
- 翻訳エントリ（en→"Settings" / ko→"설정" / zh→"设置"）は既に `messages.po` に登録済みなので PO 変更は不要

## 影響範囲

UserMenu 内の以下 5 箇所の `t\`...\`` が同時に修正される:

- Settings リンクの `aria-label`
- ログアウト IconButton の `label`
- ConfirmSheet の `title` / `message` / `confirmLabel`

スコープ外: 同じ anti-pattern を持つ他コンポーネントは locale atom や local state を経由して再レンダリングされるため実害が見えていない。本 issue では UserMenu のみ修正。

## Test plan

- [x] `pnpm vitest run src/components/auth/UserMenu.test.tsx` — 既存 5 テスト + 追加した回帰テスト 1 件、計 6 テスト pass
- [x] `npx tsc-files --noEmit -p tsconfig.app.json src/components/auth/UserMenu.tsx src/components/auth/UserMenu.test.tsx`
- [x] `npx eslint src/components/auth/UserMenu.tsx src/components/auth/UserMenu.test.tsx`
- [x] `pnpm i18n:extract` — PO 差分なし、未翻訳 0
- [x] `pnpm precheck` — error 0
- [ ] 手動: dev server で言語ボタンから en/ko/zh に切替え、Settings リンクの aria-label が Settings/설정/设置 に変わることを DevTools で確認

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)