### PR TITLE
test: branch coverage を 82% から 90% に引き上げる

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"10d4f5ac-0d23-4b52-a9aa-d0945b4d63e5","pid":60910,"procStart":"Wed May 13 10:11:19 2026","acquiredAt":1778950269092}

--- a/src/app/(public)/signin/page.test.tsx
+++ b/src/app/(public)/signin/page.test.tsx
@@ -161,4 +161,63 @@ describe("SignInPage", () => {
     });
     expect(link).toHaveAttribute("href", "/");
   });
+
+  it("メールアドレス形式が不正な場合は signInWithEmail は呼ばれない", async () => {
+    server.use(unauthenticatedHandler);
+    const { spies } = setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<SignInPage />);
+
+    await user.type(
+      await screen.findByLabelText("メールアドレス"),
+      "not-email",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "secret123");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      expect(spies.signInWithEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  it("パスワード未入力の場合は signInWithEmail は呼ばれない", async () => {
+    server.use(unauthenticatedHandler);
+    const { spies } = setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<SignInPage />);
+
+    await user.type(
+      await screen.findByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      expect(spies.signInWithEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  it("redirect クエリつきでログイン成功するとそのパスへ遷移する", async () => {
+    server.use(unauthenticatedHandler);
+    const { spies } = setupAuthClient();
+    const { router } = setupNextNavigation({
+      searchParams: new URLSearchParams("redirect=/dashboard"),
+    });
+    const user = userEvent.setup();
+    await renderWithProviders(<SignInPage />);
+
+    await user.type(
+      await screen.findByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "secret123");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      expect(spies.signInWithEmail).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
 });

--- a/src/app/(public)/signup/page.test.tsx
+++ b/src/app/(public)/signup/page.test.tsx
@@ -115,4 +115,42 @@ describe("SignUpPage", () => {
       expect(router.replace).toHaveBeenCalledWith("/");
     });
   });
+
+  it("メールアドレス形式が不正な場合はバリデーションエラーで送信されない", async () => {
+    server.use(unauthenticatedHandler);
+    const { spies } = setupAuthClient();
+
+    const user = userEvent.setup();
+    await renderWithProviders(<SignUpPage />);
+
+    await user.type(await screen.findByLabelText("表示名"), "佐藤");
+    await user.type(screen.getByLabelText("メールアドレス"), "not-email");
+    await user.type(screen.getByLabelText("パスワード"), "secret123");
+    await user.type(screen.getByLabelText("パスワード（確認）"), "secret123");
+    await user.click(screen.getByRole("button", { name: "アカウント作成" }));
+
+    await waitFor(() => {
+      expect(spies.signUpWithEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  it("名前未入力でバリデーションエラーになる", async () => {
+    server.use(unauthenticatedHandler);
+    const { spies } = setupAuthClient();
+
+    const user = userEvent.setup();
+    await renderWithProviders(<SignUpPage />);
+
+    await user.type(
+      await screen.findByLabelText("メールアドレス"),
+      "ok@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "secret123");
+    await user.type(screen.getByLabelText("パスワード（確認）"), "secret123");
+    await user.click(screen.getByRole("button", { name: "アカウント作成" }));
+
+    await waitFor(() => {
+      expect(spies.signUpWithEmail).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/digest/page.test.tsx
+++ b/src/app/digest/page.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { server } from "@/test/mocks/server";
+import { trpcQuery } from "@/test/mocks/trpc/handlerFactory";
+import { renderWithProviders } from "@/test/testUtils";
+import type { Digest } from "@/types";
+import DigestPage from "./page";
+
+const makeDigest = (overrides: Partial<Digest> = {}): Digest => ({
+  id: "digest-1",
+  userId: "user-1",
+  accuracyScore: 0.82,
+  confirmedCount: 10,
+  uncertainCount: 3,
+  unknownCount: 1,
+  totalGarments: 14,
+  isRead: false,
+  generatedAt: new Date("2026-04-10T00:00:00Z").getTime(),
+  createdAt: new Date("2026-04-10T00:00:00Z").getTime(),
+  ...overrides,
+});
+
+describe("DigestPage", () => {
+  it("ヘッダーが表示される", async () => {
+    await renderWithProviders(<DigestPage />);
+    expect(await screen.findByText("週間レポート")).toBeInTheDocument();
+    expect(
+      screen.getByText("ワードローブの状況をお伝えします"),
+    ).toBeInTheDocument();
+  });
+
+  it("digest が空のとき空状態メッセージを表示する", async () => {
+    await renderWithProviders(<DigestPage />);
+    expect(
+      await screen.findByText("まだレポートがありません"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("毎週月曜日に自動生成されます"),
+    ).toBeInTheDocument();
+  });
+
+  it("digest 一覧が返ると DigestCard が描画される", async () => {
+    server.use(trpcQuery("digest.list", () => [makeDigest()]));
+
+    await renderWithProviders(<DigestPage />);
+
+    // accuracyScore 82% は DigestCard 内に表示される
+    expect(await screen.findByText(/82/)).toBeInTheDocument();
+  });
+});

--- a/src/app/dolls/[id]/page.test.tsx
+++ b/src/app/dolls/[id]/page.test.tsx
@@ -140,4 +140,82 @@ describe("DollDetailPage", () => {
 
     expect(screen.getByText("着用可能な服がありません")).toBeInTheDocument();
   });
+
+  it("画像が登録されているドールは img タグが描画される", async () => {
+    testDb.doll.create({
+      id: "doll-1",
+      name: "リナ",
+      imageUrl: "https://example.com/doll.png",
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<DollDetailPage />);
+
+    const img = screen.getByAltText("リナ");
+    expect(img).toHaveAttribute("src", "https://example.com/doll.png");
+  });
+
+  it("アーカイブ済みドールは復元 / 完全に削除ボタンが表示される", async () => {
+    testDb.doll.create({
+      id: "doll-1",
+      name: "リナ",
+      archivedAt: FIXED_NOW - 86_400_000,
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<DollDetailPage />);
+
+    expect(screen.getByText("復元")).toBeInTheDocument();
+    expect(screen.getByText("完全に削除")).toBeInTheDocument();
+  });
+
+  it("アーカイブ済みドールの復元ボタンで /dolls に戻る", async () => {
+    testDb.doll.create({
+      id: "doll-1",
+      name: "リナ",
+      archivedAt: FIXED_NOW - 86_400_000,
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<DollDetailPage />);
+
+    fireEvent.click(screen.getByText("復元"));
+
+    await waitFor(() => {
+      expect(navHandle.current.router.push).toHaveBeenCalledWith("/dolls");
+    });
+  });
+
+  it("アーカイブ済みドールの完全削除確認後に /archive に遷移する", async () => {
+    testDb.doll.create({
+      id: "doll-1",
+      name: "リナ",
+      archivedAt: FIXED_NOW - 86_400_000,
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<DollDetailPage />);
+
+    fireEvent.click(screen.getByText("完全に削除"));
+
+    const dialog = screen.getByRole("dialog");
+    const confirmButton = within(dialog).getByRole("button", {
+      name: "削除",
+    });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(navHandle.current.router.push).toHaveBeenCalledWith("/archive");
+    });
+  });
+
+  it("存在しないドールで「一覧に戻る」を押すと /dolls に遷移する", async () => {
+    navHandle.current.setParams({ id: "non-existent" });
+
+    await renderWithProviders(<DollDetailPage />);
+
+    fireEvent.click(await screen.findByText("一覧に戻る"));
+
+    expect(navHandle.current.router.push).toHaveBeenCalledWith("/dolls");
+  });
 });

--- a/src/app/garments/[id]/page.test.tsx
+++ b/src/app/garments/[id]/page.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- multiple integration scenarios for garment detail page */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -372,6 +373,236 @@ describe("GarmentDetailPage", () => {
       expect(garment?.status).toBe("stored");
       expect(garment?.lastScannedAt).toBe(FIXED_NOW);
       expect(garment?.checkedOutAt).toBeUndefined();
+    });
+
+    it("複数ケース (grid + unit) で unit ケースをクリックすると即座にその location が選ばれる", async () => {
+      const user = userEvent.setup();
+      testDb.storageCase.create({
+        id: "case-grid",
+        name: "引き出し",
+        type: "grid",
+        rows: 1,
+        cols: 1,
+      });
+      testDb.storageLocation.create({
+        id: "loc-grid",
+        caseId: "case-grid",
+        label: "A-1",
+        row: 0,
+        col: 0,
+      });
+      testDb.storageCase.create({
+        id: "case-unit",
+        name: "ボックスケース",
+        type: "unit",
+        rows: 1,
+        cols: 1,
+      });
+      testDb.storageLocation.create({
+        id: "loc-unit",
+        caseId: "case-unit",
+        label: "ボックスケース",
+        row: 0,
+        col: 0,
+      });
+      testDb.garment.create({
+        id: "garment-1",
+        status: "checked_out",
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<GarmentDetailPage />);
+      await user.click(screen.getByRole("button", { name: /場所を設定/ }));
+
+      const dialog = screen.getByRole("dialog");
+      // ケース一覧から "ボックスケース" をクリックすると即座に locationId が確定
+      await user.click(within(dialog).getByText("ボックスケース"));
+
+      const { getDb } = await import("@/lib/db/dexie");
+      const db = getDb();
+      await waitFor(async () => {
+        const g = await db.garments.get("garment-1");
+        expect(g?.locationId).toBe("loc-unit");
+      });
+    });
+
+    it("複数行 grid を LocationPicker で開くと row 順に並ぶ", async () => {
+      const user = userEvent.setup();
+      testDb.storageCase.create({
+        id: "case-1",
+        name: "ケース",
+        rows: 2,
+        cols: 1,
+      });
+      testDb.storageLocation.create({
+        id: "loc-2",
+        caseId: "case-1",
+        label: "B-1",
+        row: 1,
+        col: 0,
+      });
+      testDb.storageLocation.create({
+        id: "loc-1",
+        caseId: "case-1",
+        label: "A-1",
+        row: 0,
+        col: 0,
+      });
+      testDb.garment.create({
+        id: "garment-1",
+        status: "checked_out",
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<GarmentDetailPage />);
+      await user.click(screen.getByRole("button", { name: /場所を設定/ }));
+
+      const dialog = screen.getByRole("dialog");
+      expect(within(dialog).getByText("A-1")).toBeInTheDocument();
+      expect(within(dialog).getByText("B-1")).toBeInTheDocument();
+    });
+
+    it("unit 型ケースを LocationPicker で選択できる", async () => {
+      const user = userEvent.setup();
+      testDb.storageCase.create({
+        id: "case-unit",
+        name: "押入れ",
+        type: "unit",
+        rows: 1,
+        cols: 1,
+      });
+      testDb.storageLocation.create({
+        id: "loc-unit",
+        caseId: "case-unit",
+        label: "押入れ",
+        row: 0,
+        col: 0,
+      });
+      testDb.garment.create({
+        id: "garment-1",
+        status: "checked_out",
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<GarmentDetailPage />);
+
+      await user.click(screen.getByRole("button", { name: /場所を設定/ }));
+      const dialog = screen.getByRole("dialog");
+      // unit 型は "ボックス" ラベルが付く
+      expect(within(dialog).getByText("ボックス")).toBeInTheDocument();
+    });
+
+    it("lost 状態の服は 'unknown' バリアントのバッジで表示される", async () => {
+      testDb.garment.create({
+        id: "garment-1",
+        name: "紛失中ドレス",
+        status: "lost",
+        locationId: undefined,
+      });
+      await seedDbFromTestDb();
+      await renderWithProviders(<GarmentDetailPage />);
+      expect(screen.getByText("紛失中ドレス")).toBeInTheDocument();
+    });
+
+    it("ブランドが設定された服はブランド情報行が描画される", async () => {
+      testDb.garment.create({
+        id: "garment-1",
+        name: "セット服",
+        brand: "メーカーX",
+      });
+      await seedDbFromTestDb();
+      await renderWithProviders(<GarmentDetailPage />);
+      expect(screen.getByText("セット服")).toBeInTheDocument();
+      expect(screen.getByText("メーカーX")).toBeInTheDocument();
+    });
+
+    it("画像 URL がある服は img タグが描画される", async () => {
+      testDb.garment.create({
+        id: "garment-1",
+        name: "白いドレス",
+        imageUrl: "https://example.com/g.png",
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<GarmentDetailPage />);
+
+      const img = screen.getByAltText("白いドレス");
+      expect(img).toHaveAttribute("src", "https://example.com/g.png");
+    });
+
+    it("ブランドが設定されている服はブランド名が表示される", async () => {
+      testDb.garment.create({
+        id: "garment-1",
+        name: "白いドレス",
+        brand: "アゾン",
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<GarmentDetailPage />);
+
+      expect(screen.getByText("アゾン")).toBeInTheDocument();
+    });
+
+    it("アーカイブ済み服は復元 / 完全に削除ボタンを表示する", async () => {
+      testDb.garment.create({
+        id: "garment-1",
+        name: "白いドレス",
+        archivedAt: FIXED_NOW - 86_400_000,
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<GarmentDetailPage />);
+
+      expect(screen.getByText("復元")).toBeInTheDocument();
+      expect(screen.getByText("完全に削除")).toBeInTheDocument();
+    });
+
+    it("アーカイブ済み服の復元ボタンで /garments に戻る", async () => {
+      testDb.garment.create({
+        id: "garment-1",
+        archivedAt: FIXED_NOW - 86_400_000,
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<GarmentDetailPage />);
+
+      fireEvent.click(screen.getByText("復元"));
+
+      await waitFor(() => {
+        expect(navHandle.current.router.push).toHaveBeenCalledWith("/garments");
+      });
+    });
+
+    it("アーカイブ済み服の完全削除確認後に /archive に遷移する", async () => {
+      testDb.garment.create({
+        id: "garment-1",
+        archivedAt: FIXED_NOW - 86_400_000,
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<GarmentDetailPage />);
+
+      fireEvent.click(screen.getByText("完全に削除"));
+
+      const dialog = screen.getByRole("dialog");
+      const confirmButton = within(dialog).getByRole("button", {
+        name: "削除",
+      });
+      fireEvent.click(confirmButton);
+
+      await waitFor(() => {
+        expect(navHandle.current.router.push).toHaveBeenCalledWith("/archive");
+      });
+    });
+
+    it("存在しない服で「一覧に戻る」を押すと /garments に遷移する", async () => {
+      navHandle.current.setParams({ id: "non-existent" });
+
+      await renderWithProviders(<GarmentDetailPage />);
+
+      fireEvent.click(await screen.findByText("一覧に戻る"));
+
+      expect(navHandle.current.router.push).toHaveBeenCalledWith("/garments");
     });
 
     it("「未配置にする」クリックで garment が checked_out に更新される", async () => {

--- a/src/app/garments/[id]/page.test.tsx
+++ b/src/app/garments/[id]/page.test.tsx
@@ -494,7 +494,7 @@ describe("GarmentDetailPage", () => {
       expect(within(dialog).getByText("ボックス")).toBeInTheDocument();
     });
 
-    it("lost 状態の服は 'unknown' バリアントのバッジで表示される", async () => {
+    it("lost 状態の服は '紛失' ラベルのバッジで表示される", async () => {
       testDb.garment.create({
         id: "garment-1",
         name: "紛失中ドレス",
@@ -504,6 +504,9 @@ describe("GarmentDetailPage", () => {
       await seedDbFromTestDb();
       await renderWithProviders(<GarmentDetailPage />);
       expect(screen.getByText("紛失中ドレス")).toBeInTheDocument();
+      // GARMENT_STATUS_LABEL.lost = msg`紛失` (Badge の text として描画される)。
+      // "ステータス" ラベル横にこの文字列が表示されることで lost 経路を直接検証。
+      expect(screen.getByText("紛失")).toBeInTheDocument();
     });
 
     it("ブランドが設定された服はブランド情報行が描画される", async () => {

--- a/src/app/garments/[id]/page.test.tsx
+++ b/src/app/garments/[id]/page.test.tsx
@@ -458,8 +458,10 @@ describe("GarmentDetailPage", () => {
       await user.click(screen.getByRole("button", { name: /場所を設定/ }));
 
       const dialog = screen.getByRole("dialog");
-      expect(within(dialog).getByText("A-1")).toBeInTheDocument();
-      expect(within(dialog).getByText("B-1")).toBeInTheDocument();
+      // 投入順は B-1 → A-1 だが、LocationPicker は row 昇順で並べるはず。
+      // 単に両 label が存在することだけでなく、DOM 順序まで確認する。
+      const labels = within(dialog).getAllByText(/^[AB]-1$/u);
+      expect(labels.map((el) => el.textContent)).toEqual(["A-1", "B-1"]);
     });
 
     it("unit 型ケースを LocationPicker で選択できる", async () => {

--- a/src/app/garments/page.test.tsx
+++ b/src/app/garments/page.test.tsx
@@ -472,7 +472,7 @@ describe("GarmentsPage", () => {
     expect(await screen.findByText("アーカイブ (1)")).toBeInTheDocument();
   });
 
-  it("ソート: 信頼度の低い順 / 高い順を切り替えてもクラッシュしない", async () => {
+  it("ソート: 信頼度 asc / desc で並び順が切り替わる", async () => {
     const user = userEvent.setup();
     testDb.garment.create({
       id: "g-1",
@@ -493,10 +493,20 @@ describe("GarmentsPage", () => {
     const sortSelect = await screen.findByRole("combobox", {
       name: /並び替え/,
     });
+
+    // 信頼度 asc: 信頼度低い (= 古いドレス) が先に来るはず
     await user.selectOptions(sortSelect, "confidence_asc");
-    expect(screen.getByText("古いドレス")).toBeInTheDocument();
+    const ascNames = screen
+      .getAllByText(/^(?:古いドレス|新しいドレス)$/u)
+      .map((el) => el.textContent);
+    expect(ascNames).toEqual(["古いドレス", "新しいドレス"]);
+
+    // 信頼度 desc: 信頼度高い (= 新しいドレス) が先に来るはず
     await user.selectOptions(sortSelect, "confidence_desc");
-    expect(screen.getByText("新しいドレス")).toBeInTheDocument();
+    const descNames = screen
+      .getAllByText(/^(?:古いドレス|新しいドレス)$/u)
+      .map((el) => el.textContent);
+    expect(descNames).toEqual(["新しいドレス", "古いドレス"]);
   });
 
   it("検索クエリに対しタグがマッチする (大文字小文字を区別しない)", async () => {

--- a/src/app/garments/page.test.tsx
+++ b/src/app/garments/page.test.tsx
@@ -457,4 +457,67 @@ describe("GarmentsPage", () => {
 
     expect(screen.getByText(/アゾン/)).toBeInTheDocument();
   });
+
+  it("アーカイブ件数が 1 以上のときアーカイブリンクが表示される", async () => {
+    testDb.garment.create({ id: "g-1", name: "現役ドレス" });
+    testDb.garment.create({
+      id: "g-2",
+      name: "アーカイブ済み",
+      archivedAt: FIXED_NOW - MS_PER_DAY,
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    expect(await screen.findByText("アーカイブ (1)")).toBeInTheDocument();
+  });
+
+  it("ソート: 信頼度の低い順 / 高い順を切り替えてもクラッシュしない", async () => {
+    const user = userEvent.setup();
+    testDb.garment.create({
+      id: "g-1",
+      name: "古いドレス",
+      lastScannedAt: FIXED_NOW - 28 * MS_PER_DAY,
+      confidenceDecayDays: 30,
+    });
+    testDb.garment.create({
+      id: "g-2",
+      name: "新しいドレス",
+      lastScannedAt: FIXED_NOW,
+      confidenceDecayDays: 30,
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    const sortSelect = await screen.findByRole("combobox", {
+      name: /並び替え/,
+    });
+    await user.selectOptions(sortSelect, "confidence_asc");
+    expect(screen.getByText("古いドレス")).toBeInTheDocument();
+    await user.selectOptions(sortSelect, "confidence_desc");
+    expect(screen.getByText("新しいドレス")).toBeInTheDocument();
+  });
+
+  it("検索クエリに対しタグがマッチする (大文字小文字を区別しない)", async () => {
+    const user = userEvent.setup();
+    testDb.garment.create({
+      id: "g-1",
+      name: "ドレス",
+      tags: ["Princess"],
+    });
+    testDb.garment.create({
+      id: "g-2",
+      name: "シャツ",
+      tags: ["casual"],
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<GarmentsPage />);
+
+    const input = await screen.findByPlaceholderText(/名前やタグで検索/);
+    await user.type(input, "princess");
+    expect(screen.getAllByText("ドレス").length).toBeGreaterThan(0);
+    expect(screen.queryByText("シャツ")).toBeNull();
+  });
 });

--- a/src/app/locations/page.test.tsx
+++ b/src/app/locations/page.test.tsx
@@ -302,4 +302,76 @@ describe("LocationsPage CRUD操作", () => {
       expect(cases.length).toBe(0);
     });
   });
+
+  it("削除でケース内の服が取り出し中になる", async () => {
+    testDb.storageCase.create({ id: "case-1", name: "衣装ケース A" });
+    testDb.storageLocation.create({ id: "loc-1", caseId: "case-1" });
+    testDb.garment.create({
+      id: "g-1",
+      locationId: "loc-1",
+      status: "stored",
+    });
+    await seedDbFromTestDb();
+
+    await renderWithProviders(<LocationsPage />);
+
+    fireEvent.click(screen.getByLabelText("削除"));
+    const deleteButtons = screen.getAllByRole("button", { name: "削除" });
+    const lastDeleteButton = deleteButtons[deleteButtons.length - 1];
+    expect(lastDeleteButton).toBeDefined();
+    if (lastDeleteButton === undefined) return;
+    fireEvent.click(lastDeleteButton);
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await waitFor(async () => {
+      const g = await db.garments.get("g-1");
+      expect(g?.status).toBe("checked_out");
+      expect(g?.locationId).toBeUndefined();
+    });
+  });
+
+  it("ユニットケース (ボックス) として作成できる", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<LocationsPage />);
+
+    fireEvent.click(screen.getByLabelText("ケースを追加"));
+    fireEvent.click(screen.getByRole("button", { name: "ボックス" }));
+    const nameInput = screen.getByLabelText("ケース名");
+    await user.clear(nameInput);
+    await user.type(nameInput, "押し入れ");
+    fireEvent.click(screen.getByRole("button", { name: "作成" }));
+
+    const { getDb } = await import("@/lib/db/dexie");
+    const db = getDb();
+    await waitFor(async () => {
+      const cases = await db.storageCases.toArray();
+      expect(cases.length).toBe(1);
+      expect(cases[0]?.type).toBe("unit");
+    });
+  });
+
+  it("ケース作成シートのキャンセルでシートが閉じる", async () => {
+    await renderWithProviders(<LocationsPage />);
+
+    fireEvent.click(screen.getByLabelText("ケースを追加"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("ケース名を空にすると作成ボタンが無効化される", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<LocationsPage />);
+
+    fireEvent.click(screen.getByLabelText("ケースを追加"));
+    const nameInput = screen.getByLabelText("ケース名");
+    await user.clear(nameInput);
+
+    const submit = screen.getByRole("button", { name: "作成" });
+    expect(submit).toBeDisabled();
+  });
 });

--- a/src/app/nfc-write/page.test.tsx
+++ b/src/app/nfc-write/page.test.tsx
@@ -179,6 +179,67 @@ describe("NfcWritePage", () => {
     );
   });
 
+  it("中止 (aborted) 時に専用エラーメッセージを表示する", async () => {
+    setNfcSupported(true);
+    mockWriteNfcTag.mockResolvedValueOnce({
+      ok: false,
+      errorKind: "aborted",
+      message: "aborted",
+    });
+    testDb.garment.create({ id: "g-1", name: "白いドレス" });
+    await seedDbFromTestDb();
+    const user = userEvent.setup();
+    await renderWithProviders(<NfcWritePage />);
+
+    await user.click(screen.getByText("服"));
+    await user.selectOptions(screen.getByRole("combobox"), "g-1");
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    await user.click(screen.getByRole("button", { name: "書き込む" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("書き込みがキャンセルされました"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("書き込み準備画面から「戻る」でアイテム選択画面に戻る", async () => {
+    setNfcSupported(true);
+    testDb.garment.create({ id: "g-1", name: "白いドレス" });
+    await seedDbFromTestDb();
+    const user = userEvent.setup();
+    await renderWithProviders(<NfcWritePage />);
+
+    await user.click(screen.getByText("服"));
+    await user.selectOptions(screen.getByRole("combobox"), "g-1");
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    // ready_to_write 状態
+    expect(screen.getByText("書き込み対象")).toBeInTheDocument();
+
+    // 戻る → select_item
+    await user.click(screen.getByText("戻る"));
+    expect(screen.getByText("書き込む服を選択")).toBeInTheDocument();
+  });
+
+  it("収納場所で case がないラベルでも fallback として caseId が表示される", async () => {
+    setNfcSupported(true);
+    testDb.storageLocation.create({
+      id: "loc-1",
+      caseId: "missing-case",
+      label: "A-1",
+    });
+    await seedDbFromTestDb();
+    const user = userEvent.setup();
+    await renderWithProviders(<NfcWritePage />);
+
+    await user.click(screen.getByText("収納場所"));
+    expect(screen.getByText("書き込む収納場所を選択")).toBeInTheDocument();
+    // option ラベル = "missing-case - A-1"
+    await user.selectOptions(screen.getByRole("combobox"), "loc-1");
+    await user.click(screen.getByRole("button", { name: "次へ" }));
+    expect(screen.getByText("dwg://l/loc-1")).toBeInTheDocument();
+  });
+
   it("「もう1枚書き込む」でタイプ選択に戻る", async () => {
     setNfcSupported(true);
     mockWriteNfcTag.mockResolvedValueOnce({ ok: true });

--- a/src/app/scan/page.test.tsx
+++ b/src/app/scan/page.test.tsx
@@ -382,16 +382,11 @@ describe("ScanPage", () => {
 
       // ダイアログ表示
       expect(screen.getByText("全部ある")).toBeInTheDocument();
-      // 「あとで」 で閉じる
-      const closeButton = screen.queryByRole("button", {
-        name: /あとで|閉じる/u,
+      // BottomSheet の「閉じる」アイコンボタン経由でダイアログを閉じる
+      fireEvent.click(screen.getByLabelText("閉じる"));
+      await waitFor(() => {
+        expect(screen.queryByText("全部ある")).toBeNull();
       });
-      if (closeButton !== null) {
-        fireEvent.click(closeButton);
-        await waitFor(() => {
-          expect(screen.queryByText("全部ある")).toBeNull();
-        });
-      }
     });
   });
 });

--- a/src/app/scan/page.test.tsx
+++ b/src/app/scan/page.test.tsx
@@ -332,4 +332,66 @@ describe("ScanPage", () => {
       expect(screen.getByText("場所を設定しました")).toBeInTheDocument();
     });
   });
+
+  describe("未登録 / 未紐付け QR のフォールバック", () => {
+    it("未登録の場所 QR ではラベルとして locationId が表示される", async () => {
+      await renderWithProviders(<ScanPage />);
+      await flushPromises();
+      await simulateQrScan("dwg://l/unknown-loc");
+      await flushPromises();
+      // 場所名フォールバック (ScanResult / ScanSessionPanel の両方に出る可能性あり)
+      expect(screen.getAllByText("unknown-loc").length).toBeGreaterThan(0);
+    });
+
+    it("未登録の服 QR では garmentId がそのまま表示される", async () => {
+      await renderWithProviders(<ScanPage />);
+      await flushPromises();
+      await simulateQrScan("dwg://g/unknown-g");
+      await flushPromises();
+      expect(screen.getByText("unknown-g")).toBeInTheDocument();
+    });
+
+    it("不明な QR スキームは無視される", async () => {
+      await renderWithProviders(<ScanPage />);
+      await flushPromises();
+      await simulateQrScan("unknown-scheme://x");
+      await flushPromises();
+      // 何も起きないため、初期の「場所のQRをスキャン」表示が継続する
+      expect(
+        screen.getByText("場所のQRをスキャンして、収納場所を設定してください"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("機会確認ダイアログの閉じる操作", () => {
+    it("ダイアログを閉じても scan 状態は維持される", async () => {
+      testDb.storageLocation.create({ id: "loc-1", label: "A-1" });
+      testDb.garment.create({
+        id: "g-1",
+        locationId: "loc-1",
+        status: "stored",
+        lastScannedAt: FIXED_NOW - 20 * MS_PER_DAY,
+        confidenceDecayDays: 30,
+      });
+      await seedDbFromTestDb();
+
+      await renderWithProviders(<ScanPage />);
+      await flushPromises();
+      await simulateQrScan("dwg://l/loc-1");
+      await flushPromises();
+
+      // ダイアログ表示
+      expect(screen.getByText("全部ある")).toBeInTheDocument();
+      // 「あとで」 で閉じる
+      const closeButton = screen.queryByRole("button", {
+        name: /あとで|閉じる/u,
+      });
+      if (closeButton !== null) {
+        fireEvent.click(closeButton);
+        await waitFor(() => {
+          expect(screen.queryByText("全部ある")).toBeNull();
+        });
+      }
+    });
+  });
 });

--- a/src/app/settings/account/page.test.tsx
+++ b/src/app/settings/account/page.test.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable max-lines -- many account-settings integration scenarios */
 import { describe, it, expect, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
 import { server } from "@/test/mocks/server";
 import { unauthenticatedHandler } from "@/test/mocks/handlers";
 import { renderWithProviders } from "@/test/testUtils";
@@ -249,5 +251,314 @@ describe("AccountSettingsPage", () => {
     await waitFor(() => {
       expect(router.replace).toHaveBeenCalledWith("/signin");
     });
+  });
+
+  it("プロフィール更新失敗時はフォーム入力が保持される", async () => {
+    const { spies } = setupAuthClient({ updateProfileShouldFail: true });
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const nameInput = await screen.findByLabelText("表示名");
+    await user.clear(nameInput);
+    await user.type(nameInput, "失敗ユーザー");
+    await user.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    await waitFor(() => {
+      expect(spies.updateProfile).toHaveBeenCalledWith({
+        name: "失敗ユーザー",
+        image: undefined,
+      });
+    });
+    expect(nameInput).toHaveValue("失敗ユーザー");
+  });
+
+  it("プロフィール画像 URL が不正な場合はバリデーションエラーになる", async () => {
+    const { spies } = setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const nameInput = await screen.findByLabelText("表示名");
+    await user.clear(nameInput);
+    await user.type(nameInput, "別名");
+    await user.type(screen.getByLabelText("プロフィール画像 URL"), "not-a-url");
+    await user.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    await waitFor(() => {
+      expect(spies.updateProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  it("メールアドレス変更失敗時は入力値が保持される", async () => {
+    const { spies } = setupAuthClient({ changeEmailShouldFail: true });
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const emailInput = await screen.findByLabelText("新しいメールアドレス");
+    await user.type(emailInput, "fail@example.com");
+    await user.click(
+      screen.getByRole("button", { name: "メールアドレスを変更" }),
+    );
+
+    await waitFor(() => {
+      expect(spies.changeEmail).toHaveBeenCalledWith({
+        newEmail: "fail@example.com",
+      });
+    });
+    expect(emailInput).toHaveValue("fail@example.com");
+  });
+
+  it("メールアドレス形式が不正な場合はバリデーションエラー (送信されない)", async () => {
+    const { spies } = setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const emailInput = await screen.findByLabelText("新しいメールアドレス");
+    await user.type(emailInput, "not-email");
+    await user.click(
+      screen.getByRole("button", { name: "メールアドレスを変更" }),
+    );
+
+    await waitFor(() => {
+      expect(spies.changeEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  it("メールアドレス変更で同じメールを入力すると送信ボタンは無効", async () => {
+    const { spies } = setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const input = await screen.findByLabelText("新しいメールアドレス");
+    await user.type(input, "test@example.com");
+
+    const submitBtn = screen.getByRole("button", {
+      name: "メールアドレスを変更",
+    });
+    expect(submitBtn).toBeDisabled();
+    expect(spies.changeEmail).not.toHaveBeenCalled();
+  });
+
+  it("パスワード変更失敗時は入力値が保持される (credential)", async () => {
+    const { spies } = setupAuthClient({ changePasswordShouldFail: true });
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const cur = await screen.findByLabelText("現在のパスワード");
+    await user.type(cur, "oldpass12");
+    await user.type(screen.getByLabelText("新しいパスワード"), "newpass12");
+    await user.type(
+      screen.getByLabelText("新しいパスワード（確認）"),
+      "newpass12",
+    );
+    await user.click(screen.getByRole("button", { name: "パスワードを変更" }));
+
+    await waitFor(() => {
+      expect(spies.changePassword).toHaveBeenCalled();
+    });
+    expect(cur).toHaveValue("oldpass12");
+  });
+
+  it("パスワード設定失敗時は入力値が保持される (OAuth-only)", async () => {
+    const { spies } = setupAuthClient({
+      accounts: [{ providerId: "google" }],
+      setPasswordShouldFail: true,
+    });
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const newPw = await screen.findByLabelText("パスワード");
+    await user.type(newPw, "newpass12");
+    await user.type(
+      screen.getByLabelText("新しいパスワード（確認）"),
+      "newpass12",
+    );
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+
+    await waitFor(() => {
+      expect(spies.setPassword).toHaveBeenCalled();
+    });
+    expect(newPw).toHaveValue("newpass12");
+  });
+
+  it("OAuth-only でパスワード短すぎる場合はバリデーションで送信されない", async () => {
+    const { spies } = setupAuthClient({ accounts: [{ providerId: "google" }] });
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const newPw = await screen.findByLabelText("パスワード");
+    await user.type(newPw, "short");
+    await user.type(screen.getByLabelText("新しいパスワード（確認）"), "short");
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+
+    await waitFor(() => {
+      expect(spies.setPassword).not.toHaveBeenCalled();
+    });
+  });
+
+  it("パスワード変更でパスワード確認が一致しないとバリデーションエラー", async () => {
+    const { spies } = setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await user.type(
+      await screen.findByLabelText("現在のパスワード"),
+      "oldpass12",
+    );
+    await user.type(screen.getByLabelText("新しいパスワード"), "newpass12");
+    await user.type(
+      screen.getByLabelText("新しいパスワード（確認）"),
+      "different12",
+    );
+    await user.click(screen.getByRole("button", { name: "パスワードを変更" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("パスワードが一致しません")).toBeInTheDocument();
+    });
+    expect(spies.changePassword).not.toHaveBeenCalled();
+  });
+
+  it("退会フロー失敗時はリダイレクトされず削除ボタンが再度押せる", async () => {
+    const { spies } = setupAuthClient({ deleteAccountShouldFail: true });
+    const { router } = setupNextNavigation();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "アカウントを削除する" }),
+    );
+    await user.type(
+      screen.getByLabelText("メールアドレスを再入力"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワードを入力"), "secret123");
+    const finalDelete = await screen.findByRole("button", {
+      name: "完全に削除",
+    });
+    await user.click(finalDelete);
+
+    await waitFor(() => {
+      expect(spies.deleteAccount).toHaveBeenCalledWith({
+        confirmEmail: "test@example.com",
+        password: "secret123",
+      });
+    });
+    expect(router.replace).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(finalDelete).not.toBeDisabled();
+    });
+  });
+
+  it("退会フロー (OAuth-only) 失敗時はパスワード欄なしで再操作可能", async () => {
+    const { spies } = setupAuthClient({
+      accounts: [],
+      deleteAccountShouldFail: true,
+    });
+    const { router } = setupNextNavigation();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "アカウントを削除する" }),
+    );
+    await user.type(
+      screen.getByLabelText("メールアドレスを再入力"),
+      "test@example.com",
+    );
+    const finalDelete = await screen.findByRole("button", {
+      name: "完全に削除",
+    });
+    await user.click(finalDelete);
+
+    await waitFor(() => {
+      expect(spies.deleteAccount).toHaveBeenCalledWith({
+        confirmEmail: "test@example.com",
+        password: undefined,
+      });
+    });
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it("退会フロー: メール不一致ならエラーメッセージを表示", async () => {
+    setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "アカウントを削除する" }),
+    );
+    await user.type(
+      screen.getByLabelText("メールアドレスを再入力"),
+      "wrong@example.com",
+    );
+
+    expect(
+      await screen.findByText("メールアドレスが一致しません"),
+    ).toBeInTheDocument();
+  });
+
+  it("退会フロー: キャンセルでシートが閉じる", async () => {
+    setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "アカウントを削除する" }),
+    );
+    const cancel = await screen.findByRole("button", { name: "キャンセル" });
+    await user.click(cancel);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "完全に削除" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("プロフィール画像 URL を入力して更新すると image 引数として送られる", async () => {
+    const { spies } = setupAuthClient();
+    const user = userEvent.setup();
+    await renderWithProviders(<AccountSettingsPage />);
+
+    const nameInput = await screen.findByLabelText("表示名");
+    await user.clear(nameInput);
+    await user.type(nameInput, "画像更新");
+    await user.type(
+      screen.getByLabelText("プロフィール画像 URL"),
+      "https://example.com/me.png",
+    );
+    await user.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    await waitFor(() => {
+      expect(spies.updateProfile).toHaveBeenCalledWith({
+        name: "画像更新",
+        image: "https://example.com/me.png",
+      });
+    });
+  });
+
+  it("プロフィール画像 URL が既に設定されているユーザーは img が表示される", async () => {
+    server.use(
+      http.get("*/api/auth/get-session", () =>
+        HttpResponse.json({
+          user: {
+            id: "user-1",
+            name: "テストユーザー",
+            email: "test@example.com",
+            image: "https://example.com/avatar.png",
+            emailVerified: false,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        }),
+      ),
+    );
+    setupAuthClient();
+    const { container } = await renderWithProviders(<AccountSettingsPage />);
+
+    await screen.findByRole("heading", { name: "プロフィール" });
+    const img = container.querySelector(
+      'img[src="https://example.com/avatar.png"]',
+    );
+    expect(img).not.toBeNull();
   });
 });

--- a/src/app/settings/api-keys/page.test.tsx
+++ b/src/app/settings/api-keys/page.test.tsx
@@ -102,4 +102,88 @@ describe("ApiKeysPage", () => {
       expect(router.replace).toHaveBeenCalledWith("/signin");
     });
   });
+
+  it("API キー発行に失敗するとシートが閉じず生キー表示も出ない", async () => {
+    const { spies } = setupAuthClient({
+      apiKeys: [],
+      createShouldFail: true,
+    });
+    const user = userEvent.setup();
+    await renderWithProviders(<ApiKeysPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "新しい API キーを発行" }),
+    );
+    await user.type(await screen.findByLabelText("名前"), "agent-fail");
+    await user.click(screen.getByRole("button", { name: "発行" }));
+
+    await waitFor(() => {
+      expect(spies.createApiKey).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("api-key-value")).toBeNull();
+  });
+
+  it("名前が空のとき発行ボタンは無効化される", async () => {
+    setupAuthClient({ apiKeys: [] });
+    const user = userEvent.setup();
+    await renderWithProviders(<ApiKeysPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "新しい API キーを発行" }),
+    );
+    const submitBtn = await screen.findByRole("button", { name: "発行" });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it("発行シートをキャンセルで閉じることができる", async () => {
+    setupAuthClient({ apiKeys: [] });
+    const user = userEvent.setup();
+    await renderWithProviders(<ApiKeysPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "新しい API キーを発行" }),
+    );
+    await user.type(await screen.findByLabelText("名前"), "tmp");
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("名前")).toBeNull();
+    });
+  });
+
+  it("最終使用済みの API キーは最終使用日時が表示される", async () => {
+    setupAuthClient({
+      apiKeys: [
+        {
+          ...baseKey,
+          id: "key-used",
+          name: "agent-used",
+          lastRequestAt: new Date("2026-02-15T10:00:00Z").getTime(),
+        },
+      ],
+    });
+
+    await renderWithProviders(<ApiKeysPage />);
+
+    expect(await screen.findByText("agent-used")).toBeInTheDocument();
+    expect(screen.queryByText("未使用")).toBeNull();
+  });
+
+  it("失効処理が失敗した場合は一覧から消えない", async () => {
+    setupAuthClient({
+      apiKeys: [baseKey],
+      revokeShouldFail: true,
+    });
+    const user = userEvent.setup();
+    await renderWithProviders(<ApiKeysPage />);
+
+    expect(await screen.findByText("agent-existing")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "失効" }));
+    const confirmButtons = screen.getAllByRole("button", { name: "失効" });
+    await user.click(confirmButtons[confirmButtons.length - 1]!);
+
+    await waitFor(() => {
+      expect(screen.getByText("agent-existing")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/app/settings/api-keys/page.test.tsx
+++ b/src/app/settings/api-keys/page.test.tsx
@@ -152,13 +152,14 @@ describe("ApiKeysPage", () => {
   });
 
   it("最終使用済みの API キーは最終使用日時が表示される", async () => {
+    const lastRequestAt = new Date("2026-02-15T10:00:00Z").getTime();
     setupAuthClient({
       apiKeys: [
         {
           ...baseKey,
           id: "key-used",
           name: "agent-used",
-          lastRequestAt: new Date("2026-02-15T10:00:00Z").getTime(),
+          lastRequestAt,
         },
       ],
     });
@@ -167,6 +168,13 @@ describe("ApiKeysPage", () => {
 
     expect(await screen.findByText("agent-used")).toBeInTheDocument();
     expect(screen.queryByText("未使用")).toBeNull();
+    // ApiKeyList は ja locale で `yyyy/MM/dd HH:mm` パターンで描画する。
+    // 環境ローカル TZ に左右されない年月部分 (2026/02) を assert することで
+    // formatDateTime 経路が実際に呼ばれていることを確認する。
+    const visibleDate = await screen.findByText(
+      /2026\/02\/\d{2}\s+\d{2}:\d{2}/u,
+    );
+    expect(visibleDate).toBeInTheDocument();
   });
 
   it("失効処理が失敗した場合は一覧から消えない", async () => {

--- a/src/components/chart/HorizontalBarChart.test.tsx
+++ b/src/components/chart/HorizontalBarChart.test.tsx
@@ -5,10 +5,8 @@ import HorizontalBarChart from "./HorizontalBarChart";
 
 describe("HorizontalBarChart", () => {
   it("items が空のときは何も描画しない", async () => {
-    const { container } = await renderWithProviders(
-      <HorizontalBarChart items={[]} />,
-    );
-    expect(container.querySelector("[role=progressbar]")).toBeNull();
+    await renderWithProviders(<HorizontalBarChart items={[]} />);
+    expect(screen.queryByRole("progressbar")).toBeNull();
   });
 
   it("単一アイテムを描画する (color あり / swatch なし)", async () => {
@@ -23,7 +21,7 @@ describe("HorizontalBarChart", () => {
   });
 
   it("swatch ありのアイテムは色サンプルが描画される", async () => {
-    const { container } = await renderWithProviders(
+    await renderWithProviders(
       <HorizontalBarChart
         items={[
           {
@@ -34,12 +32,14 @@ describe("HorizontalBarChart", () => {
         ]}
       />,
     );
-    const swatch = container.querySelector("span[style*='background-color']");
-    expect(swatch).not.toBeNull();
+    // progressbar 自体の背景色とは別に、swatch span が描画されていることを
+    // aria-label でアクセス可能な progressbar の隣に確認する
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByText("青")).toBeInTheDocument();
   });
 
   it("maxValue=0 (全 value=0) の場合は percentage=0%", async () => {
-    const { container } = await renderWithProviders(
+    await renderWithProviders(
       <HorizontalBarChart
         items={[
           { label: "A", value: 0 },
@@ -47,15 +47,15 @@ describe("HorizontalBarChart", () => {
         ]}
       />,
     );
-    const bars = container.querySelectorAll('[role="progressbar"]');
+    const bars = screen.getAllByRole("progressbar");
     expect(bars.length).toBe(2);
     bars.forEach((bar) => {
-      expect((bar as HTMLElement).style.width).toBe("0%");
+      expect(bar.style.width).toBe("0%");
     });
   });
 
   it("複数アイテムで相対割合に基づき幅が計算される", async () => {
-    const { container } = await renderWithProviders(
+    await renderWithProviders(
       <HorizontalBarChart
         items={[
           { label: "A", value: 10 },
@@ -63,8 +63,8 @@ describe("HorizontalBarChart", () => {
         ]}
       />,
     );
-    const bars = container.querySelectorAll('[role="progressbar"]');
-    expect((bars[0] as HTMLElement).style.width).toBe("100%");
-    expect((bars[1] as HTMLElement).style.width).toBe("50%");
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars[0]?.style.width).toBe("100%");
+    expect(bars[1]?.style.width).toBe("50%");
   });
 });

--- a/src/components/chart/HorizontalBarChart.test.tsx
+++ b/src/components/chart/HorizontalBarChart.test.tsx
@@ -21,7 +21,7 @@ describe("HorizontalBarChart", () => {
   });
 
   it("swatch ありのアイテムは色サンプルが描画される", async () => {
-    await renderWithProviders(
+    const { container } = await renderWithProviders(
       <HorizontalBarChart
         items={[
           {
@@ -32,10 +32,24 @@ describe("HorizontalBarChart", () => {
         ]}
       />,
     );
-    // progressbar 自体の背景色とは別に、swatch span が描画されていることを
-    // aria-label でアクセス可能な progressbar の隣に確認する
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
-    expect(screen.getByText("青")).toBeInTheDocument();
+    // swatch span は label 直前に inline 描画される。
+    // background-color が item.swatch と一致することを直接確認する。
+    const swatches = container.querySelectorAll(
+      "span.rounded-full[style*='background-color']",
+    );
+    expect(swatches.length).toBe(1);
+    // happy-dom が style 文字列を正規化してスペースを挿入する点に注意
+    expect(swatches[0]?.getAttribute("style")).toContain("hsl(240, 100%, 50%)");
+  });
+
+  it("swatch 無しのアイテムは色サンプル span が描画されない", async () => {
+    const { container } = await renderWithProviders(
+      <HorizontalBarChart items={[{ label: "ラベル", value: 1 }]} />,
+    );
+    const swatches = container.querySelectorAll(
+      "span.rounded-full[style*='background-color']",
+    );
+    expect(swatches.length).toBe(0);
   });
 
   it("maxValue=0 (全 value=0) の場合は percentage=0%", async () => {

--- a/src/components/chart/HorizontalBarChart.test.tsx
+++ b/src/components/chart/HorizontalBarChart.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/testUtils";
+import HorizontalBarChart from "./HorizontalBarChart";
+
+describe("HorizontalBarChart", () => {
+  it("items が空のときは何も描画しない", async () => {
+    const { container } = await renderWithProviders(
+      <HorizontalBarChart items={[]} />,
+    );
+    expect(container.querySelector("[role=progressbar]")).toBeNull();
+  });
+
+  it("単一アイテムを描画する (color あり / swatch なし)", async () => {
+    await renderWithProviders(
+      <HorizontalBarChart
+        items={[{ label: "赤", value: 5, color: "hsl(0,100%,50%)" }]}
+      />,
+    );
+    expect(screen.getByText("赤")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  it("swatch ありのアイテムは色サンプルが描画される", async () => {
+    const { container } = await renderWithProviders(
+      <HorizontalBarChart
+        items={[
+          {
+            label: "青",
+            value: 3,
+            swatch: "hsl(240,100%,50%)",
+          },
+        ]}
+      />,
+    );
+    const swatch = container.querySelector("span[style*='background-color']");
+    expect(swatch).not.toBeNull();
+  });
+
+  it("maxValue=0 (全 value=0) の場合は percentage=0%", async () => {
+    const { container } = await renderWithProviders(
+      <HorizontalBarChart
+        items={[
+          { label: "A", value: 0 },
+          { label: "B", value: 0 },
+        ]}
+      />,
+    );
+    const bars = container.querySelectorAll('[role="progressbar"]');
+    expect(bars.length).toBe(2);
+    bars.forEach((bar) => {
+      expect((bar as HTMLElement).style.width).toBe("0%");
+    });
+  });
+
+  it("複数アイテムで相対割合に基づき幅が計算される", async () => {
+    const { container } = await renderWithProviders(
+      <HorizontalBarChart
+        items={[
+          { label: "A", value: 10 },
+          { label: "B", value: 5 },
+        ]}
+      />,
+    );
+    const bars = container.querySelectorAll('[role="progressbar"]');
+    expect((bars[0] as HTMLElement).style.width).toBe("100%");
+    expect((bars[1] as HTMLElement).style.width).toBe("50%");
+  });
+});

--- a/src/components/garment/DollCombobox.test.tsx
+++ b/src/components/garment/DollCombobox.test.tsx
@@ -153,6 +153,18 @@ describe("DollCombobox", () => {
     expect(combobox).toHaveAttribute("aria-expanded", "true");
   });
 
+  it("閉じている状態で Enter を押しても開かれる", async () => {
+    const user = userEvent.setup();
+    const { combobox } = await renderCombobox();
+
+    await user.click(combobox);
+    await user.keyboard("{Escape}");
+    expect(combobox).toHaveAttribute("aria-expanded", "false");
+
+    await user.keyboard("{Enter}");
+    expect(combobox).toHaveAttribute("aria-expanded", "true");
+  });
+
   it("ArrowDown で末尾を超えると先頭に wrap-around する", async () => {
     const user = userEvent.setup();
     const { combobox } = await renderCombobox();

--- a/src/components/garment/GarmentCard.test.tsx
+++ b/src/components/garment/GarmentCard.test.tsx
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen } from "@testing-library/react";
+import type { Garment } from "@/types";
+import { renderWithProviders } from "@/test/testUtils";
+import { createTestGarment, FIXED_NOW } from "@/test/factories";
+import { setupAuthSession } from "@/test/mocks/modules/authAtomsState";
+import GarmentCard from "./GarmentCard";
+
+const make = (overrides: Partial<Garment> = {}): Garment =>
+  createTestGarment({
+    name: "テスト服",
+    category: "dress",
+    dollSizes: ["MSD"],
+    ...overrides,
+  });
+
+describe("GarmentCard", () => {
+  beforeEach(() => {
+    setupAuthSession({ userId: "user-1" });
+  });
+
+  it("画像 URL 無しでも fallback アイコン付きで描画される", async () => {
+    await renderWithProviders(<GarmentCard garment={make()} />);
+    expect(await screen.findByText("テスト服")).toBeInTheDocument();
+    expect(screen.queryByAltText("テスト服")).toBeNull();
+  });
+
+  it("画像 URL 設定済みなら img タグが描画される", async () => {
+    await renderWithProviders(
+      <GarmentCard garment={make({ imageUrl: "https://example.com/x.png" })} />,
+    );
+    expect(await screen.findByAltText("テスト服")).toHaveAttribute(
+      "src",
+      "https://example.com/x.png",
+    );
+  });
+
+  it("checked_out 状態の服は「取り出し中」バッジが表示される", async () => {
+    await renderWithProviders(
+      <GarmentCard
+        garment={make({
+          status: "checked_out",
+          locationId: undefined,
+          checkedOutAt: FIXED_NOW,
+        })}
+      />,
+    );
+    expect(await screen.findByText("取り出し中")).toBeInTheDocument();
+  });
+
+  it("ブランドありの服はブランド名が表示される", async () => {
+    await renderWithProviders(
+      <GarmentCard garment={make({ brand: "アゾン" })} />,
+    );
+    expect(await screen.findByText("アゾン")).toBeInTheDocument();
+  });
+
+  it("ブランド未設定の服はブランド表示行が無い", async () => {
+    await renderWithProviders(
+      <GarmentCard garment={make({ brand: undefined })} />,
+    );
+    expect(await screen.findByText("テスト服")).toBeInTheDocument();
+    expect(screen.queryByText("アゾン")).toBeNull();
+  });
+});

--- a/src/components/garment/bulk/BulkMetadataFormFields.test.tsx
+++ b/src/components/garment/bulk/BulkMetadataFormFields.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import type { BulkCaptureMetadata } from "@/types";
+import { renderWithProviders } from "@/test/testUtils";
+import BulkMetadataFormFields from "./BulkMetadataFormFields";
+
+const baseValues: BulkCaptureMetadata = {
+  captureId: "c-1",
+  name: "テスト",
+  category: "dress",
+  dollSize: "MSD",
+  colors: [],
+  tags: [],
+  brand: "",
+  confidenceDecayDays: 30,
+};
+
+describe("BulkMetadataFormFields", () => {
+  it("カテゴリ変更で onChange が新カテゴリで呼ばれる (有効値)", async () => {
+    const onChange = vi.fn();
+    await renderWithProviders(
+      <BulkMetadataFormFields values={baseValues} onChange={onChange} />,
+    );
+
+    const categorySelect = screen.getByLabelText("カテゴリ");
+    fireEvent.change(categorySelect, { target: { value: "tops" } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ category: "tops" }),
+    );
+  });
+
+  it("カテゴリ変更で無効値は無視される (型ガードで弾かれる)", async () => {
+    const onChange = vi.fn();
+    await renderWithProviders(
+      <BulkMetadataFormFields values={baseValues} onChange={onChange} />,
+    );
+
+    const categorySelect = screen.getByLabelText("カテゴリ");
+    fireEvent.change(categorySelect, {
+      target: { value: "invalid-category" },
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ドールサイズ変更で onChange が呼ばれる (有効値)", async () => {
+    const onChange = vi.fn();
+    await renderWithProviders(
+      <BulkMetadataFormFields values={baseValues} onChange={onChange} />,
+    );
+
+    const sizeSelect = screen.getByLabelText("ドールサイズ");
+    fireEvent.change(sizeSelect, { target: { value: "SD" } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ dollSize: "SD" }),
+    );
+  });
+
+  it("ドールサイズ変更で無効値は無視される", async () => {
+    const onChange = vi.fn();
+    await renderWithProviders(
+      <BulkMetadataFormFields values={baseValues} onChange={onChange} />,
+    );
+
+    const sizeSelect = screen.getByLabelText("ドールサイズ");
+    fireEvent.change(sizeSelect, { target: { value: "invalid-size" } });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("名前変更で onChange が呼ばれる", async () => {
+    const onChange = vi.fn();
+    await renderWithProviders(
+      <BulkMetadataFormFields values={baseValues} onChange={onChange} />,
+    );
+
+    const nameInput = screen.getByLabelText("名前");
+    fireEvent.change(nameInput, { target: { value: "新しい名前" } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "新しい名前" }),
+    );
+  });
+
+  it("ブランド変更で onChange が呼ばれる", async () => {
+    const onChange = vi.fn();
+    await renderWithProviders(
+      <BulkMetadataFormFields values={baseValues} onChange={onChange} />,
+    );
+
+    const brandInput = screen.getByLabelText("ブランド/メーカー");
+    fireEvent.change(brandInput, { target: { value: "アゾン" } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ brand: "アゾン" }),
+    );
+  });
+
+  it("信頼度の減衰期間が数値変換される", async () => {
+    const onChange = vi.fn();
+    await renderWithProviders(
+      <BulkMetadataFormFields values={baseValues} onChange={onChange} />,
+    );
+
+    const decaySelect = screen.getByLabelText("信頼度の減衰期間");
+    fireEvent.change(decaySelect, { target: { value: "90" } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ confidenceDecayDays: 90 }),
+    );
+  });
+});

--- a/src/hooks/useFadeInOnView.test.ts
+++ b/src/hooks/useFadeInOnView.test.ts
@@ -60,12 +60,15 @@ describe("useFadeInOnView", () => {
       return r;
     });
 
-    const last = list.at(-1);
-    if (last !== undefined) {
-      act(() => {
-        last.cb([{ isIntersecting: false }]);
+    // observer が確実に登録されていることを pre-condition として確認。
+    // ref に node がセットされた後の effect で IntersectionObserver が
+    // 1 つだけ生成されるはず。これが守られなければテストとして無意味。
+    expect(list).toHaveLength(1);
+    act(() => {
+      list.forEach((o) => {
+        o.cb([{ isIntersecting: false }]);
       });
-    }
+    });
     expect(result.current.className).toContain("opacity-0");
   });
 

--- a/src/hooks/useFadeInOnView.test.ts
+++ b/src/hooks/useFadeInOnView.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useFadeInOnView } from "@/hooks/useFadeInOnView";
+
+type ObserverCb = (entries: ReadonlyArray<{ isIntersecting: boolean }>) => void;
+
+type Observer = {
+  readonly cb: ObserverCb;
+  readonly observe: ReturnType<typeof vi.fn>;
+  readonly disconnect: ReturnType<typeof vi.fn>;
+};
+
+const observers: Observer[] = [];
+
+const installIntersectionObserver = (): readonly Observer[] => {
+  observers.splice(0, observers.length);
+
+  const FakeIO = function (this: unknown, cb: ObserverCb) {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    observers.push({ cb, observe, disconnect });
+    return {
+      observe,
+      disconnect,
+      unobserve: vi.fn(),
+      takeRecords: vi.fn(() => []),
+    };
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test global setup
+  (globalThis as any).IntersectionObserver = FakeIO;
+
+  return observers;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useFadeInOnView", () => {
+  it("初期 className は opacity-0", () => {
+    installIntersectionObserver();
+    const { result } = renderHook(() => useFadeInOnView());
+    expect(result.current.className).toContain("opacity-0");
+  });
+
+  it("ref が null のときは observe が起動しない", () => {
+    const list = installIntersectionObserver();
+    renderHook(() => useFadeInOnView());
+    expect(list.length).toBe(0);
+  });
+
+  it("isIntersecting=false の reading では opacity-0 のまま", () => {
+    const list = installIntersectionObserver();
+    const node = document.createElement("div");
+
+    const { result } = renderHook(() => {
+      const r = useFadeInOnView();
+      Object.assign(r.ref, { current: node });
+      return r;
+    });
+
+    const last = list.at(-1);
+    if (last !== undefined) {
+      act(() => {
+        last.cb([{ isIntersecting: false }]);
+      });
+    }
+    expect(result.current.className).toContain("opacity-0");
+  });
+
+  it("style.transition プロパティを含む style を返す", () => {
+    installIntersectionObserver();
+    const { result } = renderHook(() => useFadeInOnView());
+    expect(result.current.style.transition).toContain("opacity 600ms");
+  });
+});

--- a/src/hooks/useNfcReader.test.ts
+++ b/src/hooks/useNfcReader.test.ts
@@ -57,11 +57,12 @@ const createReadingEvent = ({
   encoding,
 }: {
   readonly recordType: string;
-  readonly data: string;
+  readonly data: string | undefined;
   readonly encoding?: string;
 }): NDEFReadingEvent => {
   const encoder = new TextEncoder();
-  const dataView = new DataView(encoder.encode(data).buffer);
+  const dataView =
+    data === undefined ? undefined : new DataView(encoder.encode(data).buffer);
 
   const baseEvent = new Event("reading");
   return Object.assign(baseEvent, {
@@ -372,24 +373,10 @@ describe("useNfcReader", () => {
 
     await flushMicrotasks();
 
-    // data: undefined の record
-    const baseEvent = new Event("reading");
-    const event = Object.assign(baseEvent, {
-      serialNumber: "test",
-      message: {
-        records: [
-          {
-            recordType: "url",
-            mediaType: "",
-            id: "",
-            encoding: "",
-            lang: "",
-            data: undefined,
-            toRecords: () => [],
-          },
-        ],
-      },
-    }) as unknown as NDEFReadingEvent;
+    const event = createReadingEvent({
+      recordType: "url",
+      data: undefined,
+    });
 
     act(() => {
       mockReaderRef.current.triggerReading(event);

--- a/src/hooks/useNfcReader.test.ts
+++ b/src/hooks/useNfcReader.test.ts
@@ -334,4 +334,79 @@ describe("useNfcReader", () => {
 
     expect(vibrateMock).toHaveBeenCalledWith(VIBRATION_DURATION_MS);
   });
+
+  it("readingerror で navigator.vibrate がエラーパターンで呼ばれる", async () => {
+    const onScan = vi.fn();
+    renderHook(() => useNfcReader({ onScan, isActive: true }));
+
+    await flushMicrotasks();
+
+    act(() => {
+      mockReaderRef.current.triggerReadingError(new Event("readingerror"));
+    });
+
+    expect(vibrateMock).toHaveBeenCalledWith([50, 100, 50]);
+  });
+
+  it("recordType=url で dwg:// 以外の URL は onScan を呼ばない", async () => {
+    const onScan = vi.fn();
+    renderHook(() => useNfcReader({ onScan, isActive: true }));
+
+    await flushMicrotasks();
+
+    const event = createReadingEvent({
+      recordType: "url",
+      data: "https://example.com/",
+    });
+
+    act(() => {
+      mockReaderRef.current.triggerReading(event);
+    });
+
+    expect(onScan).not.toHaveBeenCalled();
+  });
+
+  it("data 無しの NDEF record は無視される", async () => {
+    const onScan = vi.fn();
+    renderHook(() => useNfcReader({ onScan, isActive: true }));
+
+    await flushMicrotasks();
+
+    // data: undefined の record
+    const baseEvent = new Event("reading");
+    const event = Object.assign(baseEvent, {
+      serialNumber: "test",
+      message: {
+        records: [
+          {
+            recordType: "url",
+            mediaType: "",
+            id: "",
+            encoding: "",
+            lang: "",
+            data: undefined,
+            toRecords: () => [],
+          },
+        ],
+      },
+    }) as unknown as NDEFReadingEvent;
+
+    act(() => {
+      mockReaderRef.current.triggerReading(event);
+    });
+
+    expect(onScan).not.toHaveBeenCalled();
+  });
+
+  it("AbortError は無視され state は変わらない", async () => {
+    const onScan = vi.fn();
+    mockReaderRef.current.scanMock.mockRejectedValueOnce(
+      new DOMException("aborted", "AbortError"),
+    );
+    const { result } = renderHook(() =>
+      useNfcReader({ onScan, isActive: true }),
+    );
+    await flushMicrotasks();
+    expect(result.current.nfcState.status).toBe("idle");
+  });
 });

--- a/src/lib/auth.apiKey.test.ts
+++ b/src/lib/auth.apiKey.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.unmock("@/lib/auth");
+
+const mockClient = () => ({
+  getSession: vi.fn(),
+  listAccounts: vi.fn(),
+  signIn: { email: vi.fn(), social: vi.fn() },
+  signUp: { email: vi.fn() },
+  signOut: vi.fn(),
+  updateUser: vi.fn(),
+  changeEmail: vi.fn(),
+  changePassword: vi.fn(),
+  $fetch: vi.fn(),
+  apiKey: { create: vi.fn(), list: vi.fn(), delete: vi.fn() },
+});
+
+const clientHolder: { current: ReturnType<typeof mockClient> } = {
+  current: mockClient(),
+};
+
+vi.mock("better-auth/react", () => ({
+  createAuthClient: () => clientHolder.current,
+}));
+
+vi.mock("@better-auth/api-key/client", () => ({
+  apiKeyClient: () => ({}),
+}));
+
+vi.mock("@/lib/workersUrl", () => ({
+  WORKERS_URL_FOR_FETCH: "http://localhost:8787",
+}));
+
+describe("@/lib/auth API キー操作", () => {
+  beforeEach(() => {
+    clientHolder.current = mockClient();
+    vi.resetModules();
+  });
+
+  it("createApiKey 成功時に正規化されたオブジェクトを返す (read-write)", async () => {
+    const createdAt = new Date("2026-01-01T00:00:00Z");
+    clientHolder.current.apiKey.create.mockResolvedValue({
+      data: {
+        id: "k-1",
+        name: "agent",
+        enabled: true,
+        createdAt,
+        key: "raw_key",
+      },
+      error: null,
+    });
+    const { createApiKey, API_KEY_SCOPE } = await import("@/lib/auth");
+    const result = await createApiKey({
+      name: "agent",
+      scope: API_KEY_SCOPE.READ_WRITE,
+    });
+    expect(result.key).toBe("raw_key");
+    expect(result.scope).toBe(API_KEY_SCOPE.READ_WRITE);
+    expect(result.createdAt).toBe(createdAt.getTime());
+    expect(result.lastRequestAt).toBeUndefined();
+  });
+
+  it("createApiKey: name 欠落時は input.name を fallback", async () => {
+    clientHolder.current.apiKey.create.mockResolvedValue({
+      data: { id: "k-1", name: null, enabled: true, createdAt: 0, key: "raw" },
+      error: null,
+    });
+    const { createApiKey, API_KEY_SCOPE } = await import("@/lib/auth");
+    const result = await createApiKey({
+      name: "fallback",
+      scope: API_KEY_SCOPE.READ_ONLY,
+    });
+    expect(result.name).toBe("fallback");
+  });
+
+  it("createApiKey: error 時 throw", async () => {
+    clientHolder.current.apiKey.create.mockResolvedValue({
+      data: null,
+      error: { message: "no" },
+    });
+    const { createApiKey, API_KEY_SCOPE } = await import("@/lib/auth");
+    await expect(
+      createApiKey({ name: "n", scope: API_KEY_SCOPE.READ_ONLY }),
+    ).rejects.toThrow("no");
+  });
+
+  it("createApiKey: error.message 無しは既定 throw", async () => {
+    clientHolder.current.apiKey.create.mockResolvedValue({
+      data: null,
+      error: {},
+    });
+    const { createApiKey, API_KEY_SCOPE } = await import("@/lib/auth");
+    await expect(
+      createApiKey({ name: "n", scope: API_KEY_SCOPE.READ_ONLY }),
+    ).rejects.toThrow("Failed to create API key");
+  });
+
+  it("listApiKeys: permissions の write を含む場合は read-write", async () => {
+    clientHolder.current.apiKey.list.mockResolvedValue({
+      data: {
+        apiKeys: [
+          {
+            id: "k-1",
+            name: "agent",
+            permissions: { all: ["read", "write"] },
+            createdAt: 1000,
+            lastRequest: 2000,
+            enabled: true,
+          },
+        ],
+      },
+      error: null,
+    });
+    const { listApiKeys, API_KEY_SCOPE } = await import("@/lib/auth");
+    const res = await listApiKeys();
+    expect(res[0]?.scope).toBe(API_KEY_SCOPE.READ_WRITE);
+    expect(res[0]?.lastRequestAt).toBe(2000);
+  });
+
+  it("listApiKeys: name 無いと空文字、permissions 無いと read-only", async () => {
+    clientHolder.current.apiKey.list.mockResolvedValue({
+      data: {
+        apiKeys: [
+          {
+            id: "k-1",
+            name: null,
+            permissions: null,
+            createdAt: 1000,
+            lastRequest: null,
+            enabled: true,
+          },
+        ],
+      },
+      error: null,
+    });
+    const { listApiKeys, API_KEY_SCOPE } = await import("@/lib/auth");
+    const res = await listApiKeys();
+    expect(res[0]?.name).toBe("");
+    expect(res[0]?.scope).toBe(API_KEY_SCOPE.READ_ONLY);
+    expect(res[0]?.lastRequestAt).toBeUndefined();
+  });
+
+  it("listApiKeys: permissions が無効な形式の場合も read-only にフォールバック", async () => {
+    clientHolder.current.apiKey.list.mockResolvedValue({
+      data: {
+        apiKeys: [
+          {
+            id: "k-1",
+            name: "x",
+            permissions: 42,
+            createdAt: 1000,
+            lastRequest: undefined,
+            enabled: true,
+          },
+        ],
+      },
+      error: null,
+    });
+    const { listApiKeys, API_KEY_SCOPE } = await import("@/lib/auth");
+    const res = await listApiKeys();
+    expect(res[0]?.scope).toBe(API_KEY_SCOPE.READ_ONLY);
+  });
+
+  it("listApiKeys: createdAt が ISO 文字列でも数値に変換される", async () => {
+    const iso = "2026-03-10T12:00:00Z";
+    const expected = new Date(iso).getTime();
+    clientHolder.current.apiKey.list.mockResolvedValue({
+      data: {
+        apiKeys: [
+          {
+            id: "k-1",
+            name: "x",
+            permissions: { all: ["read"] },
+            createdAt: iso,
+            lastRequest: undefined,
+            enabled: true,
+          },
+        ],
+      },
+      error: null,
+    });
+    const { listApiKeys } = await import("@/lib/auth");
+    const res = await listApiKeys();
+    expect(res[0]?.createdAt).toBe(expected);
+  });
+
+  it("listApiKeys: error 時 throw", async () => {
+    clientHolder.current.apiKey.list.mockResolvedValue({
+      data: null,
+      error: { message: "boom" },
+    });
+    const { listApiKeys } = await import("@/lib/auth");
+    await expect(listApiKeys()).rejects.toThrow("boom");
+  });
+
+  it("listApiKeys: error.message 無しは既定 throw", async () => {
+    clientHolder.current.apiKey.list.mockResolvedValue({
+      data: null,
+      error: {},
+    });
+    const { listApiKeys } = await import("@/lib/auth");
+    await expect(listApiKeys()).rejects.toThrow("Failed to list API keys");
+  });
+
+  it("revokeApiKey: 成功", async () => {
+    clientHolder.current.apiKey.delete.mockResolvedValue({ error: null });
+    const { revokeApiKey } = await import("@/lib/auth");
+    await expect(revokeApiKey("k-1")).resolves.toBeUndefined();
+  });
+
+  it("revokeApiKey: error", async () => {
+    clientHolder.current.apiKey.delete.mockResolvedValue({
+      error: { message: "no" },
+    });
+    const { revokeApiKey } = await import("@/lib/auth");
+    await expect(revokeApiKey("k-1")).rejects.toThrow("no");
+  });
+
+  it("revokeApiKey: 既定 error", async () => {
+    clientHolder.current.apiKey.delete.mockResolvedValue({ error: {} });
+    const { revokeApiKey } = await import("@/lib/auth");
+    await expect(revokeApiKey("k-1")).rejects.toThrow(
+      "Failed to revoke API key",
+    );
+  });
+});

--- a/src/lib/auth.apiKey.test.ts
+++ b/src/lib/auth.apiKey.test.ts
@@ -2,25 +2,26 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.unmock("@/lib/auth");
 
-const mockClient = () => ({
-  getSession: vi.fn(),
-  listAccounts: vi.fn(),
-  signIn: { email: vi.fn(), social: vi.fn() },
-  signUp: { email: vi.fn() },
-  signOut: vi.fn(),
-  updateUser: vi.fn(),
-  changeEmail: vi.fn(),
-  changePassword: vi.fn(),
-  $fetch: vi.fn(),
-  apiKey: { create: vi.fn(), list: vi.fn(), delete: vi.fn() },
-});
-
-const clientHolder: { current: ReturnType<typeof mockClient> } = {
-  current: mockClient(),
-};
+// vi.mock factory は hoist されるため client も vi.hoisted で巻き上げる。
+// client 参照は immutable のまま、各テストで vi.fn の mockResolvedValue を
+// 上書きして使う (vi.resetAllMocks で履歴と return 値をリセット)。
+const { client } = vi.hoisted(() => ({
+  client: {
+    getSession: vi.fn(),
+    listAccounts: vi.fn(),
+    signIn: { email: vi.fn(), social: vi.fn() },
+    signUp: { email: vi.fn() },
+    signOut: vi.fn(),
+    updateUser: vi.fn(),
+    changeEmail: vi.fn(),
+    changePassword: vi.fn(),
+    $fetch: vi.fn(),
+    apiKey: { create: vi.fn(), list: vi.fn(), delete: vi.fn() },
+  },
+}));
 
 vi.mock("better-auth/react", () => ({
-  createAuthClient: () => clientHolder.current,
+  createAuthClient: () => client,
 }));
 
 vi.mock("@better-auth/api-key/client", () => ({
@@ -33,13 +34,13 @@ vi.mock("@/lib/workersUrl", () => ({
 
 describe("@/lib/auth API キー操作", () => {
   beforeEach(() => {
-    clientHolder.current = mockClient();
+    vi.resetAllMocks();
     vi.resetModules();
   });
 
   it("createApiKey 成功時に正規化されたオブジェクトを返す (read-write)", async () => {
     const createdAt = new Date("2026-01-01T00:00:00Z");
-    clientHolder.current.apiKey.create.mockResolvedValue({
+    client.apiKey.create.mockResolvedValue({
       data: {
         id: "k-1",
         name: "agent",
@@ -61,7 +62,7 @@ describe("@/lib/auth API キー操作", () => {
   });
 
   it("createApiKey: name 欠落時は input.name を fallback", async () => {
-    clientHolder.current.apiKey.create.mockResolvedValue({
+    client.apiKey.create.mockResolvedValue({
       data: { id: "k-1", name: null, enabled: true, createdAt: 0, key: "raw" },
       error: null,
     });
@@ -74,7 +75,7 @@ describe("@/lib/auth API キー操作", () => {
   });
 
   it("createApiKey: error 時 throw", async () => {
-    clientHolder.current.apiKey.create.mockResolvedValue({
+    client.apiKey.create.mockResolvedValue({
       data: null,
       error: { message: "no" },
     });
@@ -85,7 +86,7 @@ describe("@/lib/auth API キー操作", () => {
   });
 
   it("createApiKey: error.message 無しは既定 throw", async () => {
-    clientHolder.current.apiKey.create.mockResolvedValue({
+    client.apiKey.create.mockResolvedValue({
       data: null,
       error: {},
     });
@@ -96,7 +97,7 @@ describe("@/lib/auth API キー操作", () => {
   });
 
   it("listApiKeys: permissions の write を含む場合は read-write", async () => {
-    clientHolder.current.apiKey.list.mockResolvedValue({
+    client.apiKey.list.mockResolvedValue({
       data: {
         apiKeys: [
           {
@@ -118,7 +119,7 @@ describe("@/lib/auth API キー操作", () => {
   });
 
   it("listApiKeys: name 無いと空文字、permissions 無いと read-only", async () => {
-    clientHolder.current.apiKey.list.mockResolvedValue({
+    client.apiKey.list.mockResolvedValue({
       data: {
         apiKeys: [
           {
@@ -141,7 +142,7 @@ describe("@/lib/auth API キー操作", () => {
   });
 
   it("listApiKeys: permissions が無効な形式の場合も read-only にフォールバック", async () => {
-    clientHolder.current.apiKey.list.mockResolvedValue({
+    client.apiKey.list.mockResolvedValue({
       data: {
         apiKeys: [
           {
@@ -164,7 +165,7 @@ describe("@/lib/auth API キー操作", () => {
   it("listApiKeys: createdAt が ISO 文字列でも数値に変換される", async () => {
     const iso = "2026-03-10T12:00:00Z";
     const expected = new Date(iso).getTime();
-    clientHolder.current.apiKey.list.mockResolvedValue({
+    client.apiKey.list.mockResolvedValue({
       data: {
         apiKeys: [
           {
@@ -185,7 +186,7 @@ describe("@/lib/auth API キー操作", () => {
   });
 
   it("listApiKeys: error 時 throw", async () => {
-    clientHolder.current.apiKey.list.mockResolvedValue({
+    client.apiKey.list.mockResolvedValue({
       data: null,
       error: { message: "boom" },
     });
@@ -194,7 +195,7 @@ describe("@/lib/auth API キー操作", () => {
   });
 
   it("listApiKeys: error.message 無しは既定 throw", async () => {
-    clientHolder.current.apiKey.list.mockResolvedValue({
+    client.apiKey.list.mockResolvedValue({
       data: null,
       error: {},
     });
@@ -203,13 +204,13 @@ describe("@/lib/auth API キー操作", () => {
   });
 
   it("revokeApiKey: 成功", async () => {
-    clientHolder.current.apiKey.delete.mockResolvedValue({ error: null });
+    client.apiKey.delete.mockResolvedValue({ error: null });
     const { revokeApiKey } = await import("@/lib/auth");
     await expect(revokeApiKey("k-1")).resolves.toBeUndefined();
   });
 
   it("revokeApiKey: error", async () => {
-    clientHolder.current.apiKey.delete.mockResolvedValue({
+    client.apiKey.delete.mockResolvedValue({
       error: { message: "no" },
     });
     const { revokeApiKey } = await import("@/lib/auth");
@@ -217,7 +218,7 @@ describe("@/lib/auth API キー操作", () => {
   });
 
   it("revokeApiKey: 既定 error", async () => {
-    clientHolder.current.apiKey.delete.mockResolvedValue({ error: {} });
+    client.apiKey.delete.mockResolvedValue({ error: {} });
     const { revokeApiKey } = await import("@/lib/auth");
     await expect(revokeApiKey("k-1")).rejects.toThrow(
       "Failed to revoke API key",

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,410 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// setup.ts で集約モックされている `@/lib/auth` を本物に置き換え、
+// 内部で使う better-auth クライアントだけスタブ化してテストする。
+vi.unmock("@/lib/auth");
+
+const mockClient = () => ({
+  getSession: vi.fn(),
+  listAccounts: vi.fn(),
+  signIn: { email: vi.fn(), social: vi.fn() },
+  signUp: { email: vi.fn() },
+  signOut: vi.fn(),
+  updateUser: vi.fn(),
+  changeEmail: vi.fn(),
+  changePassword: vi.fn(),
+  $fetch: vi.fn(),
+  apiKey: { create: vi.fn(), list: vi.fn(), delete: vi.fn() },
+});
+
+const clientHolder: { current: ReturnType<typeof mockClient> } = {
+  current: mockClient(),
+};
+
+vi.mock("better-auth/react", () => ({
+  createAuthClient: () => clientHolder.current,
+}));
+
+vi.mock("@better-auth/api-key/client", () => ({
+  apiKeyClient: () => ({}),
+}));
+
+vi.mock("@/lib/workersUrl", () => ({
+  WORKERS_URL_FOR_FETCH: "http://localhost:8787",
+}));
+
+describe("@/lib/auth (本物)", () => {
+  beforeEach(() => {
+    clientHolder.current = mockClient();
+    vi.resetModules();
+  });
+
+  describe("getSession", () => {
+    it("成功時に rawData をマッピングして返す", async () => {
+      const updatedAt = new Date();
+      clientHolder.current.getSession.mockResolvedValue({
+        data: {
+          user: {
+            id: "u-1",
+            name: "n",
+            email: "e@example.com",
+            emailVerified: true,
+            image: null,
+            createdAt: new Date(),
+            updatedAt,
+          },
+        },
+        error: null,
+      });
+
+      const { getSession } = await import("@/lib/auth");
+      const res = await getSession();
+      expect(res.data).toBeDefined();
+      expect(res.data?.user.image).toBeUndefined();
+    });
+
+    it("rawData が null のときは data: undefined を返す", async () => {
+      clientHolder.current.getSession.mockResolvedValue({
+        data: null,
+        error: null,
+      });
+
+      const { getSession } = await import("@/lib/auth");
+      const res = await getSession();
+      expect(res.data).toBeUndefined();
+    });
+
+    it("image がある場合はそのまま透過する", async () => {
+      clientHolder.current.getSession.mockResolvedValue({
+        data: {
+          user: {
+            id: "u-1",
+            name: "n",
+            email: "e@example.com",
+            emailVerified: false,
+            image: "https://example.com/me.png",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        },
+        error: null,
+      });
+
+      const { getSession } = await import("@/lib/auth");
+      const res = await getSession();
+      expect(res.data?.user.image).toBe("https://example.com/me.png");
+    });
+
+    it("error 時は throw する", async () => {
+      clientHolder.current.getSession.mockResolvedValue({
+        data: null,
+        error: { message: "boom" },
+      });
+
+      const { getSession } = await import("@/lib/auth");
+      await expect(getSession()).rejects.toThrow("boom");
+    });
+
+    it("error.message が未定義のときは既定メッセージで throw する", async () => {
+      clientHolder.current.getSession.mockResolvedValue({
+        data: null,
+        error: {},
+      });
+      const { getSession } = await import("@/lib/auth");
+      await expect(getSession()).rejects.toThrow(
+        "セッション取得に失敗しました",
+      );
+    });
+  });
+
+  describe("listAccounts", () => {
+    it("成功時に providerId 配列を返す", async () => {
+      clientHolder.current.listAccounts.mockResolvedValue({
+        data: [{ providerId: "credential" }, { providerId: "google" }],
+        error: null,
+      });
+      const { listAccounts } = await import("@/lib/auth");
+      const res = await listAccounts();
+      expect(res).toEqual([
+        { providerId: "credential" },
+        { providerId: "google" },
+      ]);
+    });
+
+    it("error 時は throw する", async () => {
+      clientHolder.current.listAccounts.mockResolvedValue({
+        data: null,
+        error: { message: "denied" },
+      });
+      const { listAccounts } = await import("@/lib/auth");
+      await expect(listAccounts()).rejects.toThrow("denied");
+    });
+
+    it("error.message が無いときは既定メッセージで throw", async () => {
+      clientHolder.current.listAccounts.mockResolvedValue({
+        data: null,
+        error: {},
+      });
+      const { listAccounts } = await import("@/lib/auth");
+      await expect(listAccounts()).rejects.toThrow(
+        "アカウント一覧の取得に失敗しました",
+      );
+    });
+  });
+
+  describe("signInWithEmail", () => {
+    it("成功時に void を返す", async () => {
+      clientHolder.current.signIn.email.mockResolvedValue({ error: null });
+      const { signInWithEmail } = await import("@/lib/auth");
+      await expect(
+        signInWithEmail({ email: "e@example.com", password: "pw12345678" }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("error 時は throw する", async () => {
+      clientHolder.current.signIn.email.mockResolvedValue({
+        error: { message: "bad" },
+      });
+      const { signInWithEmail } = await import("@/lib/auth");
+      await expect(
+        signInWithEmail({ email: "e@example.com", password: "pw12345678" }),
+      ).rejects.toThrow("bad");
+    });
+
+    it("error.message 無しは既定メッセージで throw", async () => {
+      clientHolder.current.signIn.email.mockResolvedValue({ error: {} });
+      const { signInWithEmail } = await import("@/lib/auth");
+      await expect(
+        signInWithEmail({ email: "e@example.com", password: "pw12345678" }),
+      ).rejects.toThrow("ログインに失敗しました");
+    });
+  });
+
+  describe("signUpWithEmail", () => {
+    it("成功", async () => {
+      clientHolder.current.signUp.email.mockResolvedValue({ error: null });
+      const { signUpWithEmail } = await import("@/lib/auth");
+      await expect(
+        signUpWithEmail({
+          name: "n",
+          email: "e@example.com",
+          password: "pw12345678",
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("error 時 throw", async () => {
+      clientHolder.current.signUp.email.mockResolvedValue({
+        error: { message: "exists" },
+      });
+      const { signUpWithEmail } = await import("@/lib/auth");
+      await expect(
+        signUpWithEmail({
+          name: "n",
+          email: "e@example.com",
+          password: "pw12345678",
+        }),
+      ).rejects.toThrow("exists");
+    });
+
+    it("error.message なしは既定メッセージで throw", async () => {
+      clientHolder.current.signUp.email.mockResolvedValue({ error: {} });
+      const { signUpWithEmail } = await import("@/lib/auth");
+      await expect(
+        signUpWithEmail({
+          name: "n",
+          email: "e@example.com",
+          password: "pw12345678",
+        }),
+      ).rejects.toThrow("サインアップに失敗しました");
+    });
+  });
+
+  describe("updateProfile", () => {
+    it("成功", async () => {
+      clientHolder.current.updateUser.mockResolvedValue({ error: null });
+      const { updateProfile } = await import("@/lib/auth");
+      await expect(
+        updateProfile({ name: "n", image: undefined }),
+      ).resolves.toBeUndefined();
+    });
+    it("error", async () => {
+      clientHolder.current.updateUser.mockResolvedValue({
+        error: { message: "no" },
+      });
+      const { updateProfile } = await import("@/lib/auth");
+      await expect(
+        updateProfile({ name: "n", image: undefined }),
+      ).rejects.toThrow("no");
+    });
+    it("既定 error", async () => {
+      clientHolder.current.updateUser.mockResolvedValue({ error: {} });
+      const { updateProfile } = await import("@/lib/auth");
+      await expect(
+        updateProfile({ name: "n", image: undefined }),
+      ).rejects.toThrow("プロフィール更新に失敗しました");
+    });
+  });
+
+  describe("changeEmail", () => {
+    it("成功", async () => {
+      clientHolder.current.changeEmail.mockResolvedValue({ error: null });
+      const { changeEmail } = await import("@/lib/auth");
+      await expect(
+        changeEmail({ newEmail: "new@example.com" }),
+      ).resolves.toBeUndefined();
+    });
+    it("error", async () => {
+      clientHolder.current.changeEmail.mockResolvedValue({
+        error: { message: "taken" },
+      });
+      const { changeEmail } = await import("@/lib/auth");
+      await expect(
+        changeEmail({ newEmail: "new@example.com" }),
+      ).rejects.toThrow("taken");
+    });
+    it("既定 error", async () => {
+      clientHolder.current.changeEmail.mockResolvedValue({ error: {} });
+      const { changeEmail } = await import("@/lib/auth");
+      await expect(
+        changeEmail({ newEmail: "new@example.com" }),
+      ).rejects.toThrow("メールアドレス変更に失敗しました");
+    });
+  });
+
+  describe("changePassword", () => {
+    it("成功", async () => {
+      clientHolder.current.changePassword.mockResolvedValue({ error: null });
+      const { changePassword } = await import("@/lib/auth");
+      await expect(
+        changePassword({
+          currentPassword: "old1",
+          newPassword: "newpass12",
+          newPasswordConfirm: "newpass12",
+        }),
+      ).resolves.toBeUndefined();
+    });
+    it("currentPassword 省略時は空文字に丸める", async () => {
+      clientHolder.current.changePassword.mockResolvedValue({ error: null });
+      const { changePassword } = await import("@/lib/auth");
+      await changePassword({
+        currentPassword: undefined,
+        newPassword: "newpass12",
+        newPasswordConfirm: "newpass12",
+      });
+      expect(clientHolder.current.changePassword).toHaveBeenCalledWith({
+        currentPassword: "",
+        newPassword: "newpass12",
+        revokeOtherSessions: true,
+      });
+    });
+    it("error", async () => {
+      clientHolder.current.changePassword.mockResolvedValue({
+        error: { message: "wrong" },
+      });
+      const { changePassword } = await import("@/lib/auth");
+      await expect(
+        changePassword({
+          currentPassword: "old1",
+          newPassword: "newpass12",
+          newPasswordConfirm: "newpass12",
+        }),
+      ).rejects.toThrow("wrong");
+    });
+    it("既定 error", async () => {
+      clientHolder.current.changePassword.mockResolvedValue({ error: {} });
+      const { changePassword } = await import("@/lib/auth");
+      await expect(
+        changePassword({
+          currentPassword: "old1",
+          newPassword: "newpass12",
+          newPasswordConfirm: "newpass12",
+        }),
+      ).rejects.toThrow("パスワード変更に失敗しました");
+    });
+  });
+
+  describe("setPassword", () => {
+    it("成功", async () => {
+      clientHolder.current.$fetch.mockResolvedValue({ error: null });
+      const { setPassword } = await import("@/lib/auth");
+      await expect(
+        setPassword({
+          newPassword: "newpass12",
+          newPasswordConfirm: "newpass12",
+        }),
+      ).resolves.toBeUndefined();
+      expect(clientHolder.current.$fetch).toHaveBeenCalledWith(
+        "/set-password",
+        expect.objectContaining({
+          method: "POST",
+          body: { newPassword: "newpass12" },
+        }),
+      );
+    });
+    it("error", async () => {
+      clientHolder.current.$fetch.mockResolvedValue({
+        error: { message: "exists" },
+      });
+      const { setPassword } = await import("@/lib/auth");
+      await expect(
+        setPassword({
+          newPassword: "newpass12",
+          newPasswordConfirm: "newpass12",
+        }),
+      ).rejects.toThrow("exists");
+    });
+    it("既定 error", async () => {
+      clientHolder.current.$fetch.mockResolvedValue({ error: {} });
+      const { setPassword } = await import("@/lib/auth");
+      await expect(
+        setPassword({
+          newPassword: "newpass12",
+          newPasswordConfirm: "newpass12",
+        }),
+      ).rejects.toThrow("パスワード設定に失敗しました");
+    });
+  });
+
+  describe("deleteAccount", () => {
+    it("password 無しは confirmEmail のみ送る", async () => {
+      clientHolder.current.$fetch.mockResolvedValue({ error: null });
+      const { deleteAccount } = await import("@/lib/auth");
+      await deleteAccount({ confirmEmail: "e@example.com" });
+      expect(clientHolder.current.$fetch).toHaveBeenCalledWith(
+        "/delete-user",
+        expect.objectContaining({
+          method: "POST",
+          body: { confirmEmail: "e@example.com" },
+        }),
+      );
+    });
+    it("password ありは password を一緒に送る", async () => {
+      clientHolder.current.$fetch.mockResolvedValue({ error: null });
+      const { deleteAccount } = await import("@/lib/auth");
+      await deleteAccount({ confirmEmail: "e@example.com", password: "p" });
+      expect(clientHolder.current.$fetch).toHaveBeenCalledWith(
+        "/delete-user",
+        expect.objectContaining({
+          body: { confirmEmail: "e@example.com", password: "p" },
+        }),
+      );
+    });
+    it("error", async () => {
+      clientHolder.current.$fetch.mockResolvedValue({
+        error: { message: "no" },
+      });
+      const { deleteAccount } = await import("@/lib/auth");
+      await expect(
+        deleteAccount({ confirmEmail: "e@example.com" }),
+      ).rejects.toThrow("no");
+    });
+    it("既定 error", async () => {
+      clientHolder.current.$fetch.mockResolvedValue({ error: {} });
+      const { deleteAccount } = await import("@/lib/auth");
+      await expect(
+        deleteAccount({ confirmEmail: "e@example.com" }),
+      ).rejects.toThrow("アカウント削除に失敗しました");
+    });
+  });
+});

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -4,25 +4,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // 内部で使う better-auth クライアントだけスタブ化してテストする。
 vi.unmock("@/lib/auth");
 
-const mockClient = () => ({
-  getSession: vi.fn(),
-  listAccounts: vi.fn(),
-  signIn: { email: vi.fn(), social: vi.fn() },
-  signUp: { email: vi.fn() },
-  signOut: vi.fn(),
-  updateUser: vi.fn(),
-  changeEmail: vi.fn(),
-  changePassword: vi.fn(),
-  $fetch: vi.fn(),
-  apiKey: { create: vi.fn(), list: vi.fn(), delete: vi.fn() },
-});
-
-const clientHolder: { current: ReturnType<typeof mockClient> } = {
-  current: mockClient(),
-};
+// vi.mock factory は静的に hoist されるため、参照する client も
+// vi.hoisted で同じ位置に巻き上げる必要がある。
+// client は immutable な参照で固定し、各テストでは vi.fn の
+// mockResolvedValue 上書きと vi.resetAllMocks による履歴/return 値の
+// リセットで状態を制御する。
+const { client } = vi.hoisted(() => ({
+  client: {
+    getSession: vi.fn(),
+    listAccounts: vi.fn(),
+    signIn: { email: vi.fn(), social: vi.fn() },
+    signUp: { email: vi.fn() },
+    signOut: vi.fn(),
+    updateUser: vi.fn(),
+    changeEmail: vi.fn(),
+    changePassword: vi.fn(),
+    $fetch: vi.fn(),
+    apiKey: { create: vi.fn(), list: vi.fn(), delete: vi.fn() },
+  },
+}));
 
 vi.mock("better-auth/react", () => ({
-  createAuthClient: () => clientHolder.current,
+  createAuthClient: () => client,
 }));
 
 vi.mock("@better-auth/api-key/client", () => ({
@@ -35,14 +38,14 @@ vi.mock("@/lib/workersUrl", () => ({
 
 describe("@/lib/auth (本物)", () => {
   beforeEach(() => {
-    clientHolder.current = mockClient();
+    vi.resetAllMocks();
     vi.resetModules();
   });
 
   describe("getSession", () => {
     it("成功時に rawData をマッピングして返す", async () => {
       const updatedAt = new Date();
-      clientHolder.current.getSession.mockResolvedValue({
+      client.getSession.mockResolvedValue({
         data: {
           user: {
             id: "u-1",
@@ -64,7 +67,7 @@ describe("@/lib/auth (本物)", () => {
     });
 
     it("rawData が null のときは data: undefined を返す", async () => {
-      clientHolder.current.getSession.mockResolvedValue({
+      client.getSession.mockResolvedValue({
         data: null,
         error: null,
       });
@@ -75,7 +78,7 @@ describe("@/lib/auth (本物)", () => {
     });
 
     it("image がある場合はそのまま透過する", async () => {
-      clientHolder.current.getSession.mockResolvedValue({
+      client.getSession.mockResolvedValue({
         data: {
           user: {
             id: "u-1",
@@ -96,7 +99,7 @@ describe("@/lib/auth (本物)", () => {
     });
 
     it("error 時は throw する", async () => {
-      clientHolder.current.getSession.mockResolvedValue({
+      client.getSession.mockResolvedValue({
         data: null,
         error: { message: "boom" },
       });
@@ -106,7 +109,7 @@ describe("@/lib/auth (本物)", () => {
     });
 
     it("error.message が未定義のときは既定メッセージで throw する", async () => {
-      clientHolder.current.getSession.mockResolvedValue({
+      client.getSession.mockResolvedValue({
         data: null,
         error: {},
       });
@@ -119,7 +122,7 @@ describe("@/lib/auth (本物)", () => {
 
   describe("listAccounts", () => {
     it("成功時に providerId 配列を返す", async () => {
-      clientHolder.current.listAccounts.mockResolvedValue({
+      client.listAccounts.mockResolvedValue({
         data: [{ providerId: "credential" }, { providerId: "google" }],
         error: null,
       });
@@ -132,7 +135,7 @@ describe("@/lib/auth (本物)", () => {
     });
 
     it("error 時は throw する", async () => {
-      clientHolder.current.listAccounts.mockResolvedValue({
+      client.listAccounts.mockResolvedValue({
         data: null,
         error: { message: "denied" },
       });
@@ -141,7 +144,7 @@ describe("@/lib/auth (本物)", () => {
     });
 
     it("error.message が無いときは既定メッセージで throw", async () => {
-      clientHolder.current.listAccounts.mockResolvedValue({
+      client.listAccounts.mockResolvedValue({
         data: null,
         error: {},
       });
@@ -154,7 +157,7 @@ describe("@/lib/auth (本物)", () => {
 
   describe("signInWithEmail", () => {
     it("成功時に void を返す", async () => {
-      clientHolder.current.signIn.email.mockResolvedValue({ error: null });
+      client.signIn.email.mockResolvedValue({ error: null });
       const { signInWithEmail } = await import("@/lib/auth");
       await expect(
         signInWithEmail({ email: "e@example.com", password: "pw12345678" }),
@@ -162,7 +165,7 @@ describe("@/lib/auth (本物)", () => {
     });
 
     it("error 時は throw する", async () => {
-      clientHolder.current.signIn.email.mockResolvedValue({
+      client.signIn.email.mockResolvedValue({
         error: { message: "bad" },
       });
       const { signInWithEmail } = await import("@/lib/auth");
@@ -172,7 +175,7 @@ describe("@/lib/auth (本物)", () => {
     });
 
     it("error.message 無しは既定メッセージで throw", async () => {
-      clientHolder.current.signIn.email.mockResolvedValue({ error: {} });
+      client.signIn.email.mockResolvedValue({ error: {} });
       const { signInWithEmail } = await import("@/lib/auth");
       await expect(
         signInWithEmail({ email: "e@example.com", password: "pw12345678" }),
@@ -182,7 +185,7 @@ describe("@/lib/auth (本物)", () => {
 
   describe("signUpWithEmail", () => {
     it("成功", async () => {
-      clientHolder.current.signUp.email.mockResolvedValue({ error: null });
+      client.signUp.email.mockResolvedValue({ error: null });
       const { signUpWithEmail } = await import("@/lib/auth");
       await expect(
         signUpWithEmail({
@@ -194,7 +197,7 @@ describe("@/lib/auth (本物)", () => {
     });
 
     it("error 時 throw", async () => {
-      clientHolder.current.signUp.email.mockResolvedValue({
+      client.signUp.email.mockResolvedValue({
         error: { message: "exists" },
       });
       const { signUpWithEmail } = await import("@/lib/auth");
@@ -208,7 +211,7 @@ describe("@/lib/auth (本物)", () => {
     });
 
     it("error.message なしは既定メッセージで throw", async () => {
-      clientHolder.current.signUp.email.mockResolvedValue({ error: {} });
+      client.signUp.email.mockResolvedValue({ error: {} });
       const { signUpWithEmail } = await import("@/lib/auth");
       await expect(
         signUpWithEmail({
@@ -222,14 +225,14 @@ describe("@/lib/auth (本物)", () => {
 
   describe("updateProfile", () => {
     it("成功", async () => {
-      clientHolder.current.updateUser.mockResolvedValue({ error: null });
+      client.updateUser.mockResolvedValue({ error: null });
       const { updateProfile } = await import("@/lib/auth");
       await expect(
         updateProfile({ name: "n", image: undefined }),
       ).resolves.toBeUndefined();
     });
     it("error", async () => {
-      clientHolder.current.updateUser.mockResolvedValue({
+      client.updateUser.mockResolvedValue({
         error: { message: "no" },
       });
       const { updateProfile } = await import("@/lib/auth");
@@ -238,7 +241,7 @@ describe("@/lib/auth (本物)", () => {
       ).rejects.toThrow("no");
     });
     it("既定 error", async () => {
-      clientHolder.current.updateUser.mockResolvedValue({ error: {} });
+      client.updateUser.mockResolvedValue({ error: {} });
       const { updateProfile } = await import("@/lib/auth");
       await expect(
         updateProfile({ name: "n", image: undefined }),
@@ -248,14 +251,14 @@ describe("@/lib/auth (本物)", () => {
 
   describe("changeEmail", () => {
     it("成功", async () => {
-      clientHolder.current.changeEmail.mockResolvedValue({ error: null });
+      client.changeEmail.mockResolvedValue({ error: null });
       const { changeEmail } = await import("@/lib/auth");
       await expect(
         changeEmail({ newEmail: "new@example.com" }),
       ).resolves.toBeUndefined();
     });
     it("error", async () => {
-      clientHolder.current.changeEmail.mockResolvedValue({
+      client.changeEmail.mockResolvedValue({
         error: { message: "taken" },
       });
       const { changeEmail } = await import("@/lib/auth");
@@ -264,7 +267,7 @@ describe("@/lib/auth (本物)", () => {
       ).rejects.toThrow("taken");
     });
     it("既定 error", async () => {
-      clientHolder.current.changeEmail.mockResolvedValue({ error: {} });
+      client.changeEmail.mockResolvedValue({ error: {} });
       const { changeEmail } = await import("@/lib/auth");
       await expect(
         changeEmail({ newEmail: "new@example.com" }),
@@ -274,7 +277,7 @@ describe("@/lib/auth (本物)", () => {
 
   describe("changePassword", () => {
     it("成功", async () => {
-      clientHolder.current.changePassword.mockResolvedValue({ error: null });
+      client.changePassword.mockResolvedValue({ error: null });
       const { changePassword } = await import("@/lib/auth");
       await expect(
         changePassword({
@@ -285,21 +288,21 @@ describe("@/lib/auth (本物)", () => {
       ).resolves.toBeUndefined();
     });
     it("currentPassword 省略時は空文字に丸める", async () => {
-      clientHolder.current.changePassword.mockResolvedValue({ error: null });
+      client.changePassword.mockResolvedValue({ error: null });
       const { changePassword } = await import("@/lib/auth");
       await changePassword({
         currentPassword: undefined,
         newPassword: "newpass12",
         newPasswordConfirm: "newpass12",
       });
-      expect(clientHolder.current.changePassword).toHaveBeenCalledWith({
+      expect(client.changePassword).toHaveBeenCalledWith({
         currentPassword: "",
         newPassword: "newpass12",
         revokeOtherSessions: true,
       });
     });
     it("error", async () => {
-      clientHolder.current.changePassword.mockResolvedValue({
+      client.changePassword.mockResolvedValue({
         error: { message: "wrong" },
       });
       const { changePassword } = await import("@/lib/auth");
@@ -312,7 +315,7 @@ describe("@/lib/auth (本物)", () => {
       ).rejects.toThrow("wrong");
     });
     it("既定 error", async () => {
-      clientHolder.current.changePassword.mockResolvedValue({ error: {} });
+      client.changePassword.mockResolvedValue({ error: {} });
       const { changePassword } = await import("@/lib/auth");
       await expect(
         changePassword({
@@ -326,7 +329,7 @@ describe("@/lib/auth (本物)", () => {
 
   describe("setPassword", () => {
     it("成功", async () => {
-      clientHolder.current.$fetch.mockResolvedValue({ error: null });
+      client.$fetch.mockResolvedValue({ error: null });
       const { setPassword } = await import("@/lib/auth");
       await expect(
         setPassword({
@@ -334,7 +337,7 @@ describe("@/lib/auth (本物)", () => {
           newPasswordConfirm: "newpass12",
         }),
       ).resolves.toBeUndefined();
-      expect(clientHolder.current.$fetch).toHaveBeenCalledWith(
+      expect(client.$fetch).toHaveBeenCalledWith(
         "/set-password",
         expect.objectContaining({
           method: "POST",
@@ -343,7 +346,7 @@ describe("@/lib/auth (本物)", () => {
       );
     });
     it("error", async () => {
-      clientHolder.current.$fetch.mockResolvedValue({
+      client.$fetch.mockResolvedValue({
         error: { message: "exists" },
       });
       const { setPassword } = await import("@/lib/auth");
@@ -355,7 +358,7 @@ describe("@/lib/auth (本物)", () => {
       ).rejects.toThrow("exists");
     });
     it("既定 error", async () => {
-      clientHolder.current.$fetch.mockResolvedValue({ error: {} });
+      client.$fetch.mockResolvedValue({ error: {} });
       const { setPassword } = await import("@/lib/auth");
       await expect(
         setPassword({
@@ -368,10 +371,10 @@ describe("@/lib/auth (本物)", () => {
 
   describe("deleteAccount", () => {
     it("password 無しは confirmEmail のみ送る", async () => {
-      clientHolder.current.$fetch.mockResolvedValue({ error: null });
+      client.$fetch.mockResolvedValue({ error: null });
       const { deleteAccount } = await import("@/lib/auth");
       await deleteAccount({ confirmEmail: "e@example.com" });
-      expect(clientHolder.current.$fetch).toHaveBeenCalledWith(
+      expect(client.$fetch).toHaveBeenCalledWith(
         "/delete-user",
         expect.objectContaining({
           method: "POST",
@@ -380,10 +383,10 @@ describe("@/lib/auth (本物)", () => {
       );
     });
     it("password ありは password を一緒に送る", async () => {
-      clientHolder.current.$fetch.mockResolvedValue({ error: null });
+      client.$fetch.mockResolvedValue({ error: null });
       const { deleteAccount } = await import("@/lib/auth");
       await deleteAccount({ confirmEmail: "e@example.com", password: "p" });
-      expect(clientHolder.current.$fetch).toHaveBeenCalledWith(
+      expect(client.$fetch).toHaveBeenCalledWith(
         "/delete-user",
         expect.objectContaining({
           body: { confirmEmail: "e@example.com", password: "p" },
@@ -391,7 +394,7 @@ describe("@/lib/auth (本物)", () => {
       );
     });
     it("error", async () => {
-      clientHolder.current.$fetch.mockResolvedValue({
+      client.$fetch.mockResolvedValue({
         error: { message: "no" },
       });
       const { deleteAccount } = await import("@/lib/auth");
@@ -400,7 +403,7 @@ describe("@/lib/auth (本物)", () => {
       ).rejects.toThrow("no");
     });
     it("既定 error", async () => {
-      clientHolder.current.$fetch.mockResolvedValue({ error: {} });
+      client.$fetch.mockResolvedValue({ error: {} });
       const { deleteAccount } = await import("@/lib/auth");
       await expect(
         deleteAccount({ confirmEmail: "e@example.com" }),

--- a/src/lib/workersUrl.test.ts
+++ b/src/lib/workersUrl.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// 各テストで env を入れ替えるため、毎回 module を再評価する。
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("workersUrl", () => {
+  it("NEXT_PUBLIC_WORKERS_URL が設定されているとそれが使われる", async () => {
+    vi.stubEnv("NEXT_PUBLIC_WORKERS_URL", "https://api.example.com");
+    const mod = await import("@/lib/workersUrl");
+    expect(mod.WORKERS_URL).toBe("https://api.example.com");
+    expect(mod.WORKERS_URL_FOR_FETCH).toBe("https://api.example.com");
+  });
+
+  it("NEXT_PUBLIC_WORKERS_URL が空文字のときデフォルト URL を使う", async () => {
+    vi.stubEnv("NEXT_PUBLIC_WORKERS_URL", "");
+    const mod = await import("@/lib/workersUrl");
+    expect(mod.WORKERS_URL).toBe("http://localhost:8787");
+    // WORKERS_URL_FOR_FETCH は window 不在 (SSR) ならデフォルト、存在時は ""
+    if (typeof window === "undefined") {
+      expect(mod.WORKERS_URL_FOR_FETCH).toBe("http://localhost:8787");
+    } else {
+      expect(mod.WORKERS_URL_FOR_FETCH).toBe("");
+    }
+  });
+
+  it("NEXT_PUBLIC_WORKERS_URL 未定義でもデフォルト URL を使う", async () => {
+    vi.stubEnv("NEXT_PUBLIC_WORKERS_URL", undefined as unknown as string);
+    const mod = await import("@/lib/workersUrl");
+    expect(mod.WORKERS_URL).toBe("http://localhost:8787");
+  });
+});

--- a/src/stores/bulkCaptureAtoms.test.ts
+++ b/src/stores/bulkCaptureAtoms.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { createStore } from "jotai";
+import type { BulkCaptureItem, BulkCaptureMetadata } from "@/types";
+import {
+  addCapturedItemAtom,
+  bulkCaptureStepAtom,
+  capturedItemsAtom,
+  currentMetadataIndexAtom,
+  getMetadataForItem,
+  metadataMapAtom,
+  removeCapturedItemAtom,
+  resetBulkCaptureSessionAtom,
+  setMetadataAtom,
+} from "@/stores/bulkCaptureAtoms";
+
+const makeItem = (id: string): BulkCaptureItem => ({
+  captureId: id,
+  blob: new Blob([id], { type: "image/png" }),
+  thumbnailUrl: `blob:${id}`,
+  capturedAt: 1,
+});
+
+const makeMetadata = (captureId: string): BulkCaptureMetadata => ({
+  captureId,
+  name: `n-${captureId}`,
+  category: "dress",
+  dollSize: "MSD",
+  colors: [],
+  tags: [],
+  brand: "",
+  confidenceDecayDays: 30,
+});
+
+describe("bulkCaptureAtoms", () => {
+  it("addCapturedItemAtom で末尾に追加される", () => {
+    const store = createStore();
+    store.set(addCapturedItemAtom, makeItem("c-1"));
+    store.set(addCapturedItemAtom, makeItem("c-2"));
+    const items = store.get(capturedItemsAtom);
+    expect(items.map((i) => i.captureId)).toEqual(["c-1", "c-2"]);
+  });
+
+  it("removeCapturedItemAtom で対象のみ削除される", () => {
+    const store = createStore();
+    store.set(addCapturedItemAtom, makeItem("c-1"));
+    store.set(addCapturedItemAtom, makeItem("c-2"));
+    store.set(removeCapturedItemAtom, "c-1");
+    const items = store.get(capturedItemsAtom);
+    expect(items.map((i) => i.captureId)).toEqual(["c-2"]);
+  });
+
+  it("setMetadataAtom で metadata Map に保存される", () => {
+    const store = createStore();
+    const m = makeMetadata("c-1");
+    store.set(setMetadataAtom, m);
+    expect(store.get(metadataMapAtom).get("c-1")).toEqual(m);
+  });
+
+  it("setMetadataAtom で同じ captureId は上書きされる", () => {
+    const store = createStore();
+    store.set(setMetadataAtom, makeMetadata("c-1"));
+    const updated = { ...makeMetadata("c-1"), name: "updated" };
+    store.set(setMetadataAtom, updated);
+    expect(store.get(metadataMapAtom).get("c-1")?.name).toBe("updated");
+  });
+
+  it("resetBulkCaptureSessionAtom で全状態がリセットされる", () => {
+    const store = createStore();
+    store.set(addCapturedItemAtom, makeItem("c-1"));
+    store.set(setMetadataAtom, makeMetadata("c-1"));
+    store.set(currentMetadataIndexAtom, 5);
+    store.set(bulkCaptureStepAtom, "metadata");
+
+    store.set(resetBulkCaptureSessionAtom);
+
+    expect(store.get(capturedItemsAtom)).toEqual([]);
+    expect(store.get(metadataMapAtom).size).toBe(0);
+    expect(store.get(currentMetadataIndexAtom)).toBe(0);
+    expect(store.get(bulkCaptureStepAtom)).toBe("capture");
+  });
+
+  it("getMetadataForItem は未登録ならデフォルト値を返す", () => {
+    const map = new Map<string, BulkCaptureMetadata>();
+    const result = getMetadataForItem(map, "c-x");
+    expect(result.captureId).toBe("c-x");
+    expect(result.name).toBe("");
+    expect(result.category).toBe("tops");
+    expect(result.dollSize).toBe("SD");
+  });
+
+  it("getMetadataForItem は登録済みなら保存済み値を返す", () => {
+    const map = new Map<string, BulkCaptureMetadata>([
+      ["c-1", makeMetadata("c-1")],
+    ]);
+    const result = getMetadataForItem(map, "c-1");
+    expect(result.name).toBe("n-c-1");
+  });
+});

--- a/src/stores/digestAtoms.test.ts
+++ b/src/stores/digestAtoms.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createStore } from "jotai";
 import { server } from "@/test/mocks/server";
 import { trpcMutation, trpcQuery } from "@/test/mocks/trpc/handlerFactory";
@@ -81,30 +81,22 @@ describe("digestAtoms", () => {
 
   it("markDigestReadAtom が trpc mutation を発火する", async () => {
     const store = createStore();
-    const receivedHolder: { current: unknown } = { current: undefined };
-    server.use(
-      trpcMutation("digest.markRead", async ({ input }) => {
-        Object.assign(receivedHolder, { current: input });
-        return await Promise.resolve({ success: true });
-      }),
-    );
+    const handler = vi.fn(async () => await Promise.resolve({ success: true }));
+    server.use(trpcMutation("digest.markRead", handler));
     await store.set(markDigestReadAtom, "d-1");
-    expect(receivedHolder.current).toEqual({ id: "d-1" });
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ input: { id: "d-1" } }),
+    );
   });
 
   it("refreshDigestAtom が trigger を進める (再 query される)", async () => {
     const store = createStore();
-    const counter = { current: 0 };
-    server.use(
-      trpcQuery("digest.list", () => {
-        Object.assign(counter, { current: counter.current + 1 });
-        return [];
-      }),
-    );
+    const handler = vi.fn(() => []);
+    server.use(trpcQuery("digest.list", handler));
     await store.get(digestListAtom);
-    expect(counter.current).toBe(1);
+    expect(handler).toHaveBeenCalledTimes(1);
     store.set(refreshDigestAtom);
     await store.get(digestListAtom);
-    expect(counter.current).toBe(2);
+    expect(handler).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/stores/digestAtoms.test.ts
+++ b/src/stores/digestAtoms.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { createStore } from "jotai";
+import { server } from "@/test/mocks/server";
+import { trpcMutation, trpcQuery } from "@/test/mocks/trpc/handlerFactory";
+import {
+  digestListAtom,
+  hasUnreadDigestAtom,
+  latestDigestAtom,
+  markDigestReadAtom,
+  refreshDigestAtom,
+} from "@/stores/digestAtoms";
+
+const TEST_DIGEST = {
+  id: "d-1",
+  userId: "u",
+  accuracyScore: 0.5,
+  confirmedCount: 0,
+  uncertainCount: 0,
+  unknownCount: 0,
+  totalGarments: 0,
+  isRead: false,
+  generatedAt: 0,
+  createdAt: 0,
+};
+
+describe("digestAtoms", () => {
+  it("digestListAtom が trpc 結果を返す", async () => {
+    const store = createStore();
+    server.use(trpcQuery("digest.list", () => [TEST_DIGEST]));
+    const list = await store.get(digestListAtom);
+    expect(list).toEqual([TEST_DIGEST]);
+  });
+
+  it("digestListAtom のクエリが失敗した場合は空配列を返す (catch)", async () => {
+    const store = createStore();
+    server.use(
+      trpcQuery(
+        "digest.list",
+        async () => await Promise.reject(new Error("boom")),
+      ),
+    );
+    const list = await store.get(digestListAtom);
+    expect(list).toEqual([]);
+  });
+
+  it("latestDigestAtom が trpc 結果を返す", async () => {
+    const store = createStore();
+    server.use(trpcQuery("digest.latest", () => TEST_DIGEST));
+    const latest = await store.get(latestDigestAtom);
+    expect(latest).toEqual(TEST_DIGEST);
+  });
+
+  it("latestDigestAtom の失敗は undefined にフォールバック", async () => {
+    const store = createStore();
+    server.use(
+      trpcQuery(
+        "digest.latest",
+        async () => await Promise.reject(new Error("boom")),
+      ),
+    );
+    const latest = await store.get(latestDigestAtom);
+    expect(latest).toBeUndefined();
+  });
+
+  it("hasUnreadDigestAtom が true を返す", async () => {
+    const store = createStore();
+    server.use(trpcQuery("digest.hasUnread", () => ({ hasUnread: true })));
+    expect(await store.get(hasUnreadDigestAtom)).toBe(true);
+  });
+
+  it("hasUnreadDigestAtom の失敗時は false にフォールバック", async () => {
+    const store = createStore();
+    server.use(
+      trpcQuery(
+        "digest.hasUnread",
+        async () => await Promise.reject(new Error("boom")),
+      ),
+    );
+    expect(await store.get(hasUnreadDigestAtom)).toBe(false);
+  });
+
+  it("markDigestReadAtom が trpc mutation を発火する", async () => {
+    const store = createStore();
+    const receivedHolder: { current: unknown } = { current: undefined };
+    server.use(
+      trpcMutation("digest.markRead", async ({ input }) => {
+        Object.assign(receivedHolder, { current: input });
+        return await Promise.resolve({ success: true });
+      }),
+    );
+    await store.set(markDigestReadAtom, "d-1");
+    expect(receivedHolder.current).toEqual({ id: "d-1" });
+  });
+
+  it("refreshDigestAtom が trigger を進める (再 query される)", async () => {
+    const store = createStore();
+    const counter = { current: 0 };
+    server.use(
+      trpcQuery("digest.list", () => {
+        Object.assign(counter, { current: counter.current + 1 });
+        return [];
+      }),
+    );
+    await store.get(digestListAtom);
+    expect(counter.current).toBe(1);
+    store.set(refreshDigestAtom);
+    await store.get(digestListAtom);
+    expect(counter.current).toBe(2);
+  });
+});

--- a/src/stores/digestAtoms.test.ts
+++ b/src/stores/digestAtoms.test.ts
@@ -81,7 +81,9 @@ describe("digestAtoms", () => {
 
   it("markDigestReadAtom が trpc mutation を発火する", async () => {
     const store = createStore();
-    const handler = vi.fn(async () => await Promise.resolve({ success: true }));
+    const handler = vi.fn(
+      async () => await Promise.resolve({ success: true as const }),
+    );
     server.use(trpcMutation("digest.markRead", handler));
     await store.set(markDigestReadAtom, "d-1");
     expect(handler).toHaveBeenCalledWith(

--- a/src/stores/garmentAtoms.test.ts
+++ b/src/stores/garmentAtoms.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStore } from "jotai";
+import { getDb } from "@/lib/db/dexie";
+import { setupAuthSession } from "@/test/mocks/modules/authAtomsState";
+import { server } from "@/test/mocks/server";
+import { unauthenticatedHandler } from "@/test/mocks/handlers";
+import {
+  createTestGarment,
+  createTestStorageLocation,
+  FIXED_NOW,
+} from "@/test/factories";
+import { authSessionAtom, authSessionUnwrappedAtom } from "@/stores/authAtoms";
+import {
+  confirmAllByMemoryAtom,
+  confirmAllGarmentsAtom,
+  confirmPartialGarmentsAtom,
+} from "@/stores/garmentAtoms";
+
+const primeAuth = async (store: ReturnType<typeof createStore>) => {
+  store.sub(authSessionUnwrappedAtom, () => undefined);
+  await store.get(authSessionAtom);
+  await Promise.resolve();
+};
+
+beforeEach(() => {
+  vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("confirmAllGarmentsAtom", () => {
+  it("未認証では何もしない", async () => {
+    server.use(unauthenticatedHandler);
+    const store = createStore();
+    await primeAuth(store);
+    await store.set(confirmAllGarmentsAtom, "loc-1");
+    // 例外を投げずに何も書き込まないことを確認
+    const db = getDb();
+    expect(await db.garments.count()).toBe(0);
+  });
+
+  it("認証済みで対象を lastScannedAt 更新する", async () => {
+    setupAuthSession({ userId: "user-1" });
+    const store = createStore();
+    await primeAuth(store);
+
+    const db = getDb();
+    await db.garments.add(
+      createTestGarment({
+        id: "g-1",
+        userId: "user-1",
+        locationId: "loc-1",
+        status: "stored",
+        lastScannedAt: FIXED_NOW - 1_000_000,
+      }),
+    );
+    await db.storageLocations.add(
+      createTestStorageLocation({ id: "loc-1", userId: "user-1" }),
+    );
+
+    await store.set(confirmAllGarmentsAtom, "loc-1");
+
+    const updated = await db.garments.get("g-1");
+    expect(updated?.lastScannedAt).toBe(FIXED_NOW);
+    expect(updated?.updatedAt).toBe(FIXED_NOW);
+  });
+
+  it("location が他ユーザー所有なら lastVisitedAt は更新されない", async () => {
+    setupAuthSession({ userId: "user-1" });
+    const store = createStore();
+    await primeAuth(store);
+
+    const db = getDb();
+    await db.garments.add(
+      createTestGarment({
+        id: "g-1",
+        userId: "user-1",
+        locationId: "loc-1",
+        status: "stored",
+        lastScannedAt: FIXED_NOW - 1_000_000,
+      }),
+    );
+    await db.storageLocations.add(
+      createTestStorageLocation({
+        id: "loc-1",
+        userId: "other-user",
+        lastVisitedAt: undefined,
+      }),
+    );
+
+    await store.set(confirmAllGarmentsAtom, "loc-1");
+
+    const loc = await db.storageLocations.get("loc-1");
+    expect(loc?.lastVisitedAt).toBeUndefined();
+  });
+});
+
+describe("confirmPartialGarmentsAtom", () => {
+  it("未認証では何もしない", async () => {
+    server.use(unauthenticatedHandler);
+    const store = createStore();
+    await primeAuth(store);
+    await store.set(confirmPartialGarmentsAtom, {
+      locationId: "loc-1",
+      confirmations: [{ garmentId: "g-1", confirmed: true }],
+    });
+    expect(await getDb().garments.count()).toBe(0);
+  });
+
+  it("denied のみで discrepancy として correctionCount を増やす", async () => {
+    setupAuthSession({ userId: "user-1" });
+    const store = createStore();
+    await primeAuth(store);
+
+    const db = getDb();
+    await db.garments.add(
+      createTestGarment({
+        id: "g-1",
+        userId: "user-1",
+        locationId: "loc-1",
+        status: "stored",
+      }),
+    );
+    await db.storageLocations.add(
+      createTestStorageLocation({
+        id: "loc-1",
+        userId: "user-1",
+        confirmAllCount: 0,
+        correctionCount: 0,
+      }),
+    );
+
+    await store.set(confirmPartialGarmentsAtom, {
+      locationId: "loc-1",
+      confirmations: [{ garmentId: "g-1", confirmed: false }],
+    });
+
+    const updated = await db.garments.get("g-1");
+    expect(updated?.status).toBe("checked_out");
+    expect(updated?.locationId).toBeUndefined();
+
+    const loc = await db.storageLocations.get("loc-1");
+    expect(loc?.correctionCount).toBe(1);
+    expect(loc?.confirmAllCount).toBe(0);
+  });
+
+  it("confirmed のみで discrepancy なしの場合は confirmAllCount を増やす", async () => {
+    setupAuthSession({ userId: "user-1" });
+    const store = createStore();
+    await primeAuth(store);
+
+    const db = getDb();
+    await db.garments.add(
+      createTestGarment({
+        id: "g-1",
+        userId: "user-1",
+        locationId: "loc-1",
+        status: "stored",
+      }),
+    );
+    await db.storageLocations.add(
+      createTestStorageLocation({
+        id: "loc-1",
+        userId: "user-1",
+        confirmAllCount: 0,
+      }),
+    );
+
+    await store.set(confirmPartialGarmentsAtom, {
+      locationId: "loc-1",
+      confirmations: [{ garmentId: "g-1", confirmed: true }],
+    });
+
+    const loc = await db.storageLocations.get("loc-1");
+    expect(loc?.confirmAllCount).toBe(1);
+  });
+});
+
+describe("confirmAllByMemoryAtom", () => {
+  it("未認証では何もしない", async () => {
+    server.use(unauthenticatedHandler);
+    const store = createStore();
+    await primeAuth(store);
+    await store.set(confirmAllByMemoryAtom, "loc-1");
+    expect(await getDb().garments.count()).toBe(0);
+  });
+
+  it("認証済みで lastScannedAt を 50% 信頼度相当に巻き戻す", async () => {
+    setupAuthSession({ userId: "user-1" });
+    const store = createStore();
+    await primeAuth(store);
+
+    const db = getDb();
+    await db.garments.add(
+      createTestGarment({
+        id: "g-1",
+        userId: "user-1",
+        locationId: "loc-1",
+        status: "stored",
+        confidenceDecayDays: 30,
+        recentCheckoutCount: 0,
+      }),
+    );
+
+    await store.set(confirmAllByMemoryAtom, "loc-1");
+
+    const updated = await db.garments.get("g-1");
+    // lastScannedAt は FIXED_NOW - (30 * 0.5 * MS_PER_DAY)
+    expect(updated?.lastScannedAt).toBeLessThan(FIXED_NOW);
+    expect(updated?.updatedAt).toBe(FIXED_NOW);
+  });
+});

--- a/src/stores/locationAtoms.test.ts
+++ b/src/stores/locationAtoms.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStore } from "jotai";
+import { getDb } from "@/lib/db/dexie";
+import { setupAuthSession } from "@/test/mocks/modules/authAtomsState";
+import { server } from "@/test/mocks/server";
+import { unauthenticatedHandler } from "@/test/mocks/handlers";
+import {
+  createTestGarment,
+  createTestStorageLocation,
+  createTestStorageCase,
+  FIXED_NOW,
+} from "@/test/factories";
+import { authSessionAtom, authSessionUnwrappedAtom } from "@/stores/authAtoms";
+import {
+  addStorageCaseWithLocationsAtom,
+  deleteStorageCaseAtom,
+  updateStorageLocationAtom,
+} from "@/stores/locationAtoms";
+
+const primeAuth = async (store: ReturnType<typeof createStore>) => {
+  store.sub(authSessionUnwrappedAtom, () => undefined);
+  await store.get(authSessionAtom);
+  await Promise.resolve();
+};
+
+beforeEach(() => {
+  vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("addStorageCaseWithLocationsAtom", () => {
+  it("未認証では何もしない", async () => {
+    server.use(unauthenticatedHandler);
+    const store = createStore();
+    await primeAuth(store);
+    await store.set(addStorageCaseWithLocationsAtom, {
+      type: "grid",
+      name: "case",
+      description: undefined,
+      rows: 2,
+      cols: 2,
+      userId: "user-1",
+    });
+    expect(await getDb().storageCases.count()).toBe(0);
+  });
+
+  it("grid 型は rows*cols 個の location を生成する", async () => {
+    setupAuthSession({ userId: "user-1" });
+    const store = createStore();
+    await primeAuth(store);
+    await store.set(addStorageCaseWithLocationsAtom, {
+      type: "grid",
+      name: "ケース",
+      description: undefined,
+      rows: 2,
+      cols: 3,
+      userId: "user-1",
+    });
+    const db = getDb();
+    expect(await db.storageCases.count()).toBe(1);
+    expect(await db.storageLocations.count()).toBe(6);
+  });
+
+  it("unit 型は 1 個の location を生成する", async () => {
+    setupAuthSession({ userId: "user-1" });
+    const store = createStore();
+    await primeAuth(store);
+    await store.set(addStorageCaseWithLocationsAtom, {
+      type: "unit",
+      name: "押し入れ",
+      description: undefined,
+      userId: "user-1",
+    });
+    const db = getDb();
+    const cases = await db.storageCases.toArray();
+    expect(cases[0]?.type).toBe("unit");
+    expect(await db.storageLocations.count()).toBe(1);
+  });
+});
+
+describe("updateStorageLocationAtom", () => {
+  it("customName と description が更新される", async () => {
+    setupAuthSession({ userId: "user-1" });
+    const store = createStore();
+    await primeAuth(store);
+    const location = createTestStorageLocation({
+      id: "loc-1",
+      userId: "user-1",
+    });
+    await getDb().storageLocations.add(location);
+
+    await store.set(updateStorageLocationAtom, {
+      location,
+      customName: "新名前",
+      description: "メモ",
+    });
+
+    const updated = await getDb().storageLocations.get("loc-1");
+    expect(updated?.customName).toBe("新名前");
+    expect(updated?.description).toBe("メモ");
+  });
+});
+
+describe("deleteStorageCaseAtom", () => {
+  it("未認証では何もしない", async () => {
+    server.use(unauthenticatedHandler);
+    const store = createStore();
+    await primeAuth(store);
+    await getDb().storageCases.add(
+      createTestStorageCase({ id: "case-1", userId: "user-1" }),
+    );
+    await store.set(deleteStorageCaseAtom, "case-1");
+    expect(await getDb().storageCases.count()).toBe(1);
+  });
+
+  it("対象ケースが他ユーザーの場合は削除されない", async () => {
+    setupAuthSession({ userId: "user-1" });
+    const store = createStore();
+    await primeAuth(store);
+    await getDb().storageCases.add(
+      createTestStorageCase({ id: "case-1", userId: "other-user" }),
+    );
+    await store.set(deleteStorageCaseAtom, "case-1");
+    expect(await getDb().storageCases.count()).toBe(1);
+  });
+
+  it("ケース内に紐づく garment があれば取り出し中に変える", async () => {
+    setupAuthSession({ userId: "user-1" });
+    const store = createStore();
+    await primeAuth(store);
+    const db = getDb();
+    await db.storageCases.add(
+      createTestStorageCase({ id: "case-1", userId: "user-1" }),
+    );
+    await db.storageLocations.add(
+      createTestStorageLocation({
+        id: "loc-1",
+        caseId: "case-1",
+        userId: "user-1",
+      }),
+    );
+    await db.garments.add(
+      createTestGarment({
+        id: "g-1",
+        userId: "user-1",
+        locationId: "loc-1",
+        status: "stored",
+      }),
+    );
+
+    await store.set(deleteStorageCaseAtom, "case-1");
+
+    const garment = await db.garments.get("g-1");
+    expect(garment?.status).toBe("checked_out");
+    expect(garment?.locationId).toBeUndefined();
+    expect(await db.storageCases.count()).toBe(0);
+    expect(await db.storageLocations.count()).toBe(0);
+  });
+});

--- a/workers/src/index-auth.scenario.test.ts
+++ b/workers/src/index-auth.scenario.test.ts
@@ -1,0 +1,292 @@
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { APIError } from "better-auth/api";
+import worker from "./index";
+
+type SessionShape = {
+  readonly user: { readonly id: string; readonly email: string };
+} | null;
+
+// vi.mock は静的に hoist されるため、factory が参照する spy も
+// vi.hoisted で同じ位置に巻き上げる必要がある。さもないと
+// worker の static import が走った時点で TDZ エラーになる。
+const { setPasswordSpy, deleteUserSpy, getSessionSpy } = vi.hoisted(() => ({
+  setPasswordSpy: vi.fn(),
+  deleteUserSpy: vi.fn(),
+  getSessionSpy: vi.fn<(args: { headers: Headers }) => Promise<SessionShape>>(),
+}));
+
+vi.mock("./auth", () => ({
+  createAuth: () => ({
+    handler: async () =>
+      await Promise.resolve(new Response("noop", { status: 501 })),
+    api: {
+      setPassword: setPasswordSpy,
+      deleteUser: deleteUserSpy,
+      getSession: getSessionSpy,
+    },
+  }),
+}));
+
+const TEST_BASE = "http://test.local";
+const noop = (): void => undefined;
+
+const callWorker = async (req: Request): Promise<Response> => {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+};
+
+beforeEach(() => {
+  setPasswordSpy.mockReset();
+  deleteUserSpy.mockReset();
+  getSessionSpy.mockReset();
+  vi.spyOn(console, "log").mockImplementation(noop);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("/api/auth/set-password", () => {
+  it("newPassword が文字列でない場合は 400 を返す", async () => {
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/set-password`, {
+        method: "POST",
+        body: JSON.stringify({ newPassword: 123 }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ message: "newPassword required" });
+  });
+
+  it("JSON parse 失敗時も 400 を返す", async () => {
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/set-password`, {
+        method: "POST",
+        body: "{not-json",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("成功時は status: true を返す", async () => {
+    setPasswordSpy.mockResolvedValue({ status: true });
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/set-password`, {
+        method: "POST",
+        body: JSON.stringify({ newPassword: "newpass12" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ status: true });
+  });
+
+  it("better-auth APIError は 400 + message を返す", async () => {
+    setPasswordSpy.mockRejectedValueOnce(
+      new APIError("BAD_REQUEST", { message: "Already has password" }),
+    );
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/set-password`, {
+        method: "POST",
+        body: JSON.stringify({ newPassword: "newpass12" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toBe("Already has password");
+  });
+
+  it("APIError message が無い場合は 'Failed' で 400 を返す", async () => {
+    setPasswordSpy.mockRejectedValueOnce(new APIError("BAD_REQUEST", {}));
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/set-password`, {
+        method: "POST",
+        body: JSON.stringify({ newPassword: "newpass12" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("通常の Error は 500 を返す", async () => {
+    setPasswordSpy.mockRejectedValueOnce(new Error("boom"));
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/set-password`, {
+        method: "POST",
+        body: JSON.stringify({ newPassword: "newpass12" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("/api/auth/delete-user", () => {
+  it("confirmEmail が文字列でない場合は 400 を返す", async () => {
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({ confirmEmail: 1 }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("confirmEmail が空文字の場合も 400 を返す", async () => {
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({ confirmEmail: "   " }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("JSON parse 失敗時にも 400 を返す", async () => {
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: "{invalid",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("未認証時は 401 を返す", async () => {
+    getSessionSpy.mockResolvedValue(null);
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({ confirmEmail: "x@example.com" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("session 取得が例外を投げた場合も 401 を返す", async () => {
+    getSessionSpy.mockRejectedValue(new Error("boom"));
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({ confirmEmail: "x@example.com" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("confirmEmail が session のメールと一致しないと 403", async () => {
+    getSessionSpy.mockResolvedValue({
+      user: { id: "u-1", email: "user@example.com" },
+    });
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({ confirmEmail: "other@example.com" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("大文字小文字を吸収して一致と判定する", async () => {
+    getSessionSpy.mockResolvedValue({
+      user: { id: "u-1", email: "User@Example.com" },
+    });
+    deleteUserSpy.mockResolvedValue({ status: true });
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({ confirmEmail: "user@example.com" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("password 文字列ありで成功", async () => {
+    getSessionSpy.mockResolvedValue({
+      user: { id: "u-1", email: "user@example.com" },
+    });
+    deleteUserSpy.mockResolvedValue({ status: true });
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({
+          confirmEmail: "user@example.com",
+          password: "pass",
+        }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(deleteUserSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ body: { password: "pass" } }),
+    );
+  });
+
+  it("APIError は 400 + メッセージを返す", async () => {
+    getSessionSpy.mockResolvedValue({
+      user: { id: "u-1", email: "user@example.com" },
+    });
+    deleteUserSpy.mockRejectedValueOnce(
+      new APIError("BAD_REQUEST", { message: "Password required" }),
+    );
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({ confirmEmail: "user@example.com" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toBe("Password required");
+  });
+
+  it("APIError message が無い場合 'Failed' で 400 を返す", async () => {
+    getSessionSpy.mockResolvedValue({
+      user: { id: "u-1", email: "user@example.com" },
+    });
+    deleteUserSpy.mockRejectedValueOnce(new APIError("BAD_REQUEST", {}));
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({ confirmEmail: "user@example.com" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("通常の Error は 500 を返す", async () => {
+    getSessionSpy.mockResolvedValue({
+      user: { id: "u-1", email: "user@example.com" },
+    });
+    deleteUserSpy.mockRejectedValueOnce(new Error("boom"));
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({ confirmEmail: "user@example.com" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/workers/src/lib/auth-resolver.test.ts
+++ b/workers/src/lib/auth-resolver.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import { extractBearerKey, resolveAuthenticatedUserId } from "./auth-resolver";
+import type { Auth } from "../auth";
+
+type SessionShape = { readonly user: { readonly id: string } } | null;
+type VerifyShape =
+  | { readonly valid: true; readonly key?: { readonly referenceId?: string } }
+  | { readonly valid: false };
+
+const makeAuth = ({
+  session,
+  verify,
+}: {
+  readonly session?: SessionShape | Error;
+  readonly verify?: VerifyShape | Error;
+}): Auth =>
+  ({
+    api: {
+      getSession: vi.fn(async () =>
+        session instanceof Error
+          ? await Promise.reject(session)
+          : await Promise.resolve(session ?? null),
+      ),
+      verifyApiKey: vi.fn(async () =>
+        verify instanceof Error
+          ? await Promise.reject(verify)
+          : await Promise.resolve(verify ?? { valid: false }),
+      ),
+    },
+  }) as unknown as Auth;
+
+describe("extractBearerKey", () => {
+  it("authorization が無いとき undefined", () => {
+    expect(extractBearerKey(new Headers())).toBeUndefined();
+  });
+
+  it("Bearer プレフィックス無しは undefined", () => {
+    expect(extractBearerKey(new Headers({ authorization: "Basic xxx" }))).toBe(
+      undefined,
+    );
+  });
+
+  it("大文字小文字を吸収して bearer を抽出", () => {
+    expect(extractBearerKey(new Headers({ authorization: "BEARER abc" }))).toBe(
+      "abc",
+    );
+  });
+
+  it("Bearer 後が空白だけの場合は undefined", () => {
+    expect(extractBearerKey(new Headers({ authorization: "Bearer    " }))).toBe(
+      undefined,
+    );
+  });
+
+  it("正常な Bearer はトリムされて返る", () => {
+    expect(
+      extractBearerKey(new Headers({ authorization: "Bearer dwk_abc " })),
+    ).toBe("dwk_abc");
+  });
+});
+
+describe("resolveAuthenticatedUserId", () => {
+  it("Bearer のみ・cookie 無し→ verifyApiKey 経路で userId を返す", async () => {
+    const auth = makeAuth({
+      verify: { valid: true, key: { referenceId: "u-1" } },
+    });
+    const headers = new Headers({ authorization: "Bearer dwk_x" });
+    const result = await resolveAuthenticatedUserId({ auth, headers });
+    expect(result).toBe("u-1");
+  });
+
+  it("Bearer 経路で verifyApiKey が valid:false → undefined", async () => {
+    const auth = makeAuth({ verify: { valid: false } });
+    const headers = new Headers({ authorization: "Bearer dwk_x" });
+    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+  });
+
+  it("Bearer 経路で referenceId が空文字 → undefined", async () => {
+    const auth = makeAuth({
+      verify: { valid: true, key: { referenceId: "" } },
+    });
+    const headers = new Headers({ authorization: "Bearer dwk_x" });
+    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+  });
+
+  it("Bearer 経路で verifyApiKey が throw → undefined", async () => {
+    const auth = makeAuth({ verify: new Error("network") });
+    const headers = new Headers({ authorization: "Bearer dwk_x" });
+    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+  });
+
+  it("Cookie あり Bearer あり → session 優先", async () => {
+    const auth = makeAuth({
+      session: { user: { id: "u-cookie" } },
+      verify: { valid: true, key: { referenceId: "u-bearer" } },
+    });
+    const headers = new Headers({
+      authorization: "Bearer dwk_x",
+      cookie: "session=abc",
+    });
+    expect(await resolveAuthenticatedUserId({ auth, headers })).toBe(
+      "u-cookie",
+    );
+  });
+
+  it("Cookie あり session が null → Bearer fallback", async () => {
+    const auth = makeAuth({
+      session: null,
+      verify: { valid: true, key: { referenceId: "u-bearer" } },
+    });
+    const headers = new Headers({
+      authorization: "Bearer dwk_x",
+      cookie: "session=abc",
+    });
+    expect(await resolveAuthenticatedUserId({ auth, headers })).toBe(
+      "u-bearer",
+    );
+  });
+
+  it("Cookie あり Bearer 無しで session も無効 → undefined", async () => {
+    const auth = makeAuth({ session: null });
+    const headers = new Headers({ cookie: "session=abc" });
+    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+  });
+
+  it("Cookie あり getSession が throw → undefined にフォールバック", async () => {
+    const auth = makeAuth({ session: new Error("oops") });
+    const headers = new Headers({ cookie: "session=abc" });
+    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+  });
+
+  it("Cookie あり session.user.id が空文字 → undefined", async () => {
+    const auth = makeAuth({ session: { user: { id: "" } } });
+    const headers = new Headers({ cookie: "session=abc" });
+    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+  });
+});

--- a/workers/src/repositories/scan-repository.test.ts
+++ b/workers/src/repositories/scan-repository.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDrizzle } from "../db/client";
+import { getTestDb, resetDatabase } from "../test/helpers";
+import {
+  batchCheckin,
+  batchConfirmPartial,
+} from "../repositories/scan-repository";
+
+beforeEach(async () => {
+  await resetDatabase(getTestDb());
+});
+
+describe("scan-repository edge cases", () => {
+  it("batchCheckin: 空配列で 0 を返す (early return)", async () => {
+    const drizzleDb = createDrizzle(getTestDb());
+    const result = await batchCheckin({
+      drizzleDb,
+      userId: "u",
+      locationId: "loc-x",
+      garmentIds: [],
+    });
+    expect(result).toBe(0);
+  });
+
+  it("batchConfirmPartial: 空配列で何も起きない (early return)", async () => {
+    const drizzleDb = createDrizzle(getTestDb());
+    await expect(
+      batchConfirmPartial({
+        drizzleDb,
+        userId: "u",
+        confirmations: [],
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/workers/src/test/coordinate-crud.scenario.test.ts
+++ b/workers/src/test/coordinate-crud.scenario.test.ts
@@ -144,6 +144,22 @@ describe("コーデ CRUD シナリオ", () => {
 
       expectTRPCError(error, "NOT_FOUND");
     });
+
+    it("garmentIds を省略 (undefined) して update した場合は既存値が維持される", async () => {
+      const caller = getCaller();
+      const g1 = await caller.garment.create(createTestGarmentInput());
+      const created = await caller.coordinate.create(
+        createTestCoordinateInput({ garmentIds: [g1.id] }),
+      );
+
+      const updated = await caller.coordinate.update({
+        id: created.id,
+        name: "改名のみ",
+      });
+
+      expect(updated.name).toBe("改名のみ");
+      expect(updated.garmentIds).toEqual([g1.id]);
+    });
   });
 
   describe("コーデの削除", () => {

--- a/workers/src/test/location-management.scenario.test.ts
+++ b/workers/src/test/location-management.scenario.test.ts
@@ -42,6 +42,20 @@ describe("収納場所管理シナリオ", () => {
       expect(detail.locations).toHaveLength(1);
       expect(detail.locations[0]!.label).toBe("A-1");
     });
+
+    it("unit 型ケースを作成すると 1x1 として 1 個の location が生成される", async () => {
+      const caller = getCaller();
+      const caseResult = await caller.location.createCase({
+        name: "押入れ",
+        type: "unit",
+      });
+
+      const detail = await caller.location.getCase(caseResult.id);
+      expect(detail.storageCase.type).toBe("unit");
+      expect(detail.locations).toHaveLength(1);
+      // unit の location ラベルはケース名と同じ
+      expect(detail.locations[0]!.label).toBe("押入れ");
+    });
   });
 
   describe("ケース一覧", () => {

--- a/workers/src/test/scan-workflow.scenario.test.ts
+++ b/workers/src/test/scan-workflow.scenario.test.ts
@@ -306,5 +306,16 @@ describe("スキャン操作シナリオ", () => {
 
       expectTRPCError(error, "NOT_FOUND");
     });
+
+    it("stored_back で locationId 未指定はバリデーションエラー", async () => {
+      const { caller, garment } = await setupOrphan();
+      const error = await caller.scan
+        .orphanResolve({
+          garmentId: garment.id,
+          resolution: "stored_back",
+        })
+        .catch((e: unknown) => e);
+      expectTRPCError(error, "BAD_REQUEST");
+    });
   });
 });

--- a/workers/src/test/sync-workflow.scenario.test.ts
+++ b/workers/src/test/sync-workflow.scenario.test.ts
@@ -504,23 +504,34 @@ describe("同期ワークフロー シナリオ", () => {
 
     it("同じ priority の action は createdAt 昇順で処理される", async () => {
       const caller = getCaller();
-      const first = createCasePayload({ name: "first" });
-      const second = createCasePayload({ name: "second" });
+      // 同じ id を持つ 2 件の create を、入力では createdAt 降順で並べる。
+      // storageCases.id は upsert の conflict target なので、後勝ち
+      // (last-write-wins) の name が最終状態として観測できる。
+      const sharedId = createId();
+      const earlier = createCasePayload({ id: sharedId, name: "earlier" });
+      const later = createCasePayload({ id: sharedId, name: "later" });
       const result = await caller.sync.push({
         items: [
+          // 入力順は逆 (createdAt: 2000 が先)。sort されないと later が
+          // 先に書かれ、earlier に上書きされて最終 name = "earlier" になる。
           {
             type: "storageCase:create",
-            payload: { storageCase: second, locations: [] },
+            payload: { storageCase: later, locations: [] },
             createdAt: 2_000,
           },
           {
             type: "storageCase:create",
-            payload: { storageCase: first, locations: [] },
+            payload: { storageCase: earlier, locations: [] },
             createdAt: 1_000,
           },
         ],
       });
       expect(result.processedCount).toBe(2);
+
+      // createdAt 昇順で sort されていれば: earlier (1000) → later (2000)
+      // → 最終 name は "later" になる。
+      const detail = await caller.location.getCase(sharedId);
+      expect(detail.storageCase.name).toBe("later");
     });
 
     it("空配列の push は BAD_REQUEST を返す (items min 1 制約)", async () => {

--- a/workers/src/test/sync-workflow.scenario.test.ts
+++ b/workers/src/test/sync-workflow.scenario.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- comprehensive sync workflow scenarios */
 import { createId } from "@paralleldrive/cuid2";
 import {
   createTestCaller,
@@ -498,6 +499,59 @@ describe("同期ワークフロー シナリオ", () => {
         })
         .catch((e: unknown) => e);
 
+      expectTRPCError(error, "BAD_REQUEST");
+    });
+
+    it("同じ priority の action は createdAt 昇順で処理される", async () => {
+      const caller = getCaller();
+      const first = createCasePayload({ name: "first" });
+      const second = createCasePayload({ name: "second" });
+      const result = await caller.sync.push({
+        items: [
+          {
+            type: "storageCase:create",
+            payload: { storageCase: second, locations: [] },
+            createdAt: 2_000,
+          },
+          {
+            type: "storageCase:create",
+            payload: { storageCase: first, locations: [] },
+            createdAt: 1_000,
+          },
+        ],
+      });
+      expect(result.processedCount).toBe(2);
+    });
+
+    it("空配列の push は BAD_REQUEST を返す (items min 1 制約)", async () => {
+      const caller = getCaller();
+      const error = await caller.sync
+        .push({ items: [] })
+        .catch((e: unknown) => e);
+      expectTRPCError(error, "BAD_REQUEST");
+    });
+
+    it("複数 action の中で 1 つが失敗するとそこで中断される", async () => {
+      const caller = getCaller();
+      const error = await caller.sync
+        .push({
+          items: [
+            {
+              type: "storageCase:create",
+              payload: {
+                storageCase: createCasePayload({ name: "valid" }),
+                locations: [],
+              },
+              createdAt: Date.now(),
+            },
+            {
+              type: "garment:create",
+              payload: { invalid: true },
+              createdAt: Date.now() + 1,
+            },
+          ],
+        })
+        .catch((e: unknown) => e);
       expectTRPCError(error, "BAD_REQUEST");
     });
   });

--- a/workers/src/trpc/index.test.ts
+++ b/workers/src/trpc/index.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { env } from "cloudflare:test";
+import { TRPCError } from "@trpc/server";
+import { createCallerFactory } from "./index";
+import { appRouter } from "./router";
+import { createTestLogger, createStubAuth } from "../test/helpers";
+
+const callerFactory = createCallerFactory(appRouter);
+
+describe("trpc authMiddleware", () => {
+  it("preAuthenticatedUserId 経由なら認証チェックをスキップする", async () => {
+    const caller = callerFactory({
+      env,
+      logger: createTestLogger(),
+      preAuthenticatedUserId: "user-pre-1",
+    });
+    const result = await caller.garment.list({});
+    expect(result).toEqual([]);
+  });
+
+  it("auth が未定義 / honoContext が無い場合は UNAUTHORIZED", async () => {
+    const caller = callerFactory({
+      env,
+      logger: createTestLogger(),
+    });
+    const error = await caller.garment.list({}).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(TRPCError);
+    if (error instanceof TRPCError) {
+      expect(error.code).toBe("UNAUTHORIZED");
+    }
+  });
+
+  it("auth.api.getSession が null を返した場合 UNAUTHORIZED", async () => {
+    const stubAuth = createStubAuth(undefined);
+    const stubHono = {
+      req: { raw: { headers: new Headers({ cookie: "session=x" }) } },
+    } as unknown as import("hono").Context;
+    const caller = callerFactory({
+      env,
+      logger: createTestLogger(),
+      auth: stubAuth,
+      honoContext: stubHono,
+    });
+    const error = await caller.garment.list({}).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(TRPCError);
+    if (error instanceof TRPCError) {
+      expect(error.code).toBe("UNAUTHORIZED");
+    }
+  });
+
+  it("auth.api.getSession が userId を返した場合は protectedProcedure が通る", async () => {
+    const stubAuth = createStubAuth("user-stub-1");
+    const stubHono = {
+      req: { raw: { headers: new Headers({ cookie: "session=x" }) } },
+    } as unknown as import("hono").Context;
+    const caller = callerFactory({
+      env,
+      logger: createTestLogger(),
+      auth: stubAuth,
+      honoContext: stubHono,
+    });
+    const result = await caller.garment.list({});
+    expect(result).toEqual([]);
+  });
+});

--- a/workers/src/trpc/routers/doll.test.ts
+++ b/workers/src/trpc/routers/doll.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { createTestCaller, resetDatabase, getTestDb } from "../../test/helpers";
+import {
+  createTestCaller,
+  resetDatabase,
+  getTestDb,
+  expectTRPCError,
+} from "../../test/helpers";
 import { insertDoll } from "../../../test/helpers/factories";
 
 const db = getTestDb();
@@ -40,9 +45,10 @@ describe("dollRouter", () => {
     });
 
     it("存在しない id は NOT_FOUND エラーを投げる", async () => {
-      await expect(
-        caller.doll.get({ id: "ckxx0000000000000000000z" }),
-      ).rejects.toThrow();
+      const error = await caller.doll
+        .get({ id: "ckxx0000000000000000000z" })
+        .catch((e: unknown) => e);
+      expectTRPCError(error, "NOT_FOUND");
     });
   });
 
@@ -81,9 +87,10 @@ describe("dollRouter", () => {
     });
 
     it("存在しないドールは NOT_FOUND を投げる", async () => {
-      await expect(
-        caller.doll.update({ id: "ckxx0000000000000000000z", name: "x" }),
-      ).rejects.toThrow();
+      const error = await caller.doll
+        .update({ id: "ckxx0000000000000000000z", name: "x" })
+        .catch((e: unknown) => e);
+      expectTRPCError(error, "NOT_FOUND");
     });
   });
 
@@ -98,9 +105,10 @@ describe("dollRouter", () => {
     });
 
     it("存在しない id で削除した場合は NOT_FOUND を返す", async () => {
-      await expect(
-        caller.doll.delete({ id: "ckxx0000000000000000000z" }),
-      ).rejects.toThrow();
+      const error = await caller.doll
+        .delete({ id: "ckxx0000000000000000000z" })
+        .catch((e: unknown) => e);
+      expectTRPCError(error, "NOT_FOUND");
     });
   });
 });

--- a/workers/src/trpc/routers/doll.test.ts
+++ b/workers/src/trpc/routers/doll.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestCaller, resetDatabase, getTestDb } from "../../test/helpers";
+import { insertDoll } from "../../../test/helpers/factories";
+
+const db = getTestDb();
+const caller = createTestCaller();
+
+beforeEach(async () => {
+  await resetDatabase(db);
+});
+
+describe("dollRouter", () => {
+  describe("list", () => {
+    it("空の DB で空配列を返す", async () => {
+      const result = await caller.doll.list({});
+      expect(result).toEqual([]);
+    });
+
+    it("登録済みのドールを返す", async () => {
+      await insertDoll({ db, overrides: { name: "リナ" } });
+      await insertDoll({ db, overrides: { name: "ミユ", bodySize: "SD" } });
+      const result = await caller.doll.list({});
+      expect(result).toHaveLength(2);
+    });
+
+    it("bodySize フィルターで絞り込む", async () => {
+      await insertDoll({ db, overrides: { name: "リナ", bodySize: "MSD" } });
+      await insertDoll({ db, overrides: { name: "ミユ", bodySize: "SD" } });
+      const result = await caller.doll.list({ bodySize: "SD" });
+      expect(result).toHaveLength(1);
+      expect(result[0]?.name).toBe("ミユ");
+    });
+  });
+
+  describe("get", () => {
+    it("ドールを取得する", async () => {
+      const { id } = await insertDoll({ db, overrides: { name: "リナ" } });
+      const result = await caller.doll.get({ id });
+      expect(result.name).toBe("リナ");
+    });
+
+    it("存在しない id は NOT_FOUND エラーを投げる", async () => {
+      await expect(
+        caller.doll.get({ id: "ckxx0000000000000000000z" }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("create", () => {
+    it("最低限の入力で作成できる", async () => {
+      const result = await caller.doll.create({
+        name: "新ドール",
+        bodySize: "MSD",
+      });
+      expect(result.name).toBe("新ドール");
+    });
+
+    it("optional フィールドも保存される", async () => {
+      const result = await caller.doll.create({
+        name: "新ドール",
+        bodySize: "MSD",
+        headModel: "DDH-01",
+        imageUrl: "https://example.com/a.png",
+        memo: "メモ",
+      });
+      expect(result.headModel).toBe("DDH-01");
+      expect(result.memo).toBe("メモ");
+    });
+  });
+
+  describe("update", () => {
+    it("name と memo を更新できる", async () => {
+      const { id } = await insertDoll({ db, overrides: { name: "before" } });
+      const result = await caller.doll.update({
+        id,
+        name: "after",
+        memo: "updated",
+      });
+      expect(result.name).toBe("after");
+      expect(result.memo).toBe("updated");
+    });
+
+    it("存在しないドールは NOT_FOUND を投げる", async () => {
+      await expect(
+        caller.doll.update({ id: "ckxx0000000000000000000z", name: "x" }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("delete", () => {
+    it("登録済みのドールを削除できる", async () => {
+      const { id } = await insertDoll({ db });
+      const result = await caller.doll.delete({ id });
+      expect(result.success).toBe(true);
+
+      const after = await caller.doll.list({});
+      expect(after).toHaveLength(0);
+    });
+
+    it("存在しない id で削除した場合は NOT_FOUND を返す", async () => {
+      await expect(
+        caller.doll.delete({ id: "ckxx0000000000000000000z" }),
+      ).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- vitest の **branch coverage を 82.04% → 90.05% に引き上げ** (2382/2645、+208 branches)
- フロントエンドはテスティングトロフィーに沿い**ページ単位インテグレーションテストを中心**に拡充、サポート的にユニット/シナリオテストを追加
- アプリケーションコード (実装ファイル) には一切手を加えず、テストの新規追加・既存拡充のみ

## カバレッジ内訳

| メトリクス | カバー数 | 割合 |
| --- | --- | --- |
| **branches** | **2382 / 2645** | **90.05%** ✅ |
| lines | 4710 / 4922 | 95.69% |
| statements | 4909 / 5182 | 94.73% |
| functions | 1410 / 1524 | 92.51% |

## 変更内容

### A. ページ単位インテグレーションテスト (中心)
- `src/app/settings/account/page.test.tsx`: PasswordChangeForm / ProfileForm / EmailChangeForm / DeleteAccountSection の失敗系・バリデーション・OAuth-only 分岐
- `src/app/(public)/{signin,signup}/page.test.tsx`: EmailPasswordForm / SignUpForm の異常系・redirect クエリ
- `src/app/settings/api-keys/page.test.tsx`: ApiKeyCreateSheet / ApiKeyList の発行失敗・失効失敗・キャンセル・最終使用済み表示
- `src/app/digest/page.test.tsx` (新規): 週間レポート表示
- `src/app/{garments,locations,scan,nfc-write,archive}/page.test.tsx`: 各ページの未カバー分岐 (アーカイブリンク、ユニット型ケース、未登録 QR、NFC 中止、フォーム異常系等)
- `src/app/{garments,dolls}/[id]/page.test.tsx`: 詳細ページのアーカイブ復元/完全削除フロー、LocationPicker の unit/grid ケース選択

### B. ユーティリティ・ライブラリのユニットテスト
- `src/lib/auth.test.ts` + `auth.apiKey.test.ts` (新規): better-auth クライアントラッパー全関数の成功/エラー/既定メッセージ分岐
- `src/lib/workersUrl.test.ts` (新規): env 切替分岐
- `src/stores/{digest,location,garment,bulkCapture}Atoms.test.ts` (新規): atom の各 setter / 認証分岐
- `src/hooks/useFadeInOnView.test.ts` (新規), `useNfcReader.test.ts` 拡充
- `src/components/{garment/GarmentCard, garment/bulk/BulkMetadataFormFields, chart/HorizontalBarChart}.test.tsx` (新規)
- `src/components/garment/DollCombobox.test.tsx`: Enter キーで open する分岐

### C. Workers テスト
- `workers/src/index-auth.scenario.test.ts` (新規): `/api/auth/set-password`, `/delete-user` の全分岐 (APIError / 通常 Error / 401 / 403)
- `workers/src/lib/auth-resolver.test.ts` (新規): Bearer / Cookie / session 解決の優先順位
- `workers/src/trpc/{index,routers/doll}.test.ts` (新規): protectedProcedure の auth ミドルウェアと doll ルーター CRUD
- `workers/src/repositories/scan-repository.test.ts` (新規): 空配列 early return
- `workers/src/test/{scan,sync,coordinate,location}-*.scenario.test.ts`: 拡充

## レビュー対応

[Codex review](https://github.com/butaosuinu/Dollrobe/pull/new/dmux-1778648372825) で指摘された 2 件を修正済み:
- **[P1]** `workers/src/index-auth.scenario.test.ts`: `vi.mock` factory が参照する spy を `vi.hoisted()` で巻き上げ、TDZ 起動エラーを回避
- **[P3]** `src/app/settings/account/page.test.tsx`: image 付き profile の検証を unauthenticated 検証から実際の `<img>` 検証に修正

## Test plan

- [x] `pnpm test` 全 1457 件パス
- [x] `pnpm test:workers` 全件パス
- [x] `pnpm test:coverage` で branches 90.05% を確認
- [x] `pnpm precheck` (typecheck / lint / format / i18n) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)