### PR TITLE
chore(dx): dmux worktree 間で Claude Code permissions を symlink 共有

### DIFF
--- a/.claude/scripts/sync-settings-local.sh
+++ b/.claude/scripts/sync-settings-local.sh
@@ -6,14 +6,17 @@
 set -uo pipefail
 
 TOP="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-GIT_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)" || exit 0
 
-case "$GIT_COMMON" in
-  "$TOP/.git" | ".git") exit 0 ;;
-esac
+# git-dir / git-common-dir はサブディレクトリから呼ぶと相対パス（例: "../../.git"）
+# を返すことがあるため、両方とも絶対パスに正規化してから比較する。
+# 一致すれば main worktree（= parent）なので no-op。
+GIT_DIR_RAW="$(git rev-parse --git-dir 2>/dev/null)" || exit 0
+GIT_COMMON_RAW="$(git rev-parse --git-common-dir 2>/dev/null)" || exit 0
+GIT_DIR_ABS="$(cd "$GIT_DIR_RAW" 2>/dev/null && pwd -P)" || exit 0
+GIT_COMMON_ABS="$(cd "$GIT_COMMON_RAW" 2>/dev/null && pwd -P)" || exit 0
+[ "$GIT_DIR_ABS" = "$GIT_COMMON_ABS" ] && exit 0
 
-PARENT_GIT="$(cd "$GIT_COMMON" 2>/dev/null && pwd -P)" || exit 0
-PARENT_ROOT="${PARENT_GIT%/.git}"
+PARENT_ROOT="${GIT_COMMON_ABS%/.git}"
 [ -d "$PARENT_ROOT" ] || exit 0
 
 PARENT_SETTINGS="$PARENT_ROOT/.claude/settings.local.json"
@@ -26,24 +29,27 @@ if [ -f "$WT_SETTINGS" ]; then
     mkdir -p "$(dirname "$PARENT_SETTINGS")"
     printf '{}\n' > "$PARENT_SETTINGS"
   fi
