### PR TITLE
fix(i18n): ワードローブ分析のカテゴリ名が ja 以外で英語のままだったのを修正

### DIFF
--- a/src/components/dashboard/WardrobeAnalytics.test.tsx
+++ b/src/components/dashboard/WardrobeAnalytics.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, screen } from "@testing-library/react";
+import { i18n } from "@lingui/core";
+import { messages as jaMessages } from "@/locales/ja/messages.mjs";
+import { messages as enMessages } from "@/locales/en/messages.mjs";
+import { messages as koMessages } from "@/locales/ko/messages.mjs";
+import { testDb, FIXED_NOW } from "@/test/mocks/db";
+import { seedDbFromTestDb } from "@/test/helpers/seedDb";
+import { renderWithProviders } from "@/test/testUtils";
+import WardrobeAnalytics from "./WardrobeAnalytics";
+
+describe("WardrobeAnalytics", () => {
+  beforeEach(() => {
+    vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+    i18n.load({ ja: jaMessages, en: enMessages, ko: koMessages });
+    i18n.activate("ja");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    i18n.activate("ja");
+  });
+
+  it("locale 切替時にカテゴリラベルが再翻訳される（useMemo 内 i18n._() のキャッシュ回帰防止）", async () => {
+    testDb.garment.create({ id: "g-1", category: "onepiece" });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<WardrobeAnalytics />);
+
+    expect(await screen.findByText("ワンピース")).toBeInTheDocument();
+
+    await act(async () => {
+      i18n.activate("en");
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("One-piece")).toBeInTheDocument();
+    expect(screen.queryByText("ワンピース")).not.toBeInTheDocument();
+
+    await act(async () => {
+      i18n.activate("ko");
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("원피스")).toBeInTheDocument();
+    expect(screen.queryByText("One-piece")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/WardrobeAnalytics.tsx
+++ b/src/components/dashboard/WardrobeAnalytics.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { useAtomValue } from "jotai";
 import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react";
@@ -38,41 +38,33 @@ const WardrobeAnalytics = () => {
   const { i18n } = useLingui();
   const [activeTab, setActiveTab] = useState<AnalyticsTab>("category");
 
-  const categoryItems: readonly BarItem[] = useMemo(
-    () =>
-      aggregateByCategory(garments).map((c) => ({
-        label: i18n._(GARMENT_CATEGORY_LABEL[c.category]),
-        value: c.count,
-      })),
-    [garments, i18n],
+  const categoryItems: readonly BarItem[] = aggregateByCategory(garments).map(
+    (c) => ({
+      label: i18n._(GARMENT_CATEGORY_LABEL[c.category]),
+      value: c.count,
+    }),
   );
 
-  const sizeItems: readonly BarItem[] = useMemo(
-    () =>
-      aggregateByDollSize(garments).map((s) => ({
-        label: i18n._(DOLL_SIZE_LABEL[s.dollSize]),
-        value: s.count,
-      })),
-    [garments, i18n],
+  const sizeItems: readonly BarItem[] = aggregateByDollSize(garments).map(
+    (s) => ({
+      label: i18n._(DOLL_SIZE_LABEL[s.dollSize]),
+      value: s.count,
+    }),
   );
 
-  const colorItems: readonly BarItem[] = useMemo(
-    () =>
-      aggregateByColor(garments).map((c) => ({
-        label: i18n._(COLOR_NAME_LABEL[c.colorName]),
-        value: c.count,
-        swatch: c.hsl,
-      })),
-    [garments, i18n],
+  const colorItems: readonly BarItem[] = aggregateByColor(garments).map(
+    (c) => ({
+      label: i18n._(COLOR_NAME_LABEL[c.colorName]),
+      value: c.count,
+      swatch: c.hsl,
+    }),
   );
 
-  const brandItems: readonly BarItem[] = useMemo(
-    () =>
-      aggregateByBrand({ garments }).map((b) => ({
-        label: b.brand,
-        value: b.count,
-      })),
-    [garments],
+  const brandItems: readonly BarItem[] = aggregateByBrand({ garments }).map(
+    (b) => ({
+      label: b.brand,
+      value: b.count,
+    }),
   );
 
   if (garments.length === 0) return undefined;


### PR DESCRIPTION
## Summary

- ダッシュボード「ワードローブ分析」セクションで、`en` / `ko` / `zh` に切替えてもカテゴリ／サイズ／カラーの label が英語の Display 名 (`One-piece` 等) のまま表示されていた問題を修正
- `WardrobeAnalytics.tsx` の 4 つの `useMemo` から `i18n._()` 呼び出しを取り除き、毎 render 計算に統一

## 根本原因

`useLingui()` が返す `i18n` オブジェクトの**参照は locale 変更時に変わらない**（Lingui v5 の I18nProvider は内部 `setContext` で reactivity を担保している）。`useMemo` の deps に `i18n` を入れていたため、deps 不変として再計算されず、最初の locale で評価された label がキャッシュされ続けていた。他コンポーネント (GarmentCard / GarmentList 等) は render 中に直接 `i18n._()` を呼んでいるため問題が出ていなかった。

## 修正内容

- `useMemo` を撤廃 — aggregation (`aggregateByCategory` 等) は O(n) で軽量、毎 render 計算でも体感無視できる
- `import { useState, useMemo }` → `import { useState }`
- 他コンポーネントと同じ「render 中に `i18n._()` 直書き」パターンに揃った
- 回帰防止のインテグレーションテスト `WardrobeAnalytics.test.tsx` を新規追加 — `ja` → `en` → `ko` の locale 切替で label が再翻訳されることを検証（PO の hashed id を使うためコンパイル済み `messages.mjs` を読み込む）

Closes #210

## Test plan

- [x] `pnpm test src/components/dashboard/WardrobeAnalytics.test.tsx` — pass
- [x] 修正を退避すると同テストが落ち、戻すと pass することを確認（回帰防止が機能）
- [x] `npx tsc-files --noEmit -p tsconfig.app.json` — pass
- [x] `npx eslint` — pass
- [x] `pnpm test` — 1243 tests / 133 files all pass
- [x] `pnpm precheck` — pass (i18n / format / lint warnings only)
- [ ] 手動: ja → en → ko → zh で「ワードローブ分析」の bar label が `ワンピース` → `One-piece` → `원피스` → `连衣裙(一体式)` と変わることをブラウザで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)