### PR TITLE
fix(i18n): 英語版の件数表示で Plural マクロを使い単複対応

### DIFF
--- a/src/app/locations/[caseId]/page.tsx
+++ b/src/app/locations/[caseId]/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useAtomValue, useSetAtom } from "jotai";
 import { Trans } from "@lingui/react/macro";
-import { t } from "@lingui/core/macro";
+import { plural } from "@lingui/core/macro";
 import { storageCasesAtom, storageLocationsAtom } from "@/stores/locationAtoms";
 import { confirmAllByMemoryAtom, garmentsAtom } from "@/stores/garmentAtoms";
 import { getConfidence } from "@/lib/confidence";
@@ -125,9 +125,16 @@ const CaseDetailContent = () => {
             </Trans>
           )}
         </span>
-        <Badge>{t`${caseGarments.length}着`}</Badge>
+        <Badge>
+          {plural(caseGarments.length, { one: "#着", other: "#着" })}
+        </Badge>
         {needsReviewCount > 0 && (
-          <Badge variant="uncertain">{t`${needsReviewCount}着 要確認`}</Badge>
+          <Badge variant="uncertain">
+            {plural(needsReviewCount, {
+              one: "#着 要確認",
+              other: "#着 要確認",
+            })}
+          </Badge>
         )}
       </div>
       {isUnit ? (

--- a/src/components/confidence/ConfidenceStats.tsx
+++ b/src/components/confidence/ConfidenceStats.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { msg } from "@lingui/core/macro";
-import { Trans } from "@lingui/react/macro";
+import { Plural } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react";
 import { useAtomValue } from "jotai";
 import Card from "@/components/ui/Card";
@@ -57,7 +57,7 @@ const ConfidenceStats = ({ garments }: Props) => {
           <p className="text-xs font-medium opacity-70">{i18n._(label)}</p>
           <p className="font-display text-2xl font-bold">{value}</p>
           <p className="text-[10px] opacity-50">
-            <Trans>着</Trans>
+            <Plural value={value} one="着" other="着" />
           </p>
         </Card>
       ))}

--- a/src/components/dashboard/StaleLocationItem.tsx
+++ b/src/components/dashboard/StaleLocationItem.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { Clock, ChevronRight } from "lucide-react";
-import { Trans } from "@lingui/react/macro";
+import { Plural, Trans } from "@lingui/react/macro";
 import clsx from "clsx";
 import type { StaleLocation } from "@/stores/dashboardAtoms";
 import { FOCUS_RING_CLASS } from "@/lib/uiClasses";
@@ -50,7 +50,11 @@ const StaleLocationItem = ({ item }: Props) => {
             <Trans>{daysSinceLastVisit}日前に最後に開けました</Trans>
           )}
           {" · "}
-          <Trans>未確認 {uncertainItemCount}着</Trans>
+          <Plural
+            value={uncertainItemCount}
+            one="未確認 #着"
+            other="未確認 #着"
+          />
         </p>
       </div>
       <ChevronRight className="size-4 shrink-0 text-text-tertiary" />

--- a/src/components/digest/DigestCard.tsx
+++ b/src/components/digest/DigestCard.tsx
@@ -2,7 +2,7 @@
 
 import { useSetAtom } from "jotai";
 import { Eye, EyeOff, Sparkles } from "lucide-react";
-import { Trans } from "@lingui/react/macro";
+import { Plural, Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react";
 import { msg } from "@lingui/core/macro";
 import type { Digest } from "@/types";
@@ -108,7 +108,11 @@ const DigestCard = ({ digest }: Props) => {
 
       <div className="mt-3 border-t border-border-default pt-2">
         <p className="text-xs text-text-tertiary">
-          <Trans>管理中の服: {digest.totalGarments}着</Trans>
+          <Plural
+            value={digest.totalGarments}
+            one="管理中の服: #着"
+            other="管理中の服: #着"
+          />
         </p>
       </div>
     </Card>

--- a/src/components/doll/CompatibleGarmentList.tsx
+++ b/src/components/doll/CompatibleGarmentList.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useAtomValue } from "jotai";
 import { Shirt } from "lucide-react";
 import { t } from "@lingui/core/macro";
-import { Trans } from "@lingui/react/macro";
+import { Plural } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react";
 import type { DollSize } from "@/types";
 import { garmentsAtom } from "@/stores/garmentAtoms";
@@ -63,7 +63,11 @@ const CompatibleGarmentList = ({ dollBodySize }: Props) => {
         </Link>
       ))}
       <p className="text-center text-xs text-text-tertiary">