-  if command -v jq >/dev/null 2>&1; then
-    TMP="$(mktemp)"
-    if jq -s '
-      .[0] as $a | .[1] as $b |
-      ($a * $b) |
-      .permissions = (
-        (($a.permissions // {}) * ($b.permissions // {}))
-        | .allow = ((($a.permissions.allow // []) + ($b.permissions.allow // [])) | unique)
-        | .deny  = ((($a.permissions.deny  // []) + ($b.permissions.deny  // [])) | unique)
-        | .ask   = ((($a.permissions.ask   // []) + ($b.permissions.ask   // [])) | unique)
-      )
-    ' "$PARENT_SETTINGS" "$WT_SETTINGS" > "$TMP"; then
-      mv "$TMP" "$PARENT_SETTINGS"
-    else
-      rm -f "$TMP"
-    fi
+
+  # jq が無い、または merge に失敗した場合は worktree のファイルを保持して終了。
+  # （マージなしで rm すると permission が失われるため）
+  command -v jq >/dev/null 2>&1 || exit 0
+  TMP="$(mktemp)"
+  if jq -s '
+    .[0] as $a | .[1] as $b |
+    ($a * $b) |
+    .permissions = (
+      (($a.permissions // {}) * ($b.permissions // {}))
+      | .allow = ((($a.permissions.allow // []) + ($b.permissions.allow // [])) | unique)
+      | .deny  = ((($a.permissions.deny  // []) + ($b.permissions.deny  // [])) | unique)
+      | .ask   = ((($a.permissions.ask   // []) + ($b.permissions.ask   // [])) | unique)
+    )
+  ' "$PARENT_SETTINGS" "$WT_SETTINGS" > "$TMP"; then
+    mv "$TMP" "$PARENT_SETTINGS"
+    rm -f "$WT_SETTINGS"
+  else
+    rm -f "$TMP"
+    exit 0
   fi
-  rm -f "$WT_SETTINGS"
 fi
 
 mkdir -p "$(dirname "$WT_SETTINGS")"

--- a/.claude/scripts/sync-settings-local.sh
+++ b/.claude/scripts/sync-settings-local.sh
@@ -24,13 +24,28 @@ WT_SETTINGS="$TOP/.claude/settings.local.json"
 
 [ -L "$WT_SETTINGS" ] && exit 0
 
+# 並行 Stop hook の read-modify-write 競合を防ぐため parent 側に排他ロックを取る。
+# mkdir はアトミックなので flock 非依存（macOS/Linux 共通）。
+mkdir -p "$PARENT_ROOT/.claude"
+LOCK_DIR="$PARENT_ROOT/.claude/.settings-local.lock"
+LOCK_ACQUIRED=0
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    LOCK_ACQUIRED=1
+    trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+    break
+  fi
+  sleep 0.2
+done
+# 6 秒待ってもロックが取れなければ諦める（次回 Stop で再試行される）。
+[ "$LOCK_ACQUIRED" = "1" ] || exit 0
+
 if [ -f "$WT_SETTINGS" ]; then
   if [ ! -f "$PARENT_SETTINGS" ]; then
-    mkdir -p "$(dirname "$PARENT_SETTINGS")"
     printf '{}\n' > "$PARENT_SETTINGS"
   fi
 
-  # jq が無い、または merge に失敗した場合は worktree のファイルを保持して終了。
+  # jq が無い、または merge / mv に失敗した場合は worktree のファイルを保持して終了。
   # （マージなしで rm すると permission が失われるため）
   command -v jq >/dev/null 2>&1 || exit 0
   TMP="$(mktemp)"
@@ -44,8 +59,13 @@ if [ -f "$WT_SETTINGS" ]; then
       | .ask   = ((($a.permissions.ask   // []) + ($b.permissions.ask   // [])) | unique)
     )
   ' "$PARENT_SETTINGS" "$WT_SETTINGS" > "$TMP"; then
-    mv "$TMP" "$PARENT_SETTINGS"
-    rm -f "$WT_SETTINGS"
+    # mv が成功した場合のみ worktree ファイルを削除する。
+    if mv "$TMP" "$PARENT_SETTINGS"; then
+      rm -f "$WT_SETTINGS"
+    else
+      rm -f "$TMP"
+      exit 0
+    fi
   else
     rm -f "$TMP"
     exit 0

--- a/.claude/scripts/sync-settings-local.sh
+++ b/.claude/scripts/sync-settings-local.sh
@@ -49,14 +49,26 @@ if [ -f "$WT_SETTINGS" ]; then
   # （マージなしで rm すると permission が失われるため）
   command -v jq >/dev/null 2>&1 || exit 0
   TMP="$(mktemp)"
+  # allow/deny/ask を独立に union すると、parent の deny と worktree の allow など
+  # 同一ルールが複数カテゴリに残って runtime で deny が勝ってしまう。worktree 側の
+  # 判断を新しいものとして優先するため、worktree のカテゴリと衝突する parent 側の
+  # エントリを各リストから除外する。
   if jq -s '
     .[0] as $a | .[1] as $b |
+    ($a.permissions // {}) as $ap |
+    ($b.permissions // {}) as $bp |
+    ($bp.allow // []) as $b_allow |
+    ($bp.deny  // []) as $b_deny  |
+    ($bp.ask   // []) as $b_ask   |
     ($a * $b) |
     .permissions = (
-      (($a.permissions // {}) * ($b.permissions // {}))
-      | .allow = ((($a.permissions.allow // []) + ($b.permissions.allow // [])) | unique)
-      | .deny  = ((($a.permissions.deny  // []) + ($b.permissions.deny  // [])) | unique)
-      | .ask   = ((($a.permissions.ask   // []) + ($b.permissions.ask   // [])) | unique)
+      ($ap * $bp) |
+      .allow = ((($ap.allow // []) + $b_allow) | unique
+                | map(select(IN($b_deny[], $b_ask[]) | not)))
+      | .deny = ((($ap.deny // []) + $b_deny) | unique
+                | map(select(IN($b_allow[], $b_ask[]) | not)))
+      | .ask  = ((($ap.ask  // []) + $b_ask)  | unique
+                | map(select(IN($b_allow[], $b_deny[]) | not)))
     )
   ' "$PARENT_SETTINGS" "$WT_SETTINGS" > "$TMP"; then
     # mv が成功した場合のみ worktree ファイルを削除する。

--- a/.claude/scripts/sync-settings-local.sh
+++ b/.claude/scripts/sync-settings-local.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Stop hook: worktree の .claude/settings.local.json が symlink でない場合、
+# parent 側へ permission を merge してから symlink を貼り直す。
+# parent repo セッションでは no-op。
+
+set -uo pipefail
+
+TOP="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+GIT_COMMON="$(git rev-parse --git-common-dir 2>/dev/null)" || exit 0
+
+case "$GIT_COMMON" in
+  "$TOP/.git" | ".git") exit 0 ;;
+esac
+
+PARENT_GIT="$(cd "$GIT_COMMON" 2>/dev/null && pwd -P)" || exit 0
+PARENT_ROOT="${PARENT_GIT%/.git}"
+[ -d "$PARENT_ROOT" ] || exit 0
+
+PARENT_SETTINGS="$PARENT_ROOT/.claude/settings.local.json"
+WT_SETTINGS="$TOP/.claude/settings.local.json"
+
+[ -L "$WT_SETTINGS" ] && exit 0
+
+if [ -f "$WT_SETTINGS" ]; then
+  if [ ! -f "$PARENT_SETTINGS" ]; then
+    mkdir -p "$(dirname "$PARENT_SETTINGS")"
+    printf '{}\n' > "$PARENT_SETTINGS"
+  fi
+  if command -v jq >/dev/null 2>&1; then
+    TMP="$(mktemp)"
+    if jq -s '
+      .[0] as $a | .[1] as $b |
+      ($a * $b) |
+      .permissions = (
+        (($a.permissions // {}) * ($b.permissions // {}))
+        | .allow = ((($a.permissions.allow // []) + ($b.permissions.allow // [])) | unique)
+        | .deny  = ((($a.permissions.deny  // []) + ($b.permissions.deny  // [])) | unique)
+        | .ask   = ((($a.permissions.ask   // []) + ($b.permissions.ask   // [])) | unique)
+      )
+    ' "$PARENT_SETTINGS" "$WT_SETTINGS" > "$TMP"; then
+      mv "$TMP" "$PARENT_SETTINGS"
+    else
+      rm -f "$TMP"
+    fi
+  fi
+  rm -f "$WT_SETTINGS"
+fi
+
+mkdir -p "$(dirname "$WT_SETTINGS")"
+[ -f "$PARENT_SETTINGS" ] || printf '{}\n' > "$PARENT_SETTINGS"
+ln -s "$PARENT_SETTINGS" "$WT_SETTINGS"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": ".claude/scripts/sync-settings-local.sh"
+          },
+          {
+            "type": "command",
             "command": "pnpm precheck:full"
           }
         ]


### PR DESCRIPTION
## Summary

- `.claude/scripts/sync-settings-local.sh` を追加。Claude セッション終了時の Stop hook で、worktree の `.claude/settings.local.json` が regular file になっていたら parent へ jq merge してから symlink を貼り直す（worktree でなければ no-op）。
- `.claude/settings.json` の Stop hook 列に上記スクリプトを `pnpm precheck:full` の前段として追加。
- 目的: dmux worktree を作るたびに「過去に許可したコマンド」を再許可する必要をなくす。parent の `.claude/settings.local.json` を single source of truth とし、symlink 経由で全 worktree が同じ permission set を参照する。

> 補足: worktree 作成時の初期 symlink を貼るのは `.dmux-hooks/worktree_created`（user-local hook、git tracked 外）側の対応。本 PR は git tracked 部分のみを含む。`.dmux-hooks/worktree_created` 側のロジックも `merge-then-symlink` に置き換える必要がある（チーム共有不要のためローカルで反映済み）。

## Test plan

- [x] Sandbox（隔離した git worktree pair）で `sync-settings-local.sh` を 3 ケース検証
  - regular file + 追加 permission → parent merge + re-symlink 成功
  - 既に symlink → no-op（inode/mtime 不変）
  - parent repo（非 worktree）で実行 → exit 0、parent ファイル不変
- [x] worktree_created 相当の dry-run で fresh/pre-existing/二重起動の各ケース確認
- [ ] 実 dmux 環境で新規 pane を作成し、parent の許可コマンドが再許可なしで通ることを確認
- [ ] worktree 内で新規 permission を "Always allow" し、Stop 後に parent 側に反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)