### PR TITLE
fix(signup): Zod バリデーションメッセージを Lingui で i18n 化

### DIFF
--- a/src/app/(public)/signup/page.test.tsx
+++ b/src/app/(public)/signup/page.test.tsx
@@ -66,6 +66,29 @@ describe("SignUpPage", () => {
     });
   });
 
+  it("空のまま送信すると各フィールドに日本語バリデーションメッセージが表示される", async () => {
+    server.use(unauthenticatedHandler);
+    const { spies } = setupAuthClient();
+
+    const user = userEvent.setup();
+    await renderWithProviders(<SignUpPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "アカウント作成" }),
+    );
+
+    expect(spies.signUpWithEmail).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText("表示名を入力してください"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("正しいメールアドレスを入力してください"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText("パスワードは 8 文字以上で入力してください").length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+
   it("パスワード不一致でバリデーションエラーが表示され送信されない", async () => {
     server.use(unauthenticatedHandler);
     const { spies } = setupAuthClient();

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSetAtom } from "jotai";
 import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
-import { signUpEmailSchema, signUpWithEmail } from "@/lib/auth";
+import { useLingui } from "@lingui/react";
+import { createSignUpEmailSchema, signUpWithEmail } from "@/lib/auth";
 import { refreshAuthAtom } from "@/stores/authAtoms";
 import Button from "@/components/ui/Button";
 import ErrorAlert from "@/components/ui/ErrorAlert";
@@ -28,6 +29,8 @@ const EMPTY_ERRORS: FieldErrors = {
 const SignUpForm = () => {
   const router = useRouter();
   const refreshAuth = useSetAtom(refreshAuthAtom);
+  const { i18n } = useLingui();
+  const schema = useMemo(() => createSignUpEmailSchema(i18n), [i18n]);
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -38,7 +41,7 @@ const SignUpForm = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const validate = () => {
-    const parsed = signUpEmailSchema.safeParse({
+    const parsed = schema.safeParse({
       name,
       email,
       password,

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -30,7 +30,10 @@ const SignUpForm = () => {
   const router = useRouter();
   const refreshAuth = useSetAtom(refreshAuthAtom);
   const { i18n } = useLingui();
-  const schema = useMemo(() => createSignUpEmailSchema(i18n), [i18n]);
+  // i18n は singleton で activate しても reference が変わらないため、locale
+  // 文字列を dep に入れてロケール切替時に schema を再生成する。
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: i18n is singleton, locale string drives rebuild
+  const schema = useMemo(() => createSignUpEmailSchema(i18n), [i18n.locale]);
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { setupI18n } from "@lingui/core";
+import { messages as enMessages } from "@/locales/en/messages.mjs";
+import { createSignUpEmailSchema } from "@/lib/auth";
+
+const VALID_INPUT = {
+  name: "佐藤",
+  email: "u@example.com",
+  password: "secret123",
+  passwordConfirm: "secret123",
+} as const;
+
+type FlatErrors = Readonly<Record<string, string | undefined>>;
+
+const flatten = (
+  result: ReturnType<ReturnType<typeof createSignUpEmailSchema>["safeParse"]>,
+): FlatErrors => {
+  if (result.success) return {};
+  const { fieldErrors } = result.error.flatten();
+  return {
+    name: fieldErrors.name?.[0],
+    email: fieldErrors.email?.[0],
+    password: fieldErrors.password?.[0],
+    passwordConfirm: fieldErrors.passwordConfirm?.[0],
+  };
+};
+
+describe("createSignUpEmailSchema", () => {
+  it("ja ロケール（カタログ未ロード）では msgid そのまま = 日本語を返す", () => {
+    const i18n = setupI18n({ locale: "ja", messages: { ja: {} } });
+    const schema = createSignUpEmailSchema(i18n);
+
+    const errs = flatten(
+      schema.safeParse({ ...VALID_INPUT, name: "", email: "", password: "" }),
+    );
+
+    expect(errs.name).toBe("表示名を入力してください");
+    expect(errs.email).toBe("正しいメールアドレスを入力してください");
+    expect(errs.password).toBe("パスワードは 8 文字以上で入力してください");
+  });
+
+  it("en ロケール（コンパイル済みカタログ）では英訳メッセージを返す", () => {
+    const i18n = setupI18n({
+      locale: "en",
+      messages: { en: enMessages },
+    });
+    const schema = createSignUpEmailSchema(i18n);
+
+    const errs = flatten(
+      schema.safeParse({ ...VALID_INPUT, name: "", email: "", password: "" }),
+    );
+
+    expect(errs.name).toBe("Please enter a display name");
+    expect(errs.email).toBe("Please enter a valid email address");
+    expect(errs.password).toBe("Password must be at least 8 characters");
+  });
+
+  it("en ロケールではパスワード不一致も英訳される", () => {
+    const i18n = setupI18n({
+      locale: "en",
+      messages: { en: enMessages },
+    });
+    const schema = createSignUpEmailSchema(i18n);
+
+    const errs = flatten(
+      schema.safeParse({ ...VALID_INPUT, passwordConfirm: "different1" }),
+    );
+
+    expect(errs.passwordConfirm).toBe("Passwords do not match");
+  });
+
+  it("正常入力なら success を返す", () => {
+    const i18n = setupI18n({ locale: "ja", messages: { ja: {} } });
+    const schema = createSignUpEmailSchema(i18n);
+
+    const result = schema.safeParse(VALID_INPUT);
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,7 @@
 import { createAuthClient } from "better-auth/react";
 import { apiKeyClient } from "@better-auth/api-key/client";
+import type { I18n } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
 import { z } from "zod";
 import { WORKERS_URL_FOR_FETCH } from "@/lib/workersUrl";
 
@@ -87,17 +89,35 @@ export const signInEmailSchema = z.object({
   password: z.string().min(1),
 });
 
-export const signUpEmailSchema = z
-  .object({
-    name: nameField,
-    email: emailField,
-    password: passwordField,
-    passwordConfirm: passwordField,
-  })
-  .refine((v) => v.password === v.passwordConfirm, {
-    path: ["passwordConfirm"],
-    message: "パスワードが一致しません",
-  });
+export const createSignUpEmailSchema = (i18n: I18n) => {
+  const localizedName = z
+    .string()
+    .trim()
+    .min(1, i18n._(msg`表示名を入力してください`))
+    .max(NAME_MAX, i18n._(msg`表示名は 60 文字以内で入力してください`));
+  const localizedEmail = z
+    .string()
+    .trim()
+    .pipe(z.email(i18n._(msg`正しいメールアドレスを入力してください`)));
+  const localizedPassword = z
+    .string()
+    .min(PASSWORD_MIN, i18n._(msg`パスワードは 8 文字以上で入力してください`))
+    .max(
+      PASSWORD_MAX,
+      i18n._(msg`パスワードは 128 文字以内で入力してください`),
+    );
+  return z
+    .object({
+      name: localizedName,
+      email: localizedEmail,
+      password: localizedPassword,
+      passwordConfirm: localizedPassword,
+    })
+    .refine((v) => v.password === v.passwordConfirm, {
+      path: ["passwordConfirm"],
+      message: i18n._(msg`パスワードが一致しません`),
+    });
+};
 
 export const updateProfileSchema = z.object({
   name: nameField,
@@ -135,7 +155,9 @@ export const deleteAccountSchema = z.object({
 });
 
 export type SignInEmailInput = z.infer<typeof signInEmailSchema>;
-export type SignUpEmailInput = z.infer<typeof signUpEmailSchema>;
+export type SignUpEmailInput = z.infer<
+  ReturnType<typeof createSignUpEmailSchema>
+>;
 export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
 export type ChangeEmailInput = z.infer<typeof changeEmailSchema>;
 export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -924,6 +924,10 @@ msgstr "Password"
 msgid "パスワード（確認）"
 msgstr "Password (Confirm)"
 
+#: src/lib/auth.ts
+msgid "パスワードが一致しません"
+msgstr "Passwords do not match"
+
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "パスワードが正しくないか、アカウントの削除に失敗しました"
 msgstr "Incorrect password, or failed to delete account"
@@ -931,6 +935,14 @@ msgstr "Incorrect password, or failed to delete account"
 #: src/components/settings/account/PasswordChangeForm.tsx
 msgid "パスワードの設定に失敗しました"
 msgstr "Failed to set password"
+
+#: src/lib/auth.ts
+msgid "パスワードは 128 文字以内で入力してください"
+msgstr "Password must be 128 characters or fewer"
+
+#: src/lib/auth.ts
+msgid "パスワードは 8 文字以上で入力してください"
+msgstr "Password must be at least 8 characters"
 
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "パスワードを入力"
@@ -1822,6 +1834,10 @@ msgstr "Next page"
 msgid "次へ"
 msgstr "Next"
 
+#: src/lib/auth.ts
+msgid "正しいメールアドレスを入力してください"
+msgstr "Please enter a valid email address"
+
 #: src/app/digest/page.tsx
 msgid "毎週月曜日に自動生成されます"
 msgstr "Auto-generated every Monday"
@@ -2009,6 +2025,14 @@ msgstr "Items per page"
 #: src/components/settings/account/ProfileForm.tsx
 msgid "表示名"
 msgstr "Display Name"
+
+#: src/lib/auth.ts
+msgid "表示名は 60 文字以内で入力してください"
+msgstr "Display name must be 60 characters or fewer"
+
+#: src/lib/auth.ts
+msgid "表示名を入力してください"
+msgstr "Please enter a display name"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/components/digest/DigestCard.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -924,6 +924,10 @@ msgstr "パスワード"
 msgid "パスワード（確認）"
 msgstr "パスワード（確認）"
 
+#: src/lib/auth.ts
+msgid "パスワードが一致しません"
+msgstr "パスワードが一致しません"
+
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "パスワードが正しくないか、アカウントの削除に失敗しました"
 msgstr "パスワードが正しくないか、アカウントの削除に失敗しました"
@@ -931,6 +935,14 @@ msgstr "パスワードが正しくないか、アカウントの削除に失敗
 #: src/components/settings/account/PasswordChangeForm.tsx
 msgid "パスワードの設定に失敗しました"
 msgstr "パスワードの設定に失敗しました"
+
+#: src/lib/auth.ts
+msgid "パスワードは 128 文字以内で入力してください"
+msgstr "パスワードは 128 文字以内で入力してください"
+
+#: src/lib/auth.ts
+msgid "パスワードは 8 文字以上で入力してください"
+msgstr "パスワードは 8 文字以上で入力してください"
 
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "パスワードを入力"
@@ -1822,6 +1834,10 @@ msgstr "次のページ"
 msgid "次へ"
 msgstr "次へ"
 
+#: src/lib/auth.ts
+msgid "正しいメールアドレスを入力してください"
+msgstr "正しいメールアドレスを入力してください"
+
 #: src/app/digest/page.tsx
 msgid "毎週月曜日に自動生成されます"
 msgstr "毎週月曜日に自動生成されます"
@@ -2009,6 +2025,14 @@ msgstr "表示件数"
 #: src/components/settings/account/ProfileForm.tsx
 msgid "表示名"
 msgstr "表示名"
+
+#: src/lib/auth.ts
+msgid "表示名は 60 文字以内で入力してください"
+msgstr "表示名は 60 文字以内で入力してください"
+
+#: src/lib/auth.ts
+msgid "表示名を入力してください"
+msgstr "表示名を入力してください"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/components/digest/DigestCard.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -924,6 +924,10 @@ msgstr "비밀번호"
 msgid "パスワード（確認）"
 msgstr "비밀번호 (확인)"
 
+#: src/lib/auth.ts
+msgid "パスワードが一致しません"
+msgstr "비밀번호가 일치하지 않습니다"
+
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "パスワードが正しくないか、アカウントの削除に失敗しました"
 msgstr "비밀번호가 올바르지 않거나 계정 삭제에 실패했습니다"
@@ -931,6 +935,14 @@ msgstr "비밀번호가 올바르지 않거나 계정 삭제에 실패했습니�
 #: src/components/settings/account/PasswordChangeForm.tsx
 msgid "パスワードの設定に失敗しました"
 msgstr "비밀번호 설정에 실패했습니다"
+
+#: src/lib/auth.ts
+msgid "パスワードは 128 文字以内で入力してください"
+msgstr "비밀번호는 128자 이하로 입력해 주세요"
+
+#: src/lib/auth.ts
+msgid "パスワードは 8 文字以上で入力してください"
+msgstr "비밀번호는 8자 이상으로 입력해 주세요"
 
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "パスワードを入力"
@@ -1822,6 +1834,10 @@ msgstr "다음 페이지"
 msgid "次へ"
 msgstr "다음"
 
+#: src/lib/auth.ts
+msgid "正しいメールアドレスを入力してください"
+msgstr "올바른 이메일 주소를 입력해 주세요"
+
 #: src/app/digest/page.tsx
 msgid "毎週月曜日に自動生成されます"
 msgstr "매주 월요일에 자동 생성됩니다"
@@ -2009,6 +2025,14 @@ msgstr "표시 건수"
 #: src/components/settings/account/ProfileForm.tsx
 msgid "表示名"
 msgstr "표시 이름"
+
+#: src/lib/auth.ts
+msgid "表示名は 60 文字以内で入力してください"
+msgstr "표시 이름은 60자 이하로 입력해 주세요"
+
+#: src/lib/auth.ts
+msgid "表示名を入力してください"
+msgstr "표시 이름을 입력해 주세요"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/components/digest/DigestCard.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -924,6 +924,10 @@ msgstr "密码"
 msgid "パスワード（確認）"
 msgstr "密码（确认）"
 
+#: src/lib/auth.ts
+msgid "パスワードが一致しません"
+msgstr "两次输入的密码不一致"
+
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "パスワードが正しくないか、アカウントの削除に失敗しました"
 msgstr "密码不正确或删除账号失败"
@@ -931,6 +935,14 @@ msgstr "密码不正确或删除账号失败"
 #: src/components/settings/account/PasswordChangeForm.tsx
 msgid "パスワードの設定に失敗しました"
 msgstr "设置密码失败"
+
+#: src/lib/auth.ts
+msgid "パスワードは 128 文字以内で入力してください"
+msgstr "密码请控制在 128 个字符以内"
+
+#: src/lib/auth.ts
+msgid "パスワードは 8 文字以上で入力してください"
+msgstr "密码至少需要 8 个字符"
 
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "パスワードを入力"
@@ -1822,6 +1834,10 @@ msgstr "下一页"
 msgid "次へ"
 msgstr "下一步"
 
+#: src/lib/auth.ts
+msgid "正しいメールアドレスを入力してください"
+msgstr "请输入有效的电子邮件地址"
+
 #: src/app/digest/page.tsx
 msgid "毎週月曜日に自動生成されます"
 msgstr "每周一自动生成"
@@ -2009,6 +2025,14 @@ msgstr "每页显示数"
 #: src/components/settings/account/ProfileForm.tsx
 msgid "表示名"
 msgstr "显示名称"
+
+#: src/lib/auth.ts
+msgid "表示名は 60 文字以内で入力してください"
+msgstr "显示名称请控制在 60 个字符以内"
+
+#: src/lib/auth.ts
+msgid "表示名を入力してください"
+msgstr "请输入显示名称"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #: src/components/digest/DigestCard.tsx


### PR DESCRIPTION
Closes #205

## Summary
- `signUpEmailSchema` をモジュールトップレベルの静的 export から factory 関数 `createSignUpEmailSchema(i18n)` に置き換え、`msg` macro + `i18n._()` で全バリデーションメッセージを翻訳可能化
- 表示名 / メール / パスワード の各 Zod 制約に日本語メッセージを付与（従来は Zod デフォルトの英語 `Too small: expected string to have >=1 characters` 等が露出していた）
- `.refine()` の "パスワードが一致しません" もハードコード文字列だったため `msg` 化（en/ko/zh で英語フォールバックしていた）
- ja / en / ko / zh の PO に 6 件の新規 msgid を追加・翻訳済
- `SignUpForm` で `useLingui()` + `useMemo` を使い、ロケール変更に追随

## Why
モジュールトップレベルの schema 内では `t` macro（component context 必須）が使えないため、`src/lib/i18n-labels.ts` で確立されている `msg` macro + lazy resolve パターンに合わせた。

## Out of scope (将来 issue 化候補)
同様の問題を抱える他フォーム（`signInEmailSchema` / `changePasswordSchema` / `setPasswordSchema` / `updateProfileSchema` / `changeEmailSchema` / `deleteAccountSchema`）は本 PR では触らず、別 issue で扱う想定。

## Test plan
- [x] `pnpm precheck` パス（lint 0 errors / typecheck OK / format OK / i18n:check OK）
- [x] `pnpm test` — 1243 / 1243 passed
- [x] `pnpm test:coverage` — branches 82.04% （80% 閾値クリア）
- [x] `src/app/(public)/signup/page.test.tsx` に「空送信時に各フィールドへ日本語バリデーションメッセージが出る」ケースを追加し pass を確認
- [ ] 手動: `/signup` で空送信し、4 フィールドに英語 Zod raw メッセージではなく日本語が表示されることを確認
- [ ] 手動: ロケール切替で en / ko / zh も翻訳されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)