-        <Trans>{compatible.length}着の服が着用可能</Trans>
+        <Plural
+          value={compatible.length}
+          one="#着の服が着用可能"
+          other="#着の服が着用可能"
+        />
       </p>
     </div>
   );

--- a/src/components/location/StorageCaseCard.tsx
+++ b/src/components/location/StorageCaseCard.tsx
@@ -1,6 +1,6 @@
 import { Pencil, Trash2 } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
-import { t } from "@lingui/core/macro";
+import { plural, t } from "@lingui/core/macro";
 import type { Garment, StorageCase, StorageLocation } from "@/types";
 import { getConfidence } from "@/lib/confidence";
 import {
@@ -86,9 +86,16 @@ const StorageCaseCard = ({
             </Trans>
           )}
         </span>
-        <Badge>{t`${caseGarments.length}着`}</Badge>
+        <Badge>
+          {plural(caseGarments.length, { one: "#着", other: "#着" })}
+        </Badge>
         {needsReviewCount > 0 && (
-          <Badge variant="uncertain">{t`${needsReviewCount}着 要確認`}</Badge>
+          <Badge variant="uncertain">
+            {plural(needsReviewCount, {
+              one: "#着 要確認",
+              other: "#着 要確認",
+            })}
+          </Badge>
         )}
       </div>
       {!isUnit && (

--- a/src/components/location/StorageCell.tsx
+++ b/src/components/location/StorageCell.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { Trans } from "@lingui/react/macro";
+import { Plural } from "@lingui/react/macro";
 import type { Garment, StorageLocation } from "@/types";
 import { getConfidence, getConfidenceLabel } from "@/lib/confidence";
 import { GARMENT_STATUS } from "@/lib/constants";
@@ -55,7 +55,7 @@ const StorageCell = ({ location, garments, onClick, isSelected }: Props) => {
       )}
       {garments.length > 0 && (
         <span className="mt-0.5 text-[10px] text-text-secondary">
-          <Trans>{garments.length}着</Trans>
+          <Plural value={garments.length} one="#着" other="#着" />
         </span>
       )}
     </button>

--- a/src/components/scan/ScanSessionPanel.tsx
+++ b/src/components/scan/ScanSessionPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useAtomValue, useSetAtom } from "jotai";
 import { MapPin, RotateCcw } from "lucide-react";
-import { Trans } from "@lingui/react/macro";
+import { Plural, Trans } from "@lingui/react/macro";
 import {
   activeLocationIdAtom,
   scannedGarmentIdsAtom,
@@ -58,7 +58,11 @@ const ScanSessionPanel = ({ locationName, onConfirmAll }: Props) => {
 
       {scannedIds.length > 0 && (
         <p className="text-xs text-text-secondary">
-          <Trans>{scannedIds.length}着をスキャンしました</Trans>
+          <Plural
+            value={scannedIds.length}
+            one="#着をスキャンしました"
+            other="#着をスキャンしました"
+          />
         </p>
       )}
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,6 +13,29 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#. placeholder {0}: caseGarments.length
+#. placeholder {0}: garments.length
+#: src/app/locations/[caseId]/page.tsx
+#: src/components/location/StorageCaseCard.tsx
+#: src/components/location/StorageCell.tsx
+msgid "{0, plural, one {#着} other {#着}}"
+msgstr "{0, plural, one {# item} other {# items}}"
+
+#. placeholder {0}: compatible.length
+#: src/components/doll/CompatibleGarmentList.tsx
+msgid "{0, plural, one {#着の服が着用可能} other {#着の服が着用可能}}"
+msgstr "{0, plural, one {# garment can be worn} other {# garments can be worn}}"
+
+#. placeholder {0}: scannedIds.length
+#: src/components/scan/ScanSessionPanel.tsx
+msgid "{0, plural, one {#着をスキャンしました} other {#着をスキャンしました}}"
+msgstr "{0, plural, one {# garment scanned} other {# garments scanned}}"
+
+#. placeholder {0}: digest.totalGarments
+#: src/components/digest/DigestCard.tsx
+msgid "{0, plural, one {管理中の服: #着} other {管理中の服: #着}}"
+msgstr "{0, plural, one {Managed garments: #} other {Managed garments: #}}"
+
 #. placeholder {0}: STEP_TITLES[step]
 #: src/app/garments/import/page.tsx
 msgid "{0}"
@@ -43,13 +66,11 @@ msgstr "{0} registrations failed"
 msgid "{0}件の登録に成功しました"
 msgstr "{0} registrations succeeded"
 
-#. placeholder {0}: caseGarments.length
-#. placeholder {0}: garments.length
 #: src/app/locations/[caseId]/page.tsx
 #: src/components/location/StorageCaseCard.tsx
 #: src/components/location/StorageCell.tsx
-msgid "{0}着"
-msgstr "{0} items"
+#~ msgid "{0}着"
+#~ msgstr "{0} items"
 
 #: src/components/digest/DigestCard.tsx
 #~ msgid "{0}着が取り出されたままのようです"
@@ -59,19 +80,17 @@ msgstr "{0} items"
 #~ msgid "{0}着の服が3日以上取り出し中です"
 #~ msgstr "{0} garments have been checked out for over 3 days"
 
-#. placeholder {0}: compatible.length
 #: src/components/doll/CompatibleGarmentList.tsx
-msgid "{0}着の服が着用可能"
-msgstr "{0} garments can be worn"
+#~ msgid "{0}着の服が着用可能"
+#~ msgstr "{0} garments can be worn"
 
 #: src/components/dashboard/AlertPanel.tsx
 #~ msgid "{0}着の服を取り出し中"
 #~ msgstr "{0} garments checked out"
 
-#. placeholder {0}: scannedIds.length
 #: src/components/scan/ScanSessionPanel.tsx
-msgid "{0}着をスキャンしました"
-msgstr "{0} garments scanned"
+#~ msgid "{0}着をスキャンしました"
+#~ msgstr "{0} garments scanned"
 
 #. placeholder {0}: storageCase.rows
 #. placeholder {1}: storageCase.cols
@@ -102,8 +121,13 @@ msgstr "{errorCount} errors"
 
 #: src/app/locations/[caseId]/page.tsx
 #: src/components/location/StorageCaseCard.tsx
-msgid "{needsReviewCount}着 要確認"
-msgstr "{needsReviewCount} items need review"
+msgid "{needsReviewCount, plural, one {#着 要確認} other {#着 要確認}}"
+msgstr "{needsReviewCount, plural, one {# item needs review} other {# items need review}}"
+
+#: src/app/locations/[caseId]/page.tsx
+#: src/components/location/StorageCaseCard.tsx
+#~ msgid "{needsReviewCount}着 要確認"
+#~ msgstr "{needsReviewCount} items need review"
 
 #: src/components/digest/DigestCard.tsx
 msgid "{percent}% 正確"
@@ -112,6 +136,10 @@ msgstr "{percent}% accurate"
 #: src/components/ui/Pagination.tsx
 msgid "{size}件表示"
 msgstr "Show {size}"
+
+#: src/components/dashboard/StaleLocationItem.tsx
+msgid "{uncertainItemCount, plural, one {未確認 #着} other {未確認 #着}}"
+msgstr "{uncertainItemCount, plural, one {# item unconfirmed} other {# items unconfirmed}}"
 
 #: src/components/scan/CheckoutConfirmSheet.tsx
 msgid "{uncertainItemCount} 件が最後のスキャンから時間が経っています"
@@ -124,6 +152,10 @@ msgstr "{validCount} valid"
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件をインポート"
 msgstr "Import {validCount} items"
+
+#: src/components/confidence/ConfidenceStats.tsx
+msgid "{value, plural, one {着} other {着}}"
+msgstr "{value, plural, one {item} other {items}}"
 
 #. placeholder {0}: doll.name
 #. placeholder {0}: garment.name
@@ -1787,8 +1819,8 @@ msgid "未使用"
 msgstr "Not used"
 
 #: src/components/dashboard/StaleLocationItem.tsx
-msgid "未確認 {uncertainItemCount}着"
-msgstr "{uncertainItemCount} items unconfirmed"
+#~ msgid "未確認 {uncertainItemCount}着"
+#~ msgstr "{uncertainItemCount} items unconfirmed"
 
 #: src/components/digest/DigestCard.tsx
 msgid "未読"
@@ -1903,8 +1935,8 @@ msgid "白"
 msgstr "White"
 
 #: src/components/confidence/ConfidenceStats.tsx
-msgid "着"
-msgstr "items"
+#~ msgid "着"
+#~ msgstr "items"
 
 #: src/app/dolls/[id]/page.tsx
 msgid "着用可能な服"
@@ -1929,10 +1961,9 @@ msgstr "Confirm"
 #~ msgid "確認"
 #~ msgstr "Check"
 
-#. placeholder {0}: digest.totalGarments
 #: src/components/digest/DigestCard.tsx
-msgid "管理中の服: {0}着"
-msgstr "Managed garments: {0}"
+#~ msgid "管理中の服: {0}着"
+#~ msgstr "Managed garments: {0}"
 
 #: src/components/dashboard/CheckedOutSection.tsx
 #: src/lib/i18n-labels.ts

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -13,6 +13,29 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#. placeholder {0}: caseGarments.length
+#. placeholder {0}: garments.length
+#: src/app/locations/[caseId]/page.tsx
+#: src/components/location/StorageCaseCard.tsx
+#: src/components/location/StorageCell.tsx
+msgid "{0, plural, one {#着} other {#着}}"
+msgstr "{0, plural, one {#着} other {#着}}"
+
+#. placeholder {0}: compatible.length
+#: src/components/doll/CompatibleGarmentList.tsx
+msgid "{0, plural, one {#着の服が着用可能} other {#着の服が着用可能}}"
+msgstr "{0, plural, one {#着の服が着用可能} other {#着の服が着用可能}}"
+
+#. placeholder {0}: scannedIds.length
+#: src/components/scan/ScanSessionPanel.tsx
+msgid "{0, plural, one {#着をスキャンしました} other {#着をスキャンしました}}"
+msgstr "{0, plural, one {#着をスキャンしました} other {#着をスキャンしました}}"
+
+#. placeholder {0}: digest.totalGarments
+#: src/components/digest/DigestCard.tsx
+msgid "{0, plural, one {管理中の服: #着} other {管理中の服: #着}}"
+msgstr "{0, plural, one {管理中の服: #着} other {管理中の服: #着}}"
+
 #. placeholder {0}: STEP_TITLES[step]
 #: src/app/garments/import/page.tsx
 msgid "{0}"
@@ -43,13 +66,11 @@ msgstr "{0}件の登録に失敗しました"
 msgid "{0}件の登録に成功しました"
 msgstr "{0}件の登録に成功しました"
 
-#. placeholder {0}: caseGarments.length
-#. placeholder {0}: garments.length
 #: src/app/locations/[caseId]/page.tsx
 #: src/components/location/StorageCaseCard.tsx
 #: src/components/location/StorageCell.tsx
-msgid "{0}着"
-msgstr "{0}着"
+#~ msgid "{0}着"
+#~ msgstr "{0}着"
 
 #: src/components/digest/DigestCard.tsx
 #~ msgid "{0}着が取り出されたままのようです"
@@ -59,19 +80,17 @@ msgstr "{0}着"
 #~ msgid "{0}着の服が3日以上取り出し中です"
 #~ msgstr "{0}着の服が3日以上取り出し中です"
 
-#. placeholder {0}: compatible.length
 #: src/components/doll/CompatibleGarmentList.tsx
-msgid "{0}着の服が着用可能"
-msgstr "{0}着の服が着用可能"
+#~ msgid "{0}着の服が着用可能"
+#~ msgstr "{0}着の服が着用可能"
 
 #: src/components/dashboard/AlertPanel.tsx
 #~ msgid "{0}着の服を取り出し中"
 #~ msgstr "{0}着の服を取り出し中"
 
-#. placeholder {0}: scannedIds.length
 #: src/components/scan/ScanSessionPanel.tsx
-msgid "{0}着をスキャンしました"
-msgstr "{0}着をスキャンしました"
+#~ msgid "{0}着をスキャンしました"
+#~ msgstr "{0}着をスキャンしました"
 
 #. placeholder {0}: storageCase.rows
 #. placeholder {1}: storageCase.cols
@@ -102,8 +121,13 @@ msgstr "{errorCount}件 エラー"
 
 #: src/app/locations/[caseId]/page.tsx
 #: src/components/location/StorageCaseCard.tsx
-msgid "{needsReviewCount}着 要確認"
-msgstr "{needsReviewCount}着 要確認"
+msgid "{needsReviewCount, plural, one {#着 要確認} other {#着 要確認}}"
+msgstr "{needsReviewCount, plural, one {#着 要確認} other {#着 要確認}}"
+
+#: src/app/locations/[caseId]/page.tsx
+#: src/components/location/StorageCaseCard.tsx
+#~ msgid "{needsReviewCount}着 要確認"
+#~ msgstr "{needsReviewCount}着 要確認"
 
 #: src/components/digest/DigestCard.tsx
 msgid "{percent}% 正確"
@@ -112,6 +136,10 @@ msgstr "{percent}% 正確"
 #: src/components/ui/Pagination.tsx
 msgid "{size}件表示"
 msgstr "{size}件表示"
+
+#: src/components/dashboard/StaleLocationItem.tsx
+msgid "{uncertainItemCount, plural, one {未確認 #着} other {未確認 #着}}"
+msgstr "{uncertainItemCount, plural, one {未確認 #着} other {未確認 #着}}"
 
 #: src/components/scan/CheckoutConfirmSheet.tsx
 msgid "{uncertainItemCount} 件が最後のスキャンから時間が経っています"
@@ -124,6 +152,10 @@ msgstr "{validCount}件 有効"
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件をインポート"
 msgstr "{validCount}件をインポート"
+
+#: src/components/confidence/ConfidenceStats.tsx
+msgid "{value, plural, one {着} other {着}}"
+msgstr "{value, plural, one {着} other {着}}"
 
 #. placeholder {0}: doll.name
 #. placeholder {0}: garment.name
@@ -1787,8 +1819,8 @@ msgid "未使用"
 msgstr "未使用"
 
 #: src/components/dashboard/StaleLocationItem.tsx
-msgid "未確認 {uncertainItemCount}着"
-msgstr "未確認 {uncertainItemCount}着"
+#~ msgid "未確認 {uncertainItemCount}着"
+#~ msgstr "未確認 {uncertainItemCount}着"
 
 #: src/components/digest/DigestCard.tsx
 msgid "未読"
@@ -1903,8 +1935,8 @@ msgid "白"
 msgstr "白"
 
 #: src/components/confidence/ConfidenceStats.tsx
-msgid "着"
-msgstr "着"
+#~ msgid "着"
+#~ msgstr "着"
 
 #: src/app/dolls/[id]/page.tsx
 msgid "着用可能な服"
@@ -1929,10 +1961,9 @@ msgstr "確定する"
 #~ msgid "確認"
 #~ msgstr "確認"
 
-#. placeholder {0}: digest.totalGarments
 #: src/components/digest/DigestCard.tsx
-msgid "管理中の服: {0}着"
-msgstr "管理中の服: {0}着"
+#~ msgid "管理中の服: {0}着"
+#~ msgstr "管理中の服: {0}着"
 
 #: src/components/dashboard/CheckedOutSection.tsx
 #: src/lib/i18n-labels.ts

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -13,6 +13,29 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#. placeholder {0}: caseGarments.length
+#. placeholder {0}: garments.length
+#: src/app/locations/[caseId]/page.tsx
+#: src/components/location/StorageCaseCard.tsx
+#: src/components/location/StorageCell.tsx
+msgid "{0, plural, one {#着} other {#着}}"
+msgstr "{0, plural, one {#벌} other {#벌}}"
+
+#. placeholder {0}: compatible.length
+#: src/components/doll/CompatibleGarmentList.tsx
+msgid "{0, plural, one {#着の服が着用可能} other {#着の服が着用可能}}"
+msgstr "{0, plural, one {#벌의 옷을 입힐 수 있습니다} other {#벌의 옷을 입힐 수 있습니다}}"
+
+#. placeholder {0}: scannedIds.length
+#: src/components/scan/ScanSessionPanel.tsx
+msgid "{0, plural, one {#着をスキャンしました} other {#着をスキャンしました}}"
+msgstr "{0, plural, one {#벌 스캔 완료} other {#벌 스캔 완료}}"
+
+#. placeholder {0}: digest.totalGarments
+#: src/components/digest/DigestCard.tsx
+msgid "{0, plural, one {管理中の服: #着} other {管理中の服: #着}}"
+msgstr "{0, plural, one {관리 중인 옷: #벌} other {관리 중인 옷: #벌}}"
+
 #. placeholder {0}: STEP_TITLES[step]
 #: src/app/garments/import/page.tsx
 msgid "{0}"
@@ -43,13 +66,11 @@ msgstr "{0}건 등록에 실패했습니다"
 msgid "{0}件の登録に成功しました"
 msgstr "{0}건 등록에 성공했습니다"
 
-#. placeholder {0}: caseGarments.length
-#. placeholder {0}: garments.length
 #: src/app/locations/[caseId]/page.tsx
 #: src/components/location/StorageCaseCard.tsx
 #: src/components/location/StorageCell.tsx
-msgid "{0}着"
-msgstr "{0}벌"
+#~ msgid "{0}着"
+#~ msgstr "{0}벌"
 
 #: src/components/digest/DigestCard.tsx
 #~ msgid "{0}着が取り出されたままのようです"
@@ -59,19 +80,17 @@ msgstr "{0}벌"
 #~ msgid "{0}着の服が3日以上取り出し中です"
 #~ msgstr "{0}벌의 옷이 3일 이상 꺼낸 상태입니다"
 
-#. placeholder {0}: compatible.length
 #: src/components/doll/CompatibleGarmentList.tsx
-msgid "{0}着の服が着用可能"
-msgstr "{0}벌의 옷을 입힐 수 있습니다"
+#~ msgid "{0}着の服が着用可能"
+#~ msgstr "{0}벌의 옷을 입힐 수 있습니다"
 
 #: src/components/dashboard/AlertPanel.tsx
 #~ msgid "{0}着の服を取り出し中"
 #~ msgstr "{0}벌의 옷을 꺼낸 중"
 
-#. placeholder {0}: scannedIds.length
 #: src/components/scan/ScanSessionPanel.tsx
-msgid "{0}着をスキャンしました"
-msgstr "{0}벌 스캔 완료"
+#~ msgid "{0}着をスキャンしました"
+#~ msgstr "{0}벌 스캔 완료"
 
 #. placeholder {0}: storageCase.rows
 #. placeholder {1}: storageCase.cols
@@ -102,8 +121,13 @@ msgstr "{errorCount}건 오류"
 
 #: src/app/locations/[caseId]/page.tsx
 #: src/components/location/StorageCaseCard.tsx
-msgid "{needsReviewCount}着 要確認"
-msgstr "{needsReviewCount}벌 확인 필요"
+msgid "{needsReviewCount, plural, one {#着 要確認} other {#着 要確認}}"
+msgstr "{needsReviewCount, plural, one {#벌 확인 필요} other {#벌 확인 필요}}"
+
+#: src/app/locations/[caseId]/page.tsx
+#: src/components/location/StorageCaseCard.tsx
+#~ msgid "{needsReviewCount}着 要確認"
+#~ msgstr "{needsReviewCount}벌 확인 필요"
 
 #: src/components/digest/DigestCard.tsx
 msgid "{percent}% 正確"
@@ -112,6 +136,10 @@ msgstr "{percent}% 정확"
 #: src/components/ui/Pagination.tsx
 msgid "{size}件表示"
 msgstr "{size}건 표시"
+
+#: src/components/dashboard/StaleLocationItem.tsx
+msgid "{uncertainItemCount, plural, one {未確認 #着} other {未確認 #着}}"
+msgstr "{uncertainItemCount, plural, one {미확인 #벌} other {미확인 #벌}}"
 
 #: src/components/scan/CheckoutConfirmSheet.tsx
 msgid "{uncertainItemCount} 件が最後のスキャンから時間が経っています"
@@ -124,6 +152,10 @@ msgstr "{validCount}건 유효"
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件をインポート"
 msgstr "{validCount}건 가져오기"
+
+#: src/components/confidence/ConfidenceStats.tsx
+msgid "{value, plural, one {着} other {着}}"
+msgstr "{value, plural, one {벌} other {벌}}"
 
 #. placeholder {0}: doll.name
 #. placeholder {0}: garment.name
@@ -1787,8 +1819,8 @@ msgid "未使用"
 msgstr "사용 전"
 
 #: src/components/dashboard/StaleLocationItem.tsx
-msgid "未確認 {uncertainItemCount}着"
-msgstr "미확인 {uncertainItemCount}벌"
+#~ msgid "未確認 {uncertainItemCount}着"
+#~ msgstr "미확인 {uncertainItemCount}벌"
 
 #: src/components/digest/DigestCard.tsx
 msgid "未読"
@@ -1903,8 +1935,8 @@ msgid "白"
 msgstr "흰색"
 
 #: src/components/confidence/ConfidenceStats.tsx
-msgid "着"
-msgstr "벌"
+#~ msgid "着"
+#~ msgstr "벌"
 
 #: src/app/dolls/[id]/page.tsx
 msgid "着用可能な服"
@@ -1929,10 +1961,9 @@ msgstr "확정"
 #~ msgid "確認"
 #~ msgstr "확인"
 
-#. placeholder {0}: digest.totalGarments
 #: src/components/digest/DigestCard.tsx
-msgid "管理中の服: {0}着"
-msgstr "관리 중인 옷: {0}벌"
+#~ msgid "管理中の服: {0}着"
+#~ msgstr "관리 중인 옷: {0}벌"
 
 #: src/components/dashboard/CheckedOutSection.tsx
 #: src/lib/i18n-labels.ts

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -13,6 +13,29 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#. placeholder {0}: caseGarments.length
+#. placeholder {0}: garments.length
+#: src/app/locations/[caseId]/page.tsx
+#: src/components/location/StorageCaseCard.tsx
+#: src/components/location/StorageCell.tsx
+msgid "{0, plural, one {#着} other {#着}}"
+msgstr "{0, plural, one {#件} other {#件}}"
+
+#. placeholder {0}: compatible.length
+#: src/components/doll/CompatibleGarmentList.tsx
+msgid "{0, plural, one {#着の服が着用可能} other {#着の服が着用可能}}"
+msgstr "{0, plural, one {#件衣服可穿着} other {#件衣服可穿着}}"
+
+#. placeholder {0}: scannedIds.length
+#: src/components/scan/ScanSessionPanel.tsx
+msgid "{0, plural, one {#着をスキャンしました} other {#着をスキャンしました}}"
+msgstr "{0, plural, one {已扫描#件} other {已扫描#件}}"
+
+#. placeholder {0}: digest.totalGarments
+#: src/components/digest/DigestCard.tsx
+msgid "{0, plural, one {管理中の服: #着} other {管理中の服: #着}}"
+msgstr "{0, plural, one {管理中的衣服：#件} other {管理中的衣服：#件}}"
+
 #. placeholder {0}: STEP_TITLES[step]
 #: src/app/garments/import/page.tsx
 msgid "{0}"
@@ -43,13 +66,11 @@ msgstr "{0}项登记失败"
 msgid "{0}件の登録に成功しました"
 msgstr "{0}项登记成功"
 
-#. placeholder {0}: caseGarments.length
-#. placeholder {0}: garments.length
 #: src/app/locations/[caseId]/page.tsx
 #: src/components/location/StorageCaseCard.tsx
 #: src/components/location/StorageCell.tsx
-msgid "{0}着"
-msgstr "{0}件"
+#~ msgid "{0}着"
+#~ msgstr "{0}件"
 
 #: src/components/digest/DigestCard.tsx
 #~ msgid "{0}着が取り出されたままのようです"
@@ -59,19 +80,17 @@ msgstr "{0}件"
 #~ msgid "{0}着の服が3日以上取り出し中です"
 #~ msgstr "{0}件衣服已取出超过3天"
 
-#. placeholder {0}: compatible.length
 #: src/components/doll/CompatibleGarmentList.tsx
-msgid "{0}着の服が着用可能"
-msgstr "{0}件衣服可穿着"
+#~ msgid "{0}着の服が着用可能"
+#~ msgstr "{0}件衣服可穿着"
 
 #: src/components/dashboard/AlertPanel.tsx
 #~ msgid "{0}着の服を取り出し中"
 #~ msgstr "{0}件衣服取出中"
 
-#. placeholder {0}: scannedIds.length
 #: src/components/scan/ScanSessionPanel.tsx
-msgid "{0}着をスキャンしました"
-msgstr "已扫描{0}件"
+#~ msgid "{0}着をスキャンしました"
+#~ msgstr "已扫描{0}件"
 
 #. placeholder {0}: storageCase.rows
 #. placeholder {1}: storageCase.cols
@@ -102,8 +121,13 @@ msgstr "{errorCount}项错误"
 
 #: src/app/locations/[caseId]/page.tsx
 #: src/components/location/StorageCaseCard.tsx
-msgid "{needsReviewCount}着 要確認"
-msgstr "{needsReviewCount}件 待确认"
+msgid "{needsReviewCount, plural, one {#着 要確認} other {#着 要確認}}"
+msgstr "{needsReviewCount, plural, one {#件 待确认} other {#件 待确认}}"
+
+#: src/app/locations/[caseId]/page.tsx
+#: src/components/location/StorageCaseCard.tsx
+#~ msgid "{needsReviewCount}着 要確認"
+#~ msgstr "{needsReviewCount}件 待确认"
 
 #: src/components/digest/DigestCard.tsx
 msgid "{percent}% 正確"
@@ -112,6 +136,10 @@ msgstr "{percent}% 准确"
 #: src/components/ui/Pagination.tsx
 msgid "{size}件表示"
 msgstr "显示{size}项"
+
+#: src/components/dashboard/StaleLocationItem.tsx
+msgid "{uncertainItemCount, plural, one {未確認 #着} other {未確認 #着}}"
+msgstr "{uncertainItemCount, plural, one {未确认 #件} other {未确认 #件}}"
 
 #: src/components/scan/CheckoutConfirmSheet.tsx
 msgid "{uncertainItemCount} 件が最後のスキャンから時間が経っています"
@@ -124,6 +152,10 @@ msgstr "{validCount}项有效"
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "{validCount}件をインポート"
 msgstr "导入{validCount}项"
+
+#: src/components/confidence/ConfidenceStats.tsx
+msgid "{value, plural, one {着} other {着}}"
+msgstr "{value, plural, one {件} other {件}}"
 
 #. placeholder {0}: doll.name
 #. placeholder {0}: garment.name
@@ -1787,8 +1819,8 @@ msgid "未使用"
 msgstr "未使用"
 
 #: src/components/dashboard/StaleLocationItem.tsx
-msgid "未確認 {uncertainItemCount}着"
-msgstr "未确认 {uncertainItemCount}件"
+#~ msgid "未確認 {uncertainItemCount}着"
+#~ msgstr "未确认 {uncertainItemCount}件"
 
 #: src/components/digest/DigestCard.tsx
 msgid "未読"
@@ -1903,8 +1935,8 @@ msgid "白"
 msgstr "白色"
 
 #: src/components/confidence/ConfidenceStats.tsx
-msgid "着"
-msgstr "件"
+#~ msgid "着"
+#~ msgstr "件"
 
 #: src/app/dolls/[id]/page.tsx
 msgid "着用可能な服"
@@ -1929,10 +1961,9 @@ msgstr "确认"
 #~ msgid "確認"
 #~ msgstr "确认"
 
-#. placeholder {0}: digest.totalGarments
 #: src/components/digest/DigestCard.tsx
-msgid "管理中の服: {0}着"
-msgstr "管理中的衣服：{0}件"
+#~ msgid "管理中の服: {0}着"
+#~ msgstr "管理中的衣服：{0}件"
 
 #: src/components/dashboard/CheckedOutSection.tsx
 #: src/lib/i18n-labels.ts


### PR DESCRIPTION
## Summary
- 英語ロケールで「Total 1 items」「Confirmed 1 items」のように 1 件でも複数形が出る不具合を修正
- Lingui の `Plural` / `plural` マクロを導入し、ICU plural 形式 (`{n, plural, one {…} other {…}}`) に置き換え
- 英語 PO には `one {# item}` / `other {# items}` 形を投入。ja / ko / zh は文法上の単複差がないため同一形を保持

## 対象範囲

| File | 変更内容 |
| ---- | -------- |
| `src/components/confidence/ConfidenceStats.tsx` | Issue 主因。`<Trans>着</Trans>` → `<Plural value={value} one="着" other="着" />` |
| `src/components/location/StorageCaseCard.tsx` | `t\`${N}着\`` / `t\`${N}着 要確認\`` → `plural(...)` |
| `src/components/location/StorageCell.tsx` | `<Trans>{N}着</Trans>` → `<Plural>` |
| `src/components/dashboard/StaleLocationItem.tsx` | `<Trans>未確認 {N}着</Trans>` → `<Plural>` |
| `src/components/doll/CompatibleGarmentList.tsx` | `<Trans>{N}着の服が着用可能</Trans>` → `<Plural>` |
| `src/components/scan/ScanSessionPanel.tsx` | `<Trans>{N}着をスキャンしました</Trans>` → `<Plural>` |
| `src/components/digest/DigestCard.tsx` | `<Trans>管理中の服: {N}着</Trans>` → `<Plural>` |
| `src/app/locations/[caseId]/page.tsx` | StorageCaseCard と同形 |
| `src/locales/{ja,en,ko,zh}/messages.po` | 7 件の新 plural msgid に翻訳投入 |

「件」系 UI 文言 (Pagination / CSV / Bulk import / CheckoutConfirm 等) は本 Issue のスコープ外（別途）。

## Test plan
- [x] `pnpm i18n:extract && pnpm i18n:compile && pnpm i18n:check` — 未翻訳 0 件
- [x] `pnpm precheck` — 0 errors (既存の magic-number warning のみ)
- [x] `pnpm test` — 1242 / 1242 pass（`DigestCard.test.tsx` の `/管理中の服: 51着/` も含め全緑）
- [x] `pnpm test:coverage` — branches 82.04% ≥ 80%
- [x] `npx tsc-files --noEmit -p tsconfig.app.json <変更ファイル>` — clean
- [x] `npx eslint <変更ファイル>` — clean
- [ ] 手動: 言語 = English / 服 1 件 → ダッシュボードのステータスカードが「1 item」と表示されることを目視確認

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)