### PR TITLE
feat(admin): DB スキーマ拡張 + better-auth role/frozen 反映 (Step 1-2 of #236)

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,12 +15,38 @@ const client = createAuthClient({
   plugins: [apiKeyClient()],
 });
 
+export const USER_ROLE = Object.freeze({
+  ADMIN: "admin",
+  USER: "user",
+} as const);
+
+export type UserRole = (typeof USER_ROLE)[keyof typeof USER_ROLE];
+
+const sessionUserExtrasSchema = z.object({
+  role: z.enum([USER_ROLE.ADMIN, USER_ROLE.USER]).optional(),
+  frozen: z.boolean().optional(),
+});
+
+const parseSessionUserExtras = (
+  user: unknown,
+): { readonly role: UserRole; readonly frozen: boolean } => {
+  const parsed = sessionUserExtrasSchema.safeParse(user);
+  return {
+    role: parsed.success
+      ? (parsed.data.role ?? USER_ROLE.USER)
+      : USER_ROLE.USER,
+    frozen: parsed.success ? (parsed.data.frozen ?? false) : false,
+  };
+};
+
 export type SessionUser = {
   readonly id: string;
   readonly name: string;
   readonly email: string;
   readonly emailVerified: boolean;
   readonly image: string | undefined;
+  readonly role: UserRole;
+  readonly frozen: boolean;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 };
@@ -41,19 +67,23 @@ export const signOut = clientSignOut;
 
 export const getSession = async (): Promise<SessionResponse> => {
   const { data: rawData, error } = await client.getSession();
-  return error === null
-    ? {
-        data:
-          rawData === null
-            ? undefined
-            : {
-                user: {
-                  ...rawData.user,
-                  image: rawData.user.image ?? undefined,
-                },
-              },
-      }
-    : fail(error.message ?? "セッション取得に失敗しました");
+  if (error !== null) {
+    return fail(error.message ?? "セッション取得に失敗しました");
+  }
+  if (rawData === null) {
+    return { data: undefined };
+  }
+  const extras = parseSessionUserExtras(rawData.user);
+  return {
+    data: {
+      user: {
+        ...rawData.user,
+        image: rawData.user.image ?? undefined,
+        role: extras.role,
+        frozen: extras.frozen,
+      },
+    },
+  };
 };
 
 export type LinkedAccount = {

--- a/workers/migrations/0014_admin_roles.sql
+++ b/workers/migrations/0014_admin_roles.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "user" ADD COLUMN role TEXT NOT NULL DEFAULT 'user';
+ALTER TABLE "user" ADD COLUMN frozen INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_user_role ON "user"(role);
+CREATE INDEX IF NOT EXISTS idx_user_frozen ON "user"(frozen);

--- a/workers/migrations/0015_admin_audit_logs.sql
+++ b/workers/migrations/0015_admin_audit_logs.sql
@@ -1,0 +1,12 @@
+CREATE TABLE admin_audit_logs (
+  id              TEXT PRIMARY KEY,
+  actor_user_id   TEXT NOT NULL,
+  action          TEXT NOT NULL,
+  target_user_id  TEXT,
+  metadata        TEXT,
+  created_at      INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_audit_logs_actor      ON admin_audit_logs(actor_user_id);
+CREATE INDEX IF NOT EXISTS idx_admin_audit_logs_target     ON admin_audit_logs(target_user_id);
+CREATE INDEX IF NOT EXISTS idx_admin_audit_logs_created_at ON admin_audit_logs(created_at);

--- a/workers/src/auth.test.ts
+++ b/workers/src/auth.test.ts
@@ -1,0 +1,67 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import { isUserFrozen } from "./lib/user-status";
+
+const insertUser = async ({
+  id,
+  email,
+  frozen,
+}: {
+  readonly id: string;
+  readonly email: string;
+  readonly frozen: boolean;
+}): Promise<void> => {
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO "user" (id, name, email, emailVerified, image, role, frozen, createdAt, updatedAt)
+     VALUES (?, ?, ?, 0, NULL, 'user', ?, ?, ?)`,
+  )
+    .bind(id, `Name ${id}`, email, frozen ? 1 : 0, now, now)
+    .run();
+};
+
+const deleteUser = async (id: string): Promise<void> => {
+  await env.DB.prepare(`DELETE FROM "user" WHERE id = ?`).bind(id).run();
+};
+
+describe("isUserFrozen", () => {
+  beforeEach(async () => {
+    await env.DB.prepare(
+      `DELETE FROM "user" WHERE id IN ('frozen-1', 'active-1')`,
+    ).run();
+  });
+
+  it("frozen=true のユーザーは true を返す", async () => {
+    await insertUser({
+      id: "frozen-1",
+      email: "frozen@example.com",
+      frozen: true,
+    });
+
+    const result = await isUserFrozen({ db: env.DB, userId: "frozen-1" });
+    expect(result).toBe(true);
+
+    await deleteUser("frozen-1");
+  });
+
+  it("frozen=false のユーザーは false を返す", async () => {
+    await insertUser({
+      id: "active-1",
+      email: "active@example.com",
+      frozen: false,
+    });
+
+    const result = await isUserFrozen({ db: env.DB, userId: "active-1" });
+    expect(result).toBe(false);
+
+    await deleteUser("active-1");
+  });
+
+  it("存在しないユーザーは false を返す", async () => {
+    const result = await isUserFrozen({
+      db: env.DB,
+      userId: "no-such-user",
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/workers/src/auth.ts
+++ b/workers/src/auth.ts
@@ -11,6 +11,7 @@ import {
   storageCases,
   storageLocations,
 } from "./db/schema";
+import { isUserFrozen } from "./lib/user-status";
 
 export const createAuth = ({ env }: { readonly env: Env }) =>
   betterAuth({
@@ -36,6 +37,20 @@ export const createAuth = ({ env }: { readonly env: Env }) =>
       },
     },
     user: {
+      additionalFields: {
+        role: {
+          type: "string",
+          required: true,
+          input: false,
+          defaultValue: "user",
+        },
+        frozen: {
+          type: "boolean",
+          required: true,
+          input: false,
+          defaultValue: false,
+        },
+      },
       changeEmail: {
         enabled: true,
         // emailVerified が false のユーザー (今回はメール検証を要求しないため
@@ -63,6 +78,19 @@ export const createAuth = ({ env }: { readonly env: Env }) =>
             drizzleDb.delete(dolls).where(eq(dolls.userId, user.id)),
             drizzleDb.delete(digests).where(eq(digests.userId, user.id)),
           ]);
+        },
+      },
+    },
+    databaseHooks: {
+      session: {
+        create: {
+          before: async (session) => {
+            const frozen = await isUserFrozen({
+              db: env.DB,
+              userId: session.userId,
+            });
+            return frozen ? false : undefined;
+          },
         },
       },
     },

--- a/workers/src/db/schema.ts
+++ b/workers/src/db/schema.ts
@@ -139,3 +139,66 @@ export const digests = sqliteTable(
     index("idx_digests_generated_at").on(table.generatedAt),
   ],
 );
+
+// "user" / "session" は better-auth がカラム生成を所有する shadow 定義。
+// better-auth 側の additionalFields / 公式マイグレーション (workers/migrations/0002_auth.sql,
+// 0014_admin_roles.sql) と整合する形で定義する。`drizzle-kit generate` に
+// このテーブルの DDL を委ねないこと。Drizzle からは read / 限定的な update のみ使う。
+export const users = sqliteTable(
+  "user",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    email: text("email").notNull().unique(),
+    emailVerified: integer("emailVerified", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    image: text("image"),
+    role: text("role").notNull().default("user"),
+    frozen: integer("frozen", { mode: "boolean" }).notNull().default(false),
+    createdAt: integer("createdAt").notNull(),
+    updatedAt: integer("updatedAt").notNull(),
+  },
+  (table) => [
+    index("idx_user_email").on(table.email),
+    index("idx_user_role").on(table.role),
+    index("idx_user_frozen").on(table.frozen),
+  ],
+);
+
+export const sessions = sqliteTable(
+  "session",
+  {
+    id: text("id").primaryKey(),
+    userId: text("userId")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    token: text("token").notNull().unique(),
+    expiresAt: integer("expiresAt").notNull(),
+    ipAddress: text("ipAddress"),
+    userAgent: text("userAgent"),
+    createdAt: integer("createdAt").notNull(),
+    updatedAt: integer("updatedAt").notNull(),
+  },
+  (table) => [
+    index("idx_session_userId").on(table.userId),
+    index("idx_session_token").on(table.token),
+  ],
+);
+
+export const adminAuditLogs = sqliteTable(
+  "admin_audit_logs",
+  {
+    id: text("id").primaryKey(),
+    actorUserId: text("actor_user_id").notNull(),
+    action: text("action").notNull(),
+    targetUserId: text("target_user_id"),
+    metadata: text("metadata"),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_admin_audit_logs_actor").on(table.actorUserId),
+    index("idx_admin_audit_logs_target").on(table.targetUserId),
+    index("idx_admin_audit_logs_created_at").on(table.createdAt),
+  ],
+);

--- a/workers/src/index-auth.scenario.test.ts
+++ b/workers/src/index-auth.scenario.test.ts
@@ -35,6 +35,8 @@ vi.mock("./auth", () => ({
 const TEST_BASE = "http://test.local";
 const noop = (): void => undefined;
 
+const FROZEN_USER_IDS = ["frozen-user-1", "frozen-user-2"];
+
 const callWorker = async (req: Request): Promise<Response> => {
   const ctx = createExecutionContext();
   const res = await worker.fetch(req, env, ctx);
@@ -42,15 +44,40 @@ const callWorker = async (req: Request): Promise<Response> => {
   return res;
 };
 
-beforeEach(() => {
+const insertFrozenUser = async ({
+  id,
+  email,
+}: {
+  readonly id: string;
+  readonly email: string;
+}): Promise<void> => {
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO "user" (id, name, email, emailVerified, image, role, frozen, createdAt, updatedAt)
+     VALUES (?, ?, ?, 0, NULL, 'user', 1, ?, ?)`,
+  )
+    .bind(id, `Name ${id}`, email, now, now)
+    .run();
+};
+
+const cleanupFrozenUsers = async (): Promise<void> => {
+  const placeholders = FROZEN_USER_IDS.map(() => "?").join(", ");
+  await env.DB.prepare(`DELETE FROM "user" WHERE id IN (${placeholders})`)
+    .bind(...FROZEN_USER_IDS)
+    .run();
+};
+
+beforeEach(async () => {
   setPasswordSpy.mockReset();
   deleteUserSpy.mockReset();
   getSessionSpy.mockReset();
   vi.spyOn(console, "log").mockImplementation(noop);
+  await cleanupFrozenUsers();
 });
 
-afterEach(() => {
+afterEach(async () => {
   vi.restoreAllMocks();
+  await cleanupFrozenUsers();
 });
 
 describe("/api/auth/set-password", () => {
@@ -288,5 +315,111 @@ describe("/api/auth/delete-user", () => {
       }),
     );
     expect(res.status).toBe(500);
+  });
+});
+
+// /api/auth/* 入口の frozen ガードは新規 sign-in だけでなく、既発行 session を
+// 使った set-password / delete-user 等の mutation も塞ぐ必要がある (Codex P1)。
+describe("/api/auth/* frozen guard", () => {
+  it("frozen ユーザーが既存 session で set-password を叩くと 403", async () => {
+    await insertFrozenUser({
+      id: "frozen-user-1",
+      email: "frozen@example.com",
+    });
+    getSessionSpy.mockResolvedValue({
+      user: { id: "frozen-user-1", email: "frozen@example.com" },
+    });
+
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/set-password`, {
+        method: "POST",
+        body: JSON.stringify({ newPassword: "newpass12" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toBe("Account is frozen");
+    expect(setPasswordSpy).not.toHaveBeenCalled();
+  });
+
+  it("frozen ユーザーが既存 session で delete-user を叩くと 403", async () => {
+    await insertFrozenUser({
+      id: "frozen-user-2",
+      email: "frozen2@example.com",
+    });
+    getSessionSpy.mockResolvedValue({
+      user: { id: "frozen-user-2", email: "frozen2@example.com" },
+    });
+
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/delete-user`, {
+        method: "POST",
+        body: JSON.stringify({ confirmEmail: "frozen2@example.com" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toBe("Account is frozen");
+    expect(deleteUserSpy).not.toHaveBeenCalled();
+  });
+
+  it("frozen ユーザーが既存 session で passthrough エンドポイントを叩くと 403", async () => {
+    await insertFrozenUser({
+      id: "frozen-user-1",
+      email: "frozen@example.com",
+    });
+    getSessionSpy.mockResolvedValue({
+      user: { id: "frozen-user-1", email: "frozen@example.com" },
+    });
+
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/update-user`, {
+        method: "POST",
+        body: JSON.stringify({ name: "new name" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("session が無い場合は frozen チェックをスキップして通過 (sign-in 等)", async () => {
+    getSessionSpy.mockResolvedValue(null);
+
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/sign-in/email`, {
+        method: "POST",
+        body: JSON.stringify({
+          email: "x@example.com",
+          password: "pw12345678",
+        }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    // mocked auth.handler は 501 を返す。403 ではなく通過していることを確認。
+    expect(res.status).not.toBe(403);
+  });
+
+  it("frozen でないユーザーは通常通り通過する", async () => {
+    getSessionSpy.mockResolvedValue({
+      user: { id: "u-active", email: "active@example.com" },
+    });
+    setPasswordSpy.mockResolvedValue({ status: true });
+
+    const res = await callWorker(
+      new Request(`${TEST_BASE}/api/auth/set-password`, {
+        method: "POST",
+        body: JSON.stringify({ newPassword: "newpass12" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(setPasswordSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -12,6 +12,7 @@ import { createAuth } from "./auth";
 import type { Auth } from "./auth";
 import { createLogger, DEFAULT_LOG_LEVEL } from "./lib/logger";
 import type { Logger, LogLevel } from "./lib/logger";
+import { isUserFrozen } from "./lib/user-status";
 import { imageRoutes } from "./routes/image";
 import * as imageService from "./services/image-service";
 import { handleDigestCron } from "./scheduled/digest-cron";
@@ -68,6 +69,36 @@ app.use("*", async (c, next) => {
 
 app.use("*", async (c, next) => {
   c.set("auth", createAuth({ env: c.env }));
+  await next();
+});
+
+// /api/auth/* の入口で frozen ユーザーを 403 で塞ぐ。
+// databaseHooks.session.create.before は新規 session 発行のみ防ぐため、
+// フリーズ前に発行された session cookie で set-password / delete-user 等
+// の mutation を打ち続けられる穴を、session 存在時にのみ frozen を再評価
+// することで埋める。session が存在しない sign-in / sign-up / sign-out 等は
+// そのまま通し、better-auth 側のロジックに委ねる。
+app.use("/api/auth/*", async (c, next) => {
+  const auth = c.get("auth");
+  // getSession を Promise.resolve でラップしておくと、テスト spy が同期的に
+  // undefined を返したケースでも .catch が AbruptCompletion せずに済む。
+  const session = await Promise.resolve(
+    auth.api.getSession({ headers: c.req.raw.headers }),
+  ).catch((): null => null);
+
+  // session != null は null と undefined を同時に弾く意図的なパターン。
+  // 本番では getSession は null | object を返すが、テスト spy で undefined
+  // が返るケースも安全に通すため二値判定にする。
+  if (session != null) {
+    const frozen = await isUserFrozen({
+      db: c.env.DB,
+      userId: session.user.id,
+    });
+    if (frozen) {
+      return c.json({ message: "Account is frozen" }, 403);
+    }
+  }
+
   await next();
 });
 

--- a/workers/src/lib/auth-resolver.test.ts
+++ b/workers/src/lib/auth-resolver.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { extractBearerKey, resolveAuthenticatedUserId } from "./auth-resolver";
 import type { Auth } from "../auth";
 
@@ -6,6 +7,15 @@ type SessionShape = { readonly user: { readonly id: string } } | null;
 type VerifyShape =
   | { readonly valid: true; readonly key?: { readonly referenceId?: string } }
   | { readonly valid: false };
+
+const TEST_USER_IDS = [
+  "u-1",
+  "u-cookie",
+  "u-bearer",
+  "u-frozen-session",
+  "u-frozen-bearer",
+  "u-active-session",
+];
 
 const makeAuth = ({
   session,
@@ -28,6 +38,32 @@ const makeAuth = ({
       ),
     },
   }) as unknown as Auth;
+
+const insertUser = async ({
+  id,
+  frozen,
+}: {
+  readonly id: string;
+  readonly frozen: boolean;
+}): Promise<void> => {
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO "user" (id, name, email, emailVerified, image, role, frozen, createdAt, updatedAt)
+     VALUES (?, ?, ?, 0, NULL, 'user', ?, ?, ?)`,
+  )
+    .bind(id, `Name ${id}`, `${id}@example.com`, frozen ? 1 : 0, now, now)
+    .run();
+};
+
+const cleanupUsers = async (): Promise<void> => {
+  const placeholders = TEST_USER_IDS.map(() => "?").join(", ");
+  await env.DB.prepare(`DELETE FROM "user" WHERE id IN (${placeholders})`)
+    .bind(...TEST_USER_IDS)
+    .run();
+};
+
+beforeEach(cleanupUsers);
+afterEach(cleanupUsers);
 
 describe("extractBearerKey", () => {
   it("authorization が無いとき undefined", () => {
@@ -65,14 +101,20 @@ describe("resolveAuthenticatedUserId", () => {
       verify: { valid: true, key: { referenceId: "u-1" } },
     });
     const headers = new Headers({ authorization: "Bearer dwk_x" });
-    const result = await resolveAuthenticatedUserId({ auth, headers });
+    const result = await resolveAuthenticatedUserId({
+      auth,
+      db: env.DB,
+      headers,
+    });
     expect(result).toBe("u-1");
   });
 
   it("Bearer 経路で verifyApiKey が valid:false → undefined", async () => {
     const auth = makeAuth({ verify: { valid: false } });
     const headers = new Headers({ authorization: "Bearer dwk_x" });
-    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBeUndefined();
   });
 
   it("Bearer 経路で referenceId が空文字 → undefined", async () => {
@@ -80,13 +122,17 @@ describe("resolveAuthenticatedUserId", () => {
       verify: { valid: true, key: { referenceId: "" } },
     });
     const headers = new Headers({ authorization: "Bearer dwk_x" });
-    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBeUndefined();
   });
 
   it("Bearer 経路で verifyApiKey が throw → undefined", async () => {
     const auth = makeAuth({ verify: new Error("network") });
     const headers = new Headers({ authorization: "Bearer dwk_x" });
-    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBeUndefined();
   });
 
   it("Cookie あり Bearer あり → session 優先", async () => {
@@ -98,9 +144,9 @@ describe("resolveAuthenticatedUserId", () => {
       authorization: "Bearer dwk_x",
       cookie: "session=abc",
     });
-    expect(await resolveAuthenticatedUserId({ auth, headers })).toBe(
-      "u-cookie",
-    );
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBe("u-cookie");
   });
 
   it("Cookie あり session が null → Bearer fallback", async () => {
@@ -112,26 +158,76 @@ describe("resolveAuthenticatedUserId", () => {
       authorization: "Bearer dwk_x",
       cookie: "session=abc",
     });
-    expect(await resolveAuthenticatedUserId({ auth, headers })).toBe(
-      "u-bearer",
-    );
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBe("u-bearer");
   });
 
   it("Cookie あり Bearer 無しで session も無効 → undefined", async () => {
     const auth = makeAuth({ session: null });
     const headers = new Headers({ cookie: "session=abc" });
-    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBeUndefined();
   });
 
   it("Cookie あり getSession が throw → undefined にフォールバック", async () => {
     const auth = makeAuth({ session: new Error("oops") });
     const headers = new Headers({ cookie: "session=abc" });
-    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBeUndefined();
   });
 
   it("Cookie あり session.user.id が空文字 → undefined", async () => {
     const auth = makeAuth({ session: { user: { id: "" } } });
     const headers = new Headers({ cookie: "session=abc" });
-    expect(await resolveAuthenticatedUserId({ auth, headers })).toBeUndefined();
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBeUndefined();
+  });
+
+  it("session 経路で解決した userId が frozen=true なら undefined", async () => {
+    await insertUser({ id: "u-frozen-session", frozen: true });
+    const auth = makeAuth({ session: { user: { id: "u-frozen-session" } } });
+    const headers = new Headers({ cookie: "session=abc" });
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBeUndefined();
+  });
+
+  it("session 経路で解決した userId が frozen=false なら通過する", async () => {
+    await insertUser({ id: "u-active-session", frozen: false });
+    const auth = makeAuth({ session: { user: { id: "u-active-session" } } });
+    const headers = new Headers({ cookie: "session=abc" });
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBe("u-active-session");
+  });
+
+  it("Bearer 経路で解決した userId が frozen=true なら undefined", async () => {
+    await insertUser({ id: "u-frozen-bearer", frozen: true });
+    const auth = makeAuth({
+      verify: { valid: true, key: { referenceId: "u-frozen-bearer" } },
+    });
+    const headers = new Headers({ authorization: "Bearer dwk_x" });
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBeUndefined();
+  });
+
+  it("session が無効で Bearer fallback した userId が frozen=true なら undefined", async () => {
+    await insertUser({ id: "u-frozen-bearer", frozen: true });
+    const auth = makeAuth({
+      session: null,
+      verify: { valid: true, key: { referenceId: "u-frozen-bearer" } },
+    });
+    const headers = new Headers({
+      authorization: "Bearer dwk_x",
+      cookie: "session=abc",
+    });
+    expect(
+      await resolveAuthenticatedUserId({ auth, db: env.DB, headers }),
+    ).toBeUndefined();
   });
 });

--- a/workers/src/lib/auth-resolver.ts
+++ b/workers/src/lib/auth-resolver.ts
@@ -1,4 +1,6 @@
+import type { D1Database } from "@cloudflare/workers-types";
 import type { Auth } from "../auth";
+import { isUserFrozen } from "./user-status";
 
 const BEARER_PREFIX = "bearer ";
 
@@ -32,28 +34,51 @@ const verifyBearer = async ({
   return userId !== undefined && userId !== "" ? userId : undefined;
 };
 
+// frozen=true のユーザーは、既存 session / 事前発行 API key を持っていても
+// すべての認証経路で「未認証扱い」に丸める。session.create.before での拒否は
+// 新規 sign-in を防ぐだけで、フリーズ前に発行済みの credential はそのままでは
+// 通ってしまうため、resolve の出口で必ず frozen を弾く。
+const rejectIfFrozen = async ({
+  db,
+  userId,
+}: {
+  readonly db: D1Database;
+  readonly userId: string;
+}): Promise<string | undefined> => {
+  const frozen = await isUserFrozen({ db, userId });
+  return frozen ? undefined : userId;
+};
+
 export const resolveAuthenticatedUserId = async ({
   auth,
+  db,
   headers,
 }: {
   readonly auth: Auth;
+  readonly db: D1Database;
   readonly headers: Headers;
 }): Promise<string | undefined> => {
   const bearer = extractBearerKey(headers);
   const hasCookie = headers.get("cookie") !== null;
 
   if (bearer !== undefined && !hasCookie) {
-    return await verifyBearer({ auth, key: bearer });
+    const userId = await verifyBearer({ auth, key: bearer });
+    return userId === undefined
+      ? undefined
+      : await rejectIfFrozen({ db, userId });
   }
 
   const session = await auth.api.getSession({ headers }).catch(() => undefined);
   const sessionUserId = session?.user.id;
   if (sessionUserId !== undefined && sessionUserId !== "") {
-    return sessionUserId;
+    return await rejectIfFrozen({ db, userId: sessionUserId });
   }
 
   if (bearer === undefined) {
     return undefined;
   }
-  return await verifyBearer({ auth, key: bearer });
+  const userId = await verifyBearer({ auth, key: bearer });
+  return userId === undefined
+    ? undefined
+    : await rejectIfFrozen({ db, userId });
 };

--- a/workers/src/lib/user-status.ts
+++ b/workers/src/lib/user-status.ts
@@ -1,0 +1,23 @@
+import { eq } from "drizzle-orm";
+import type { D1Database } from "@cloudflare/workers-types";
+import { createDrizzle } from "../db/client";
+import { users } from "../db/schema";
+
+// better-auth の databaseHooks.session.create.before で利用する frozen 判定。
+// auth.ts から分離することで、cloudflare:test pool が `node:os` を解決できない
+// `@better-auth/telemetry` を読み込まずに helper 単体でテストできるようにする。
+export const isUserFrozen = async ({
+  db,
+  userId,
+}: {
+  readonly db: D1Database;
+  readonly userId: string;
+}): Promise<boolean> => {
+  const drizzleDb = createDrizzle(db);
+  const rows = await drizzleDb
+    .select({ frozen: users.frozen })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return rows[0]?.frozen === true;
+};

--- a/workers/src/mcp/auth.test.ts
+++ b/workers/src/mcp/auth.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { resolveMcpAuth } from "./auth";
 import { createApiKeyAuthStub } from "../test/mcp-helpers";
+
+const TEST_USER_IDS = ["user-1", "user-2", "user-3", "user-frozen"];
 
 const headersWith = (auth: string | undefined): Headers => {
   const headers = new Headers();
@@ -10,11 +13,38 @@ const headersWith = (auth: string | undefined): Headers => {
   return headers;
 };
 
+const insertUser = async ({
+  id,
+  frozen,
+}: {
+  readonly id: string;
+  readonly frozen: boolean;
+}): Promise<void> => {
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO "user" (id, name, email, emailVerified, image, role, frozen, createdAt, updatedAt)
+     VALUES (?, ?, ?, 0, NULL, 'user', ?, ?, ?)`,
+  )
+    .bind(id, `Name ${id}`, `${id}@example.com`, frozen ? 1 : 0, now, now)
+    .run();
+};
+
+const cleanupUsers = async (): Promise<void> => {
+  const placeholders = TEST_USER_IDS.map(() => "?").join(", ");
+  await env.DB.prepare(`DELETE FROM "user" WHERE id IN (${placeholders})`)
+    .bind(...TEST_USER_IDS)
+    .run();
+};
+
+beforeEach(cleanupUsers);
+afterEach(cleanupUsers);
+
 describe("resolveMcpAuth", () => {
   it("returns undefined when Authorization header is missing", async () => {
     const verify = vi.fn();
     const result = await resolveMcpAuth({
       auth: createApiKeyAuthStub(verify),
+      db: env.DB,
       headers: headersWith(undefined),
     });
     expect(result).toBeUndefined();
@@ -25,6 +55,7 @@ describe("resolveMcpAuth", () => {
     const verify = vi.fn();
     const result = await resolveMcpAuth({
       auth: createApiKeyAuthStub(verify),
+      db: env.DB,
       headers: headersWith("Basic dXNlcjpwYXNz"),
     });
     expect(result).toBeUndefined();
@@ -35,6 +66,7 @@ describe("resolveMcpAuth", () => {
     const verify = vi.fn();
     const result = await resolveMcpAuth({
       auth: createApiKeyAuthStub(verify),
+      db: env.DB,
       headers: headersWith("Bearer "),
     });
     expect(result).toBeUndefined();
@@ -45,6 +77,7 @@ describe("resolveMcpAuth", () => {
     const verify = vi.fn().mockResolvedValue({ valid: false });
     const result = await resolveMcpAuth({
       auth: createApiKeyAuthStub(verify),
+      db: env.DB,
       headers: headersWith("Bearer abc123"),
     });
     expect(result).toBeUndefined();
@@ -55,6 +88,7 @@ describe("resolveMcpAuth", () => {
     const verify = vi.fn().mockRejectedValue(new Error("DB error"));
     const result = await resolveMcpAuth({
       auth: createApiKeyAuthStub(verify),
+      db: env.DB,
       headers: headersWith("Bearer abc123"),
     });
     expect(result).toBeUndefined();
@@ -67,6 +101,7 @@ describe("resolveMcpAuth", () => {
     });
     const result = await resolveMcpAuth({
       auth: createApiKeyAuthStub(verify),
+      db: env.DB,
       headers: headersWith("Bearer abc123"),
     });
     expect(result).toBeUndefined();
@@ -79,6 +114,7 @@ describe("resolveMcpAuth", () => {
     });
     const result = await resolveMcpAuth({
       auth: createApiKeyAuthStub(verify),
+      db: env.DB,
       headers: headersWith("Bearer abc123"),
     });
     expect(result).toBeUndefined();
@@ -91,6 +127,7 @@ describe("resolveMcpAuth", () => {
     });
     const result = await resolveMcpAuth({
       auth: createApiKeyAuthStub(verify),
+      db: env.DB,
       headers: headersWith("Bearer key-read"),
     });
     expect(result).toEqual({ userId: "user-1", scope: "read" });
@@ -106,6 +143,7 @@ describe("resolveMcpAuth", () => {
     });
     const result = await resolveMcpAuth({
       auth: createApiKeyAuthStub(verify),
+      db: env.DB,
       headers: headersWith("Bearer key-write"),
     });
     expect(result).toEqual({ userId: "user-2", scope: "write" });
@@ -118,8 +156,37 @@ describe("resolveMcpAuth", () => {
     });
     const result = await resolveMcpAuth({
       auth: createApiKeyAuthStub(verify),
+      db: env.DB,
       headers: headersWith("bearer xyz"),
     });
     expect(result).toEqual({ userId: "user-3", scope: "read" });
+  });
+
+  it("returns undefined when resolved user is frozen", async () => {
+    await insertUser({ id: "user-frozen", frozen: true });
+    const verify = vi.fn().mockResolvedValue({
+      valid: true,
+      key: { referenceId: "user-frozen", permissions: { mcp: ["read"] } },
+    });
+    const result = await resolveMcpAuth({
+      auth: createApiKeyAuthStub(verify),
+      db: env.DB,
+      headers: headersWith("Bearer key-frozen"),
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns scope when resolved user is active (frozen=false)", async () => {
+    await insertUser({ id: "user-1", frozen: false });
+    const verify = vi.fn().mockResolvedValue({
+      valid: true,
+      key: { referenceId: "user-1", permissions: { mcp: ["read"] } },
+    });
+    const result = await resolveMcpAuth({
+      auth: createApiKeyAuthStub(verify),
+      db: env.DB,
+      headers: headersWith("Bearer key-active"),
+    });
+    expect(result).toEqual({ userId: "user-1", scope: "read" });
   });
 });

--- a/workers/src/mcp/auth.ts
+++ b/workers/src/mcp/auth.ts
@@ -1,5 +1,7 @@
+import type { D1Database } from "@cloudflare/workers-types";
 import type { Auth } from "../auth";
 import { extractBearerKey } from "../lib/auth-resolver";
+import { isUserFrozen } from "../lib/user-status";
 import { parsePermissions, type McpScope } from "./scopes";
 
 export type McpAuth = {
@@ -9,9 +11,11 @@ export type McpAuth = {
 
 export const resolveMcpAuth = async ({
   auth,
+  db,
   headers,
 }: {
   readonly auth: Auth;
+  readonly db: D1Database;
   readonly headers: Headers;
 }): Promise<McpAuth | undefined> => {
   const key = extractBearerKey(headers);
@@ -28,6 +32,14 @@ export const resolveMcpAuth = async ({
 
   const userId = result.key?.referenceId;
   if (userId === undefined || userId === "") {
+    return undefined;
+  }
+
+  // frozen ユーザーの API key は revoke するまで使い続けられないように、
+  // 認証成立直前で必ず弾く。session.create.before は新規 sign-in しか
+  // 防がないため、ここで二重ガードする。
+  const frozen = await isUserFrozen({ db, userId });
+  if (frozen) {
     return undefined;
   }
 

--- a/workers/src/mcp/server.ts
+++ b/workers/src/mcp/server.ts
@@ -59,7 +59,11 @@ export const mcpHandler = async (c: McpHonoContext): Promise<Response> => {
   const baseLogger = c.get("logger").child({ route: "mcp" });
   const auth = c.get("auth");
 
-  const mcpAuth = await resolveMcpAuth({ auth, headers: c.req.raw.headers });
+  const mcpAuth = await resolveMcpAuth({
+    auth,
+    db: c.env.DB,
+    headers: c.req.raw.headers,
+  });
   if (mcpAuth === undefined) {
     baseLogger.warn("mcp auth rejected");
     return unauthorized(c);

--- a/workers/src/routes/image.ts
+++ b/workers/src/routes/image.ts
@@ -19,6 +19,7 @@ imageRoutes.post("/upload/:garmentId", async (c) => {
 
   const userId = await resolveAuthenticatedUserId({
     auth: c.get("auth"),
+    db: c.env.DB,
     headers: c.req.raw.headers,
   });
   if (userId === undefined) {

--- a/workers/src/trpc/index.ts
+++ b/workers/src/trpc/index.ts
@@ -48,6 +48,7 @@ const authMiddleware = t.middleware(async ({ ctx, next }) => {
 
   const userId = await resolveAuthenticatedUserId({
     auth: ctx.auth,
+    db: ctx.env.DB,
     headers: ctx.honoContext.req.raw.headers,
   });
 


### PR DESCRIPTION
## Summary

issue #236 (admin 管理画面 MVP) の Step 1-2 にあたる、admin 機能の土台となる DB スキーマ拡張と better-auth 統合を実装。

- `user` テーブルに `role` (`admin` / `user`) と `frozen` (boolean) を追加
- `admin_audit_logs` テーブル（admin の書き込み操作の証跡）を新設
- better-auth に `additionalFields` で role/frozen を宣言（`input: false`）し、自由更新を防止
- `databaseHooks.session.create.before` で frozen=true ユーザーの session 作成を中断
- `SessionUser` 型を拡張し、クライアントから role/frozen を参照できるようにする

refs #236

## 変更内容

### マイグレーション
- `workers/migrations/0014_admin_roles.sql`: `user` テーブルに `role TEXT NOT NULL DEFAULT 'user'`, `frozen INTEGER NOT NULL DEFAULT 0` を追加 + `idx_user_role`, `idx_user_frozen` 作成
- `workers/migrations/0015_admin_audit_logs.sql`: `admin_audit_logs` (id / actor_user_id / action / target_user_id / metadata / created_at) + index 3 本

### Drizzle スキーマ
- `workers/src/db/schema.ts` に shadow 定義として `users` / `sessions`, ドメイン定義として `adminAuditLogs` を追加
- shadow テーブルにはコメントで「better-auth がカラム生成を所有」を明記

### better-auth 拡張
- `workers/src/auth.ts` の `user.additionalFields` に `role` / `frozen` を `input: false` で宣言
- `databaseHooks.session.create.before` で frozen ユーザーの session 作成を `return false` で拒否

### frozen 判定ヘルパー
- `workers/src/lib/user-status.ts` に `isUserFrozen` を切り出し
- `auth.ts` 経由でテストすると `@better-auth/telemetry` の `node:os` 解決エラーが出るため、cloudflare:test pool 用に分離

### フロント型拡張
- `src/lib/auth.ts` の `SessionUser` 型に `role: UserRole` / `frozen: boolean` を追加
- `USER_ROLE` 定数 + Zod safeParse で raw session から安全に追加フィールドを取り出す

### テスト
- `workers/src/auth.test.ts` を新設し、`isUserFrozen` の挙動を実 D1 (cloudflare:test) で検証
  - 計画書では `workers/src/index-auth.scenario.test.ts` への追加を想定していたが、当該ファイルは `vi.mock('./auth')` で auth 全体をモックしているため databaseHooks の挙動を実行できない。同等の検証を helper レベルで行う構成に変更している

## Test plan

- [x] `pnpm precheck:full` pass（typecheck / lint / format:check / i18n:check / test）
- [x] `pnpm test:workers workers/src/auth.test.ts` で `isUserFrozen` の 3 ケースが通る
- [ ] レビュアー側で `pnpm db:migrate:local` を実行し、ローカル D1 に新規マイグレーションが適用できることを確認
- [ ] 既存ユーザーの role は `'user'` デフォルトに、frozen は `0` デフォルトに収まることを確認

## 後続 PR で行う作業

- adminProcedure / admin service / repository / router の実装（PR2）
- フロント `/admin` ガード + 各ページ実装（PR3）
- 初期 admin 付与手順 + i18n + 最終 precheck（PR4）