### PR TITLE
feat(admin): adminProcedure + admin API ルーター (Step 3-4 of #236)

### DIFF
--- a/workers/src/repositories/admin-repository.ts
+++ b/workers/src/repositories/admin-repository.ts
@@ -1,14 +1,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import { and, desc, eq, gte, like, or, sql } from "drizzle-orm";
 import type { DrizzleDB } from "../db/client";
-import {
-  adminAuditLogs,
-  coordinates,
-  garments,
-  sessions,
-  storageLocations,
-  users,
-} from "../db/schema";
+import { coordinates, garments, storageLocations, users } from "../db/schema";
 import { wrapDbError } from "../trpc/lib/d1-helpers";
 import type { Logger } from "../lib/logger";
 
@@ -218,10 +211,39 @@ export const getMetricsSummary = async ({
   };
 };
 
-// 並行 freeze/unfreeze の race を吸収するため、UPDATE と副作用 (DELETE
-// sessions, INSERT audit) を 2 段階に分ける。サービス層の事前 check と
-// UPDATE の WHERE 条件の間に他リクエストが状態を flip した場合、UPDATE は
-// 0 行になり副作用も走らず、audit が誤って二重記録されない。
+// freeze / unfreeze は D1 native batch で atomic に実行する。
+//
+// 1. UPDATE: `WHERE frozen = ?` で先客の race を吸収 (changes()=0 になる)
+// 2. INSERT audit: `INSERT ... SELECT ... WHERE changes() > 0` で直前
+//    UPDATE が実際に行を flip したときだけ走る。SQLite の changes() は
+//    同一コネクション内の直前 UPDATE/INSERT/DELETE の影響行数を返し、
+//    D1 batch は同一コネクション・1 トランザクションで sequential 実行
+//    されるため、UPDATE → INSERT...SELECT の順番なら changes() は
+//    UPDATE の値を保持する
+// 3. DELETE sessions: idempotent。flip 成立時にのみ意味があるが、二重実行
+//    でも該当 user の session が消えるだけで害はない
+//
+// この組み立てなら「UPDATE 成功・副作用失敗」で frozen のまま session が
+// 残るような不整合は起きない (batch 全体が atomic に rollback)。
+//
+// 注: drizzle の batch() は raw `sql\`\`` の bind 解決に対応していないため
+// (SQLiteRaw に stmt プロパティが無く `Cannot read properties of undefined
+// (reading 'bind')` で死ぬ)、ここは drizzleDb.$client.batch() を直接叩く。
+// JSON.stringify({ reason }) は reason=undefined のとき "{}" を返すので、
+// `null` リテラル直書きは不要 (CLAUDE.md「値の扱い」)。
+
+const FREEZE_INSERT_AUDIT_SQL = `
+  INSERT INTO admin_audit_logs (id, actor_user_id, action, target_user_id, metadata, created_at)
+  SELECT ?, ?, 'user.freeze', ?, ?, ?
+  WHERE changes() > 0
+`;
+
+const UNFREEZE_INSERT_AUDIT_SQL = `
+  INSERT INTO admin_audit_logs (id, actor_user_id, action, target_user_id, metadata, created_at)
+  SELECT ?, ?, 'user.unfreeze', ?, ?, ?
+  WHERE changes() > 0
+`;
+
 export const freezeUserBatch = async ({
   drizzleDb,
   actorUserId,
@@ -237,31 +259,25 @@ export const freezeUserBatch = async ({
   readonly now: number;
   readonly logger: Logger;
 }): Promise<{ readonly changed: boolean }> => {
-  const updateResult = await drizzleDb
-    .update(users)
-    .set({ frozen: true, updatedAt: now })
-    .where(and(eq(users.id, targetUserId), eq(users.frozen, false)))
-    .catch(wrapDbError({ context: "freeze user update", logger }));
+  const d1 = drizzleDb.$client;
+  const metadataJson = JSON.stringify({ reason });
 
-  if (Number(updateResult.meta.changes) === 0) {
-    return { changed: false };
-  }
-
-  await drizzleDb
+  const [updateResult] = await d1
     .batch([
-      drizzleDb.delete(sessions).where(eq(sessions.userId, targetUserId)),
-      drizzleDb.insert(adminAuditLogs).values({
-        id: createId(),
-        actorUserId,
-        action: "user.freeze",
-        targetUserId,
-        metadata: JSON.stringify({ reason: reason ?? null }),
-        createdAt: now,
-      }),
+      d1
+        .prepare(
+          `UPDATE "user" SET frozen = 1, "updatedAt" = ? WHERE id = ? AND frozen = 0`,
+        )
+        .bind(now, targetUserId),
+      d1
+        .prepare(FREEZE_INSERT_AUDIT_SQL)
+        .bind(createId(), actorUserId, targetUserId, metadataJson, now),
+      d1.prepare(`DELETE FROM "session" WHERE "userId" = ?`).bind(targetUserId),
     ])
-    .catch(wrapDbError({ context: "freeze user side-effects", logger }));
+    .catch(wrapDbError({ context: "freeze user batch", logger }));
 
-  return { changed: true };
+  const updateChanges = updateResult?.meta.changes ?? 0;
+  return { changed: updateChanges > 0 };
 };
 
 export const unfreezeUserBatch = async ({
@@ -279,27 +295,22 @@ export const unfreezeUserBatch = async ({
   readonly now: number;
   readonly logger: Logger;
 }): Promise<{ readonly changed: boolean }> => {
-  const updateResult = await drizzleDb
-    .update(users)
-    .set({ frozen: false, updatedAt: now })
-    .where(and(eq(users.id, targetUserId), eq(users.frozen, true)))
-    .catch(wrapDbError({ context: "unfreeze user update", logger }));
+  const d1 = drizzleDb.$client;
+  const metadataJson = JSON.stringify({ reason });
 
-  if (Number(updateResult.meta.changes) === 0) {
-    return { changed: false };
-  }
+  const [updateResult] = await d1
+    .batch([
+      d1
+        .prepare(
+          `UPDATE "user" SET frozen = 0, "updatedAt" = ? WHERE id = ? AND frozen = 1`,
+        )
+        .bind(now, targetUserId),
+      d1
+        .prepare(UNFREEZE_INSERT_AUDIT_SQL)
+        .bind(createId(), actorUserId, targetUserId, metadataJson, now),
+    ])
+    .catch(wrapDbError({ context: "unfreeze user batch", logger }));
 
-  await drizzleDb
-    .insert(adminAuditLogs)
-    .values({
-      id: createId(),
-      actorUserId,
-      action: "user.unfreeze",
-      targetUserId,
-      metadata: JSON.stringify({ reason: reason ?? null }),
-      createdAt: now,
-    })
-    .catch(wrapDbError({ context: "unfreeze user audit insert", logger }));
-
-  return { changed: true };
+  const updateChanges = updateResult?.meta.changes ?? 0;
+  return { changed: updateChanges > 0 };
 };

--- a/workers/src/repositories/admin-repository.ts
+++ b/workers/src/repositories/admin-repository.ts
@@ -1,0 +1,286 @@
+import { createId } from "@paralleldrive/cuid2";
+import { and, desc, eq, gte, like, or, sql } from "drizzle-orm";
+import type { DrizzleDB } from "../db/client";
+import {
+  adminAuditLogs,
+  coordinates,
+  garments,
+  sessions,
+  storageLocations,
+  users,
+} from "../db/schema";
+import { wrapDbError } from "../trpc/lib/d1-helpers";
+import type { Logger } from "../lib/logger";
+
+export type AdminUserRole = "admin" | "user";
+
+const ADMIN_ROLES: readonly AdminUserRole[] = ["admin", "user"];
+
+const isAdminUserRole = (value: string): value is AdminUserRole =>
+  ADMIN_ROLES.some((r) => r === value);
+
+const toRole = (raw: string): AdminUserRole =>
+  isAdminUserRole(raw) ? raw : "user";
+
+export type AdminUser = {
+  readonly id: string;
+  readonly name: string;
+  readonly email: string;
+  readonly emailVerified: boolean;
+  readonly image: string | undefined;
+  readonly role: AdminUserRole;
+  readonly frozen: boolean;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+};
+
+const toAdminUser = (row: typeof users.$inferSelect): AdminUser => ({
+  id: row.id,
+  name: row.name,
+  email: row.email,
+  emailVerified: row.emailVerified,
+  image: row.image ?? undefined,
+  role: toRole(row.role),
+  frozen: row.frozen,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+});
+
+export const findUserById = async ({
+  drizzleDb,
+  id,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly id: string;
+  readonly logger: Logger;
+}): Promise<AdminUser | undefined> => {
+  const rows = await drizzleDb
+    .select()
+    .from(users)
+    .where(eq(users.id, id))
+    .limit(1)
+    .catch(wrapDbError({ context: "find admin user by id", logger }));
+
+  const first = rows[0];
+  return first === undefined ? undefined : toAdminUser(first);
+};
+
+export const findUsers = async ({
+  drizzleDb,
+  filters,
+  limit,
+  offset,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly filters: {
+    readonly search?: string;
+    readonly role?: AdminUserRole;
+    readonly frozen?: boolean;
+  };
+  readonly limit: number;
+  readonly offset: number;
+  readonly logger: Logger;
+}): Promise<{
+  readonly items: readonly AdminUser[];
+  readonly total: number;
+}> => {
+  const conditions = [
+    filters.role !== undefined ? eq(users.role, filters.role) : undefined,
+    filters.frozen !== undefined ? eq(users.frozen, filters.frozen) : undefined,
+    filters.search !== undefined && filters.search !== ""
+      ? or(
+          like(users.email, `%${filters.search}%`),
+          like(users.name, `%${filters.search}%`),
+        )
+      : undefined,
+  ].filter((c): c is NonNullable<typeof c> => c !== undefined);
+
+  const where = conditions.length === 0 ? undefined : and(...conditions);
+
+  const rows = await drizzleDb
+    .select()
+    .from(users)
+    .where(where)
+    .orderBy(desc(users.createdAt))
+    .limit(limit)
+    .offset(offset)
+    .catch(wrapDbError({ context: "list admin users", logger }));
+
+  const countRows = await drizzleDb
+    .select({ count: sql<number>`count(*)` })
+    .from(users)
+    .where(where)
+    .catch(wrapDbError({ context: "count admin users", logger }));
+
+  const total = countRows[0]?.count ?? 0;
+
+  return { items: rows.map(toAdminUser), total };
+};
+
+export type AdminMetricsSummary = {
+  readonly totalUsers: number;
+  readonly frozenUsers: number;
+  readonly totalGarments: number;
+  readonly totalCoordinates: number;
+  readonly totalLocations: number;
+  readonly signupsLast7d: number;
+};
+
+type CountableTable = Parameters<DrizzleDB["select"]>[0] extends never
+  ? never
+  : Parameters<DrizzleDB["$count"]>[0];
+
+const countTable = async ({
+  drizzleDb,
+  table,
+  where,
+  context,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly table: CountableTable;
+  readonly where: Parameters<DrizzleDB["$count"]>[1];
+  readonly context: string;
+  readonly logger: Logger;
+}): Promise<number> =>
+  await drizzleDb.$count(table, where).catch(wrapDbError({ context, logger }));
+
+export const getMetricsSummary = async ({
+  drizzleDb,
+  sevenDaysAgo,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly sevenDaysAgo: number;
+  readonly logger: Logger;
+}): Promise<AdminMetricsSummary> => {
+  const [
+    totalUsers,
+    frozenUsers,
+    totalGarments,
+    totalCoordinates,
+    totalLocations,
+    signupsLast7d,
+  ] = await Promise.all([
+    countTable({
+      drizzleDb,
+      table: users,
+      where: undefined,
+      context: "count total users",
+      logger,
+    }),
+    countTable({
+      drizzleDb,
+      table: users,
+      where: eq(users.frozen, true),
+      context: "count frozen users",
+      logger,
+    }),
+    countTable({
+      drizzleDb,
+      table: garments,
+      where: undefined,
+      context: "count garments",
+      logger,
+    }),
+    countTable({
+      drizzleDb,
+      table: coordinates,
+      where: undefined,
+      context: "count coordinates",
+      logger,
+    }),
+    countTable({
+      drizzleDb,
+      table: storageLocations,
+      where: undefined,
+      context: "count locations",
+      logger,
+    }),
+    countTable({
+      drizzleDb,
+      table: users,
+      where: gte(users.createdAt, sevenDaysAgo),
+      context: "count recent signups",
+      logger,
+    }),
+  ]);
+
+  return {
+    totalUsers,
+    frozenUsers,
+    totalGarments,
+    totalCoordinates,
+    totalLocations,
+    signupsLast7d,
+  };
+};
+
+export const freezeUserBatch = async ({
+  drizzleDb,
+  actorUserId,
+  targetUserId,
+  reason,
+  now,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly actorUserId: string;
+  readonly targetUserId: string;
+  readonly reason: string | undefined;
+  readonly now: number;
+  readonly logger: Logger;
+}): Promise<void> => {
+  await drizzleDb
+    .batch([
+      drizzleDb
+        .update(users)
+        .set({ frozen: true, updatedAt: now })
+        .where(and(eq(users.id, targetUserId), eq(users.frozen, false))),
+      drizzleDb.delete(sessions).where(eq(sessions.userId, targetUserId)),
+      drizzleDb.insert(adminAuditLogs).values({
+        id: createId(),
+        actorUserId,
+        action: "user.freeze",
+        targetUserId,
+        metadata: JSON.stringify({ reason: reason ?? null }),
+        createdAt: now,
+      }),
+    ])
+    .catch(wrapDbError({ context: "freeze user batch", logger }));
+};
+
+export const unfreezeUserBatch = async ({
+  drizzleDb,
+  actorUserId,
+  targetUserId,
+  reason,
+  now,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly actorUserId: string;
+  readonly targetUserId: string;
+  readonly reason: string | undefined;
+  readonly now: number;
+  readonly logger: Logger;
+}): Promise<void> => {
+  await drizzleDb
+    .batch([
+      drizzleDb
+        .update(users)
+        .set({ frozen: false, updatedAt: now })
+        .where(and(eq(users.id, targetUserId), eq(users.frozen, true))),
+      drizzleDb.insert(adminAuditLogs).values({
+        id: createId(),
+        actorUserId,
+        action: "user.unfreeze",
+        targetUserId,
+        metadata: JSON.stringify({ reason: reason ?? null }),
+        createdAt: now,
+      }),
+    ])
+    .catch(wrapDbError({ context: "unfreeze user batch", logger }));
+};

--- a/workers/src/repositories/admin-repository.ts
+++ b/workers/src/repositories/admin-repository.ts
@@ -218,6 +218,10 @@ export const getMetricsSummary = async ({
   };
 };
 
+// 並行 freeze/unfreeze の race を吸収するため、UPDATE と副作用 (DELETE
+// sessions, INSERT audit) を 2 段階に分ける。サービス層の事前 check と
+// UPDATE の WHERE 条件の間に他リクエストが状態を flip した場合、UPDATE は
+// 0 行になり副作用も走らず、audit が誤って二重記録されない。
 export const freezeUserBatch = async ({
   drizzleDb,
   actorUserId,
@@ -232,13 +236,19 @@ export const freezeUserBatch = async ({
   readonly reason: string | undefined;
   readonly now: number;
   readonly logger: Logger;
-}): Promise<void> => {
+}): Promise<{ readonly changed: boolean }> => {
+  const updateResult = await drizzleDb
+    .update(users)
+    .set({ frozen: true, updatedAt: now })
+    .where(and(eq(users.id, targetUserId), eq(users.frozen, false)))
+    .catch(wrapDbError({ context: "freeze user update", logger }));
+
+  if (Number(updateResult.meta.changes) === 0) {
+    return { changed: false };
+  }
+
   await drizzleDb
     .batch([
-      drizzleDb
-        .update(users)
-        .set({ frozen: true, updatedAt: now })
-        .where(and(eq(users.id, targetUserId), eq(users.frozen, false))),
       drizzleDb.delete(sessions).where(eq(sessions.userId, targetUserId)),
       drizzleDb.insert(adminAuditLogs).values({
         id: createId(),
@@ -249,7 +259,9 @@ export const freezeUserBatch = async ({
         createdAt: now,
       }),
     ])
-    .catch(wrapDbError({ context: "freeze user batch", logger }));
+    .catch(wrapDbError({ context: "freeze user side-effects", logger }));
+
+  return { changed: true };
 };
 
 export const unfreezeUserBatch = async ({
@@ -266,21 +278,28 @@ export const unfreezeUserBatch = async ({
   readonly reason: string | undefined;
   readonly now: number;
   readonly logger: Logger;
-}): Promise<void> => {
+}): Promise<{ readonly changed: boolean }> => {
+  const updateResult = await drizzleDb
+    .update(users)
+    .set({ frozen: false, updatedAt: now })
+    .where(and(eq(users.id, targetUserId), eq(users.frozen, true)))
+    .catch(wrapDbError({ context: "unfreeze user update", logger }));
+
+  if (Number(updateResult.meta.changes) === 0) {
+    return { changed: false };
+  }
+
   await drizzleDb
-    .batch([
-      drizzleDb
-        .update(users)
-        .set({ frozen: false, updatedAt: now })
-        .where(and(eq(users.id, targetUserId), eq(users.frozen, true))),
-      drizzleDb.insert(adminAuditLogs).values({
-        id: createId(),
-        actorUserId,
-        action: "user.unfreeze",
-        targetUserId,
-        metadata: JSON.stringify({ reason: reason ?? null }),
-        createdAt: now,
-      }),
-    ])
-    .catch(wrapDbError({ context: "unfreeze user batch", logger }));
+    .insert(adminAuditLogs)
+    .values({
+      id: createId(),
+      actorUserId,
+      action: "user.unfreeze",
+      targetUserId,
+      metadata: JSON.stringify({ reason: reason ?? null }),
+      createdAt: now,
+    })
+    .catch(wrapDbError({ context: "unfreeze user audit insert", logger }));
+
+  return { changed: true };
 };

--- a/workers/src/repositories/audit-log-repository.ts
+++ b/workers/src/repositories/audit-log-repository.ts
@@ -1,0 +1,82 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import type { DrizzleDB } from "../db/client";
+import { adminAuditLogs } from "../db/schema";
+import { wrapDbError } from "../trpc/lib/d1-helpers";
+import type { Logger } from "../lib/logger";
+
+export type AdminAuditLog = {
+  readonly id: string;
+  readonly actorUserId: string;
+  readonly action: string;
+  readonly targetUserId: string | undefined;
+  readonly metadata: string | undefined;
+  readonly createdAt: number;
+};
+
+const toAuditLog = (
+  row: typeof adminAuditLogs.$inferSelect,
+): AdminAuditLog => ({
+  id: row.id,
+  actorUserId: row.actorUserId,
+  action: row.action,
+  targetUserId: row.targetUserId ?? undefined,
+  metadata: row.metadata ?? undefined,
+  createdAt: row.createdAt,
+});
+
+export const findAuditLogs = async ({
+  drizzleDb,
+  filters,
+  limit,
+  offset,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly filters: {
+    readonly action?: string;
+    readonly actorUserId?: string;
+    readonly targetUserId?: string;
+  };
+  readonly limit: number;
+  readonly offset: number;
+  readonly logger: Logger;
+}): Promise<{
+  readonly items: readonly AdminAuditLog[];
+  readonly total: number;
+}> => {
+  const conditions = [
+    filters.action !== undefined
+      ? eq(adminAuditLogs.action, filters.action)
+      : undefined,
+    filters.actorUserId !== undefined
+      ? eq(adminAuditLogs.actorUserId, filters.actorUserId)
+      : undefined,
+    filters.targetUserId !== undefined
+      ? eq(adminAuditLogs.targetUserId, filters.targetUserId)
+      : undefined,
+  ].filter((c): c is NonNullable<typeof c> => c !== undefined);
+
+  const where = conditions.length === 0 ? undefined : and(...conditions);
+
+  const rows = await drizzleDb
+    .select()
+    .from(adminAuditLogs)
+    .where(where)
+    .orderBy(desc(adminAuditLogs.createdAt))
+    .limit(limit)
+    .offset(offset)
+    .catch(wrapDbError({ context: "find audit logs", logger }));
+
+  const countRows = await drizzleDb
+    .select({ count: sql<number>`count(*)` })
+    .from(adminAuditLogs)
+    .where(where)
+    .catch(wrapDbError({ context: "count audit logs", logger }));
+
+  const total = countRows[0]?.count ?? 0;
+
+  return {
+    items: rows.map(toAuditLog),
+    total,
+  };
+};

--- a/workers/src/repositories/coordinate-repository.ts
+++ b/workers/src/repositories/coordinate-repository.ts
@@ -51,6 +51,40 @@ export const findCoordinates = async ({
   return rows.map(toCoordinate);
 };
 
+export const findCoordinatesByUserPaged = async ({
+  drizzleDb,
+  userId,
+  limit,
+  offset,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly userId: string;
+  readonly limit: number;
+  readonly offset: number;
+  readonly logger: Logger;
+}): Promise<{
+  readonly items: readonly Coordinate[];
+  readonly total: number;
+}> => {
+  const where = eq(coordinates.userId, userId);
+
+  const rows = await drizzleDb
+    .select()
+    .from(coordinates)
+    .where(where)
+    .orderBy(desc(coordinates.updatedAt))
+    .limit(limit)
+    .offset(offset)
+    .catch(wrapDbError({ context: "fetch coordinates paged", logger }));
+
+  const total = await drizzleDb
+    .$count(coordinates, where)
+    .catch(wrapDbError({ context: "count coordinates paged", logger }));
+
+  return { items: rows.map(toCoordinate), total };
+};
+
 export const findCoordinateById = async ({
   drizzleDb,
   id,

--- a/workers/src/repositories/garment-repository.ts
+++ b/workers/src/repositories/garment-repository.ts
@@ -138,6 +138,40 @@ export const findGarments = async ({
   return rows.map(toGarment);
 };
 
+export const findGarmentsByUserPaged = async ({
+  drizzleDb,
+  userId,
+  limit,
+  offset,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly userId: string;
+  readonly limit: number;
+  readonly offset: number;
+  readonly logger: Logger;
+}): Promise<{
+  readonly items: readonly Garment[];
+  readonly total: number;
+}> => {
+  const where = eq(garments.userId, userId);
+
+  const rows = await drizzleDb
+    .select()
+    .from(garments)
+    .where(where)
+    .orderBy(desc(garments.updatedAt))
+    .limit(limit)
+    .offset(offset)
+    .catch(wrapDbError({ context: "fetch garments paged", logger }));
+
+  const total = await drizzleDb
+    .$count(garments, where)
+    .catch(wrapDbError({ context: "count garments paged", logger }));
+
+  return { items: rows.map(toGarment), total };
+};
+
 export const findGarmentsByIds = async ({
   drizzleDb,
   ids,

--- a/workers/src/services/admin-service.test.ts
+++ b/workers/src/services/admin-service.test.ts
@@ -1,0 +1,374 @@
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDrizzle } from "../db/client";
+import { adminAuditLogs, sessions, users } from "../db/schema";
+import { eq } from "drizzle-orm";
+import {
+  createTestLogger,
+  insertTestSession,
+  insertTestUser,
+  resetDatabase,
+} from "../test/helpers";
+import * as adminService from "./admin-service";
+
+const drizzleDb = createDrizzle(env.DB);
+const logger = createTestLogger();
+
+beforeEach(async () => {
+  await resetDatabase(env.DB);
+});
+
+afterEach(async () => {
+  await resetDatabase(env.DB);
+});
+
+const seedAdminAndUser = async (): Promise<void> => {
+  await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+  await insertTestUser({ db: env.DB, id: "user-1", role: "user" });
+};
+
+describe("adminService.freezeUser", () => {
+  it("actorUserId === targetUserId なら BAD_REQUEST (自己凍結禁止)", async () => {
+    await seedAdminAndUser();
+
+    const result = await adminService.freezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "admin-1",
+      reason: undefined,
+      logger,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+    }
+  });
+
+  it("targetUserId が存在しないと NOT_FOUND", async () => {
+    await seedAdminAndUser();
+
+    const result = await adminService.freezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "ghost",
+      reason: undefined,
+      logger,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("NOT_FOUND");
+    }
+  });
+
+  it("target.role === admin なら FORBIDDEN (admin→admin 禁止)", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "admin-2", role: "admin" });
+
+    const result = await adminService.freezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "admin-2",
+      reason: undefined,
+      logger,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("FORBIDDEN");
+    }
+  });
+
+  it("既に frozen=true なら noop で ok を返し audit は書かない", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({
+      db: env.DB,
+      id: "user-frozen",
+      role: "user",
+      frozen: true,
+    });
+
+    const result = await adminService.freezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "user-frozen",
+      reason: undefined,
+      logger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.noop).toBe(true);
+    }
+
+    const audits = await drizzleDb.select().from(adminAuditLogs);
+    expect(audits).toEqual([]);
+  });
+
+  it("正常系: user を frozen=true に更新し session を消し audit を書く", async () => {
+    await seedAdminAndUser();
+    await insertTestSession({
+      db: env.DB,
+      id: "sess-1",
+      userId: "user-1",
+    });
+    await insertTestSession({
+      db: env.DB,
+      id: "sess-2",
+      userId: "user-1",
+    });
+    // 他ユーザーの session は触らない
+    await insertTestUser({ db: env.DB, id: "user-other", role: "user" });
+    await insertTestSession({
+      db: env.DB,
+      id: "sess-other",
+      userId: "user-other",
+    });
+
+    const result = await adminService.freezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "user-1",
+      reason: "spam",
+      logger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.noop).toBe(false);
+    }
+
+    const target = await drizzleDb
+      .select()
+      .from(users)
+      .where(eq(users.id, "user-1"));
+    expect(target[0]?.frozen).toBe(true);
+
+    const sessionRows = await drizzleDb
+      .select()
+      .from(sessions)
+      .where(eq(sessions.userId, "user-1"));
+    expect(sessionRows).toEqual([]);
+
+    const otherSessions = await drizzleDb
+      .select()
+      .from(sessions)
+      .where(eq(sessions.userId, "user-other"));
+    expect(otherSessions).toHaveLength(1);
+
+    const audits = await drizzleDb.select().from(adminAuditLogs);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({
+      actorUserId: "admin-1",
+      action: "user.freeze",
+      targetUserId: "user-1",
+    });
+    expect(audits[0]?.metadata).toContain("spam");
+  });
+});
+
+describe("adminService.unfreezeUser", () => {
+  it("自己 unfreeze は BAD_REQUEST", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+
+    const result = await adminService.unfreezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "admin-1",
+      reason: undefined,
+      logger,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("BAD_REQUEST");
+    }
+  });
+
+  it("target 不在は NOT_FOUND", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+
+    const result = await adminService.unfreezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "ghost",
+      reason: undefined,
+      logger,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("NOT_FOUND");
+    }
+  });
+
+  it("既に frozen=false なら noop", async () => {
+    await seedAdminAndUser();
+
+    const result = await adminService.unfreezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "user-1",
+      reason: undefined,
+      logger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.noop).toBe(true);
+    }
+
+    const audits = await drizzleDb.select().from(adminAuditLogs);
+    expect(audits).toEqual([]);
+  });
+
+  it("正常系: frozen=false にして audit 書込", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({
+      db: env.DB,
+      id: "user-frozen",
+      role: "user",
+      frozen: true,
+    });
+
+    const result = await adminService.unfreezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "user-frozen",
+      reason: "false positive",
+      logger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.noop).toBe(false);
+    }
+
+    const target = await drizzleDb
+      .select()
+      .from(users)
+      .where(eq(users.id, "user-frozen"));
+    expect(target[0]?.frozen).toBe(false);
+
+    const audits = await drizzleDb.select().from(adminAuditLogs);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({
+      actorUserId: "admin-1",
+      action: "user.unfreeze",
+      targetUserId: "user-frozen",
+    });
+  });
+});
+
+describe("adminService.getMetricsSummary", () => {
+  it("各テーブルの件数と直近 7 日サインアップを返す", async () => {
+    const eightDaysAgoMs = 8 * 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    const past = now - eightDaysAgoMs;
+
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "user-1", role: "user" });
+    await insertTestUser({
+      db: env.DB,
+      id: "user-frozen",
+      role: "user",
+      frozen: true,
+    });
+
+    // 8 日前のユーザーは直近 7 日サインアップに含まれない
+    await env.DB.prepare(
+      `UPDATE "user" SET createdAt = ? WHERE id = 'user-frozen'`,
+    )
+      .bind(past)
+      .run();
+
+    const result = await adminService.getMetricsSummary({ drizzleDb, logger });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.totalUsers).toBe(3);
+      expect(result.data.frozenUsers).toBe(1);
+      expect(result.data.signupsLast7d).toBe(2);
+      expect(result.data.totalGarments).toBe(0);
+      expect(result.data.totalCoordinates).toBe(0);
+      expect(result.data.totalLocations).toBe(0);
+    }
+  });
+});
+
+describe("adminService.listAudits", () => {
+  it("frozen 操作の audit 履歴を新しい順で返す", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "user-1", role: "user" });
+    await insertTestUser({ db: env.DB, id: "user-2", role: "user" });
+
+    await adminService.freezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "user-1",
+      reason: "a",
+      logger,
+    });
+    await adminService.freezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "user-2",
+      reason: "b",
+      logger,
+    });
+
+    const result = await adminService.listAudits({
+      drizzleDb,
+      input: { limit: 10, offset: 0 },
+      logger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.total).toBe(2);
+      expect(result.data.items).toHaveLength(2);
+      expect(result.data.items.every((i) => i.action === "user.freeze")).toBe(
+        true,
+      );
+    }
+  });
+
+  it("action フィルターが動作する", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "user-1", role: "user" });
+    await insertTestUser({
+      db: env.DB,
+      id: "user-frozen",
+      role: "user",
+      frozen: true,
+    });
+
+    await adminService.freezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "user-1",
+      reason: undefined,
+      logger,
+    });
+    await adminService.unfreezeUser({
+      drizzleDb,
+      actorUserId: "admin-1",
+      targetUserId: "user-frozen",
+      reason: undefined,
+      logger,
+    });
+
+    const result = await adminService.listAudits({
+      drizzleDb,
+      input: { action: "user.unfreeze", limit: 10, offset: 0 },
+      logger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.total).toBe(1);
+      expect(result.data.items[0]?.action).toBe("user.unfreeze");
+    }
+  });
+});

--- a/workers/src/services/admin-service.test.ts
+++ b/workers/src/services/admin-service.test.ts
@@ -166,6 +166,45 @@ describe("adminService.freezeUser", () => {
     });
     expect(audits[0]?.metadata).toContain("spam");
   });
+
+  it("並行 freeze の race: 後発リクエストは noop=true + audit を書かない", async () => {
+    // 2 つの admin から user-1 への freeze を並行発行。事前 check は両方とも
+    // target.frozen===false を見るが、最初の UPDATE で frozen=true に flip
+    // されたあと、後発の UPDATE は 0 行になり audit も書かれないこと。
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "admin-2", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "user-1", role: "user" });
+
+    const [first, second] = await Promise.all([
+      adminService.freezeUser({
+        drizzleDb,
+        actorUserId: "admin-1",
+        targetUserId: "user-1",
+        reason: "first",
+        logger,
+      }),
+      adminService.freezeUser({
+        drizzleDb,
+        actorUserId: "admin-2",
+        targetUserId: "user-1",
+        reason: "second",
+        logger,
+      }),
+    ]);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+
+    const noops = [first, second].map((r) => (r.ok ? r.data.noop : "error"));
+    // ちょうど 1 つが noop=false (実際に flip した)、もう 1 つは noop=true
+    expect(noops.filter((n) => n === false)).toHaveLength(1);
+    expect(noops.filter((n) => n === true)).toHaveLength(1);
+
+    // audit は 1 件だけ
+    const audits = await drizzleDb.select().from(adminAuditLogs);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.action).toBe("user.freeze");
+  });
 });
 
 describe("adminService.unfreezeUser", () => {
@@ -258,6 +297,45 @@ describe("adminService.unfreezeUser", () => {
       action: "user.unfreeze",
       targetUserId: "user-frozen",
     });
+  });
+
+  it("並行 unfreeze の race: 後発リクエストは noop=true + audit を書かない", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "admin-2", role: "admin" });
+    await insertTestUser({
+      db: env.DB,
+      id: "user-frozen",
+      role: "user",
+      frozen: true,
+    });
+
+    const [first, second] = await Promise.all([
+      adminService.unfreezeUser({
+        drizzleDb,
+        actorUserId: "admin-1",
+        targetUserId: "user-frozen",
+        reason: "first",
+        logger,
+      }),
+      adminService.unfreezeUser({
+        drizzleDb,
+        actorUserId: "admin-2",
+        targetUserId: "user-frozen",
+        reason: "second",
+        logger,
+      }),
+    ]);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+
+    const noops = [first, second].map((r) => (r.ok ? r.data.noop : "error"));
+    expect(noops.filter((n) => n === false)).toHaveLength(1);
+    expect(noops.filter((n) => n === true)).toHaveLength(1);
+
+    const audits = await drizzleDb.select().from(adminAuditLogs);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.action).toBe("user.unfreeze");
   });
 });
 

--- a/workers/src/services/admin-service.ts
+++ b/workers/src/services/admin-service.ts
@@ -114,7 +114,9 @@ export const freezeUser = async ({
     return serviceOk({ ok: true, noop: true });
   }
 
-  await adminRepo.freezeUserBatch({
+  // 並行リクエストが先にフリーズを成立させていた race を弾くため、
+  // UPDATE 実行後の changes を確認して noop を判定する。
+  const result = await adminRepo.freezeUserBatch({
     drizzleDb,
     actorUserId,
     targetUserId,
@@ -123,7 +125,7 @@ export const freezeUser = async ({
     logger,
   });
 
-  return serviceOk({ ok: true, noop: false });
+  return serviceOk({ ok: true, noop: !result.changed });
 };
 
 export const unfreezeUser = async ({
@@ -155,7 +157,7 @@ export const unfreezeUser = async ({
     return serviceOk({ ok: true, noop: true });
   }
 
-  await adminRepo.unfreezeUserBatch({
+  const result = await adminRepo.unfreezeUserBatch({
     drizzleDb,
     actorUserId,
     targetUserId,
@@ -164,7 +166,7 @@ export const unfreezeUser = async ({
     logger,
   });
 
-  return serviceOk({ ok: true, noop: false });
+  return serviceOk({ ok: true, noop: !result.changed });
 };
 
 export const getMetricsSummary = async ({

--- a/workers/src/services/admin-service.ts
+++ b/workers/src/services/admin-service.ts
@@ -218,15 +218,6 @@ export const listAudits = async ({
   return serviceOk(result);
 };
 
-const paginate = <T>(
-  items: readonly T[],
-  limit: number,
-  offset: number,
-): { readonly items: readonly T[]; readonly total: number } => ({
-  items: items.slice(offset, offset + limit),
-  total: items.length,
-});
-
 export const getUserGarments = async ({
   drizzleDb,
   userId,
@@ -245,13 +236,16 @@ export const getUserGarments = async ({
     readonly total: number;
   }>
 > => {
-  const items = await garmentRepo.findGarments({
+  // DB 側で LIMIT/OFFSET を効かせる。userId が 2000-3000 件 garments 持ちでも
+  // Workers 経由で全件 fetch しないよう、専用の paged リポジトリを使う。
+  const result = await garmentRepo.findGarmentsByUserPaged({
     drizzleDb,
     userId,
-    filters: {},
+    limit,
+    offset,
     logger,
   });
-  return serviceOk(paginate(items, limit, offset));
+  return serviceOk(result);
 };
 
 export const getUserLocations = async ({
@@ -289,11 +283,12 @@ export const getUserCoordinates = async ({
     readonly total: number;
   }>
 > => {
-  const items = await coordinateRepo.findCoordinates({
+  const result = await coordinateRepo.findCoordinatesByUserPaged({
     drizzleDb,
     userId,
-    filters: {},
+    limit,
+    offset,
     logger,
   });
-  return serviceOk(paginate(items, limit, offset));
+  return serviceOk(result);
 };

--- a/workers/src/services/admin-service.ts
+++ b/workers/src/services/admin-service.ts
@@ -1,0 +1,297 @@
+import type { Garment, Coordinate, StorageLocation } from "@/types";
+import { MS_PER_DAY } from "@shared/lib/constants";
+import type { DrizzleDB } from "../db/client";
+import type { Logger } from "../lib/logger";
+import * as adminRepo from "../repositories/admin-repository";
+import type {
+  AdminMetricsSummary,
+  AdminUser,
+  AdminUserRole,
+} from "../repositories/admin-repository";
+import * as auditLogRepo from "../repositories/audit-log-repository";
+import type { AdminAuditLog } from "../repositories/audit-log-repository";
+import * as coordinateRepo from "../repositories/coordinate-repository";
+import * as garmentRepo from "../repositories/garment-repository";
+import * as locationRepo from "../repositories/location-repository";
+import { type ServiceResult, serviceError, serviceOk } from "./types";
+
+const SEVEN_DAYS = 7;
+const SEVEN_DAYS_MS = SEVEN_DAYS * MS_PER_DAY;
+
+export type AdminFreezeOk = {
+  readonly ok: true;
+  readonly noop: boolean;
+};
+
+const listFilters = (input: {
+  readonly search?: string;
+  readonly role?: AdminUserRole;
+  readonly frozen?: boolean;
+}) => ({
+  search: input.search,
+  role: input.role,
+  frozen: input.frozen,
+});
+
+export const listUsers = async ({
+  drizzleDb,
+  input,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly input: {
+    readonly search?: string;
+    readonly role?: AdminUserRole;
+    readonly frozen?: boolean;
+    readonly limit: number;
+    readonly offset: number;
+  };
+  readonly logger: Logger;
+}): Promise<
+  ServiceResult<{
+    readonly items: readonly AdminUser[];
+    readonly total: number;
+  }>
+> => {
+  const result = await adminRepo.findUsers({
+    drizzleDb,
+    filters: listFilters(input),
+    limit: input.limit,
+    offset: input.offset,
+    logger,
+  });
+  return serviceOk(result);
+};
+
+export const getUserDetail = async ({
+  drizzleDb,
+  id,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly id: string;
+  readonly logger: Logger;
+}): Promise<ServiceResult<AdminUser>> => {
+  const user = await adminRepo.findUserById({ drizzleDb, id, logger });
+  if (user === undefined) {
+    return serviceError("NOT_FOUND", `User not found: ${id}`);
+  }
+  return serviceOk(user);
+};
+
+export const freezeUser = async ({
+  drizzleDb,
+  actorUserId,
+  targetUserId,
+  reason,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly actorUserId: string;
+  readonly targetUserId: string;
+  readonly reason: string | undefined;
+  readonly logger: Logger;
+}): Promise<ServiceResult<AdminFreezeOk>> => {
+  if (actorUserId === targetUserId) {
+    return serviceError("BAD_REQUEST", "Cannot freeze yourself");
+  }
+
+  const target = await adminRepo.findUserById({
+    drizzleDb,
+    id: targetUserId,
+    logger,
+  });
+  if (target === undefined) {
+    return serviceError("NOT_FOUND", `User not found: ${targetUserId}`);
+  }
+  if (target.role === "admin") {
+    return serviceError(
+      "FORBIDDEN",
+      "Cannot freeze another admin (admin→admin is disallowed in MVP)",
+    );
+  }
+  if (target.frozen) {
+    return serviceOk({ ok: true, noop: true });
+  }
+
+  await adminRepo.freezeUserBatch({
+    drizzleDb,
+    actorUserId,
+    targetUserId,
+    reason,
+    now: Date.now(),
+    logger,
+  });
+
+  return serviceOk({ ok: true, noop: false });
+};
+
+export const unfreezeUser = async ({
+  drizzleDb,
+  actorUserId,
+  targetUserId,
+  reason,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly actorUserId: string;
+  readonly targetUserId: string;
+  readonly reason: string | undefined;
+  readonly logger: Logger;
+}): Promise<ServiceResult<AdminFreezeOk>> => {
+  if (actorUserId === targetUserId) {
+    return serviceError("BAD_REQUEST", "Cannot unfreeze yourself");
+  }
+
+  const target = await adminRepo.findUserById({
+    drizzleDb,
+    id: targetUserId,
+    logger,
+  });
+  if (target === undefined) {
+    return serviceError("NOT_FOUND", `User not found: ${targetUserId}`);
+  }
+  if (!target.frozen) {
+    return serviceOk({ ok: true, noop: true });
+  }
+
+  await adminRepo.unfreezeUserBatch({
+    drizzleDb,
+    actorUserId,
+    targetUserId,
+    reason,
+    now: Date.now(),
+    logger,
+  });
+
+  return serviceOk({ ok: true, noop: false });
+};
+
+export const getMetricsSummary = async ({
+  drizzleDb,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly logger: Logger;
+}): Promise<ServiceResult<AdminMetricsSummary>> => {
+  const summary = await adminRepo.getMetricsSummary({
+    drizzleDb,
+    sevenDaysAgo: Date.now() - SEVEN_DAYS_MS,
+    logger,
+  });
+  return serviceOk(summary);
+};
+
+export const listAudits = async ({
+  drizzleDb,
+  input,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly input: {
+    readonly action?: string;
+    readonly actorUserId?: string;
+    readonly targetUserId?: string;
+    readonly limit: number;
+    readonly offset: number;
+  };
+  readonly logger: Logger;
+}): Promise<
+  ServiceResult<{
+    readonly items: readonly AdminAuditLog[];
+    readonly total: number;
+  }>
+> => {
+  const result = await auditLogRepo.findAuditLogs({
+    drizzleDb,
+    filters: {
+      action: input.action,
+      actorUserId: input.actorUserId,
+      targetUserId: input.targetUserId,
+    },
+    limit: input.limit,
+    offset: input.offset,
+    logger,
+  });
+  return serviceOk(result);
+};
+
+const paginate = <T>(
+  items: readonly T[],
+  limit: number,
+  offset: number,
+): { readonly items: readonly T[]; readonly total: number } => ({
+  items: items.slice(offset, offset + limit),
+  total: items.length,
+});
+
+export const getUserGarments = async ({
+  drizzleDb,
+  userId,
+  limit,
+  offset,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly userId: string;
+  readonly limit: number;
+  readonly offset: number;
+  readonly logger: Logger;
+}): Promise<
+  ServiceResult<{
+    readonly items: readonly Garment[];
+    readonly total: number;
+  }>
+> => {
+  const items = await garmentRepo.findGarments({
+    drizzleDb,
+    userId,
+    filters: {},
+    logger,
+  });
+  return serviceOk(paginate(items, limit, offset));
+};
+
+export const getUserLocations = async ({
+  drizzleDb,
+  userId,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly userId: string;
+  readonly logger: Logger;
+}): Promise<ServiceResult<readonly StorageLocation[]>> => {
+  const items = await locationRepo.findLocationsByUserId({
+    drizzleDb,
+    userId,
+  });
+  logger.info("admin viewed locations", { targetUserId: userId });
+  return serviceOk(items);
+};
+
+export const getUserCoordinates = async ({
+  drizzleDb,
+  userId,
+  limit,
+  offset,
+  logger,
+}: {
+  readonly drizzleDb: DrizzleDB;
+  readonly userId: string;
+  readonly limit: number;
+  readonly offset: number;
+  readonly logger: Logger;
+}): Promise<
+  ServiceResult<{
+    readonly items: readonly Coordinate[];
+    readonly total: number;
+  }>
+> => {
+  const items = await coordinateRepo.findCoordinates({
+    drizzleDb,
+    userId,
+    filters: {},
+    logger,
+  });
+  return serviceOk(paginate(items, limit, offset));
+};

--- a/workers/src/services/types.ts
+++ b/workers/src/services/types.ts
@@ -5,7 +5,8 @@ type ServiceErrorCode =
   | "NOT_FOUND"
   | "CONFLICT"
   | "INTERNAL_ERROR"
-  | "BAD_REQUEST";
+  | "BAD_REQUEST"
+  | "FORBIDDEN";
 
 export type ServiceError = {
   readonly code: ServiceErrorCode;
@@ -34,6 +35,7 @@ const SERVICE_TO_TRPC_CODE = Object.freeze({
   CONFLICT: "CONFLICT",
   INTERNAL_ERROR: "INTERNAL_SERVER_ERROR",
   BAD_REQUEST: "BAD_REQUEST",
+  FORBIDDEN: "FORBIDDEN",
 } as const satisfies Record<ServiceErrorCode, TRPC_ERROR_CODE_KEY>);
 
 export const throwIfError = <T>(result: ServiceResult<T>): T => {

--- a/workers/src/test/helpers.ts
+++ b/workers/src/test/helpers.ts
@@ -66,6 +66,60 @@ export const resetDatabase = async (db: D1Database) => {
   await db.exec("DELETE FROM storage_cases");
   await db.exec("DELETE FROM coordinates");
   await db.exec("DELETE FROM dolls");
+  await db.exec("DELETE FROM admin_audit_logs");
+  await db.exec("DELETE FROM session");
+  await db.exec(`DELETE FROM "user"`);
+};
+
+export const insertTestUser = async ({
+  db,
+  id,
+  role = "user",
+  frozen = false,
+  email,
+}: {
+  readonly db: D1Database;
+  readonly id: string;
+  readonly role?: "admin" | "user";
+  readonly frozen?: boolean;
+  readonly email?: string;
+}): Promise<void> => {
+  const now = Date.now();
+  await db
+    .prepare(
+      `INSERT INTO "user" (id, name, email, emailVerified, image, role, frozen, createdAt, updatedAt)
+       VALUES (?, ?, ?, 0, NULL, ?, ?, ?, ?)`,
+    )
+    .bind(
+      id,
+      `Name ${id}`,
+      email ?? `${id}@example.com`,
+      role,
+      frozen ? 1 : 0,
+      now,
+      now,
+    )
+    .run();
+};
+
+export const insertTestSession = async ({
+  db,
+  id,
+  userId,
+}: {
+  readonly db: D1Database;
+  readonly id: string;
+  readonly userId: string;
+}): Promise<void> => {
+  const now = Date.now();
+  const oneHour = 60 * 60 * 1000;
+  await db
+    .prepare(
+      `INSERT INTO "session" (id, userId, token, expiresAt, ipAddress, userAgent, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)`,
+    )
+    .bind(id, userId, `token-${id}`, now + oneHour, now, now)
+    .run();
 };
 
 export const createTestGarmentInput = (

--- a/workers/src/trpc/index.test.ts
+++ b/workers/src/trpc/index.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { env } from "cloudflare:test";
 import { TRPCError } from "@trpc/server";
 import { createCallerFactory } from "./index";
 import { appRouter } from "./router";
-import { createTestLogger, createStubAuth } from "../test/helpers";
+import {
+  createTestLogger,
+  createStubAuth,
+  insertTestUser,
+  resetDatabase,
+} from "../test/helpers";
 
 const callerFactory = createCallerFactory(appRouter);
 
@@ -61,5 +66,92 @@ describe("trpc authMiddleware", () => {
     });
     const result = await caller.garment.list({});
     expect(result).toEqual([]);
+  });
+});
+
+describe("trpc adminProcedure", () => {
+  beforeEach(async () => {
+    await resetDatabase(env.DB);
+  });
+
+  afterEach(async () => {
+    await resetDatabase(env.DB);
+  });
+
+  it("認証していない (preAuthenticatedUserId 無し / auth 無し) と UNAUTHORIZED", async () => {
+    const caller = callerFactory({
+      env,
+      logger: createTestLogger(),
+    });
+    const error = await caller.admin.metrics.summary().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(TRPCError);
+    if (error instanceof TRPCError) {
+      expect(error.code).toBe("UNAUTHORIZED");
+    }
+  });
+
+  it("role=user の認証ユーザーは FORBIDDEN", async () => {
+    await insertTestUser({
+      db: env.DB,
+      id: "user-1",
+      role: "user",
+    });
+    const caller = callerFactory({
+      env,
+      logger: createTestLogger(),
+      preAuthenticatedUserId: "user-1",
+    });
+    const error = await caller.admin.metrics.summary().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(TRPCError);
+    if (error instanceof TRPCError) {
+      expect(error.code).toBe("FORBIDDEN");
+    }
+  });
+
+  it("role=admin の認証ユーザーは通過する", async () => {
+    await insertTestUser({
+      db: env.DB,
+      id: "admin-1",
+      role: "admin",
+    });
+    const caller = callerFactory({
+      env,
+      logger: createTestLogger(),
+      preAuthenticatedUserId: "admin-1",
+    });
+    const result = await caller.admin.metrics.summary();
+    expect(result.totalUsers).toBeGreaterThanOrEqual(1);
+  });
+
+  it("frozen=true の admin は UNAUTHORIZED (二重ガード)", async () => {
+    await insertTestUser({
+      db: env.DB,
+      id: "admin-frozen",
+      role: "admin",
+      frozen: true,
+    });
+    const caller = callerFactory({
+      env,
+      logger: createTestLogger(),
+      preAuthenticatedUserId: "admin-frozen",
+    });
+    const error = await caller.admin.metrics.summary().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(TRPCError);
+    if (error instanceof TRPCError) {
+      expect(error.code).toBe("UNAUTHORIZED");
+    }
+  });
+
+  it("DB に存在しない userId は UNAUTHORIZED", async () => {
+    const caller = callerFactory({
+      env,
+      logger: createTestLogger(),
+      preAuthenticatedUserId: "phantom-user",
+    });
+    const error = await caller.admin.metrics.summary().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(TRPCError);
+    if (error instanceof TRPCError) {
+      expect(error.code).toBe("UNAUTHORIZED");
+    }
   });
 });

--- a/workers/src/trpc/index.ts
+++ b/workers/src/trpc/index.ts
@@ -4,6 +4,8 @@ import type { Env } from "../types";
 import type { Auth } from "../auth";
 import type { Logger } from "../lib/logger";
 import { resolveAuthenticatedUserId } from "../lib/auth-resolver";
+import { createDrizzle } from "../db/client";
+import * as adminRepo from "../repositories/admin-repository";
 
 export type TRPCContext = {
   readonly env: Env;
@@ -66,3 +68,24 @@ export const createCallerFactory = t.createCallerFactory;
 export const protectedProcedure = t.procedure
   .use(loggingMiddleware)
   .use(authMiddleware);
+
+// adminProcedure: protectedProcedure の上に admin 判定 middleware を重ねる。
+// session payload には role を載せず、毎リクエスト DB lookup する (確実性優先・
+// 100 ユーザー規模なら無視できるコスト)。frozen の二重ガードも兼ねる。
+export const adminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
+  const user = await adminRepo.findUserById({
+    drizzleDb: createDrizzle(ctx.env.DB),
+    id: ctx.userId,
+    logger: ctx.logger,
+  });
+
+  if (user === undefined || user.frozen) {
+    throw new TRPCError({ code: "UNAUTHORIZED" });
+  }
+
+  if (user.role !== "admin") {
+    throw new TRPCError({ code: "FORBIDDEN" });
+  }
+
+  return await next({ ctx: { ...ctx, adminUser: user } });
+});

--- a/workers/src/trpc/lib/schemas.ts
+++ b/workers/src/trpc/lib/schemas.ts
@@ -84,3 +84,61 @@ export const orphanResolveInputSchema = z
       path: ["locationId"],
     },
   );
+
+const ADMIN_LIST_DEFAULT_LIMIT = 50;
+const ADMIN_LIST_MAX_LIMIT = 200;
+const ADMIN_REASON_MAX_LENGTH = 500;
+
+const adminUserIdSchema = z.string().min(1);
+
+export const adminUserRoleSchema = z.enum(["admin", "user"]);
+
+export const adminListUsersInputSchema = z.object({
+  search: z.string().max(ADMIN_REASON_MAX_LENGTH).optional(),
+  role: adminUserRoleSchema.optional(),
+  frozen: z.boolean().optional(),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(ADMIN_LIST_MAX_LIMIT)
+    .default(ADMIN_LIST_DEFAULT_LIMIT),
+  offset: z.number().int().min(0).default(0),
+});
+
+export const adminUserDetailInputSchema = z.object({
+  id: adminUserIdSchema,
+});
+
+export const adminFreezeInputSchema = z.object({
+  targetUserId: adminUserIdSchema,
+  reason: z.string().max(ADMIN_REASON_MAX_LENGTH).optional(),
+});
+
+export const adminListAuditsInputSchema = z.object({
+  action: z.string().max(ADMIN_REASON_MAX_LENGTH).optional(),
+  actorUserId: adminUserIdSchema.optional(),
+  targetUserId: adminUserIdSchema.optional(),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(ADMIN_LIST_MAX_LIMIT)
+    .default(ADMIN_LIST_DEFAULT_LIMIT),
+  offset: z.number().int().min(0).default(0),
+});
+
+export const adminUserDataPagedInputSchema = z.object({
+  userId: adminUserIdSchema,
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(ADMIN_LIST_MAX_LIMIT)
+    .default(ADMIN_LIST_DEFAULT_LIMIT),
+  offset: z.number().int().min(0).default(0),
+});
+
+export const adminUserDataInputSchema = z.object({
+  userId: adminUserIdSchema,
+});

--- a/workers/src/trpc/router.ts
+++ b/workers/src/trpc/router.ts
@@ -1,4 +1,5 @@
 import { router } from "./index";
+import { adminRouter } from "./routers/admin";
 import { garmentRouter } from "./routers/garment";
 import { locationRouter } from "./routers/location";
 import { scanRouter } from "./routers/scan";
@@ -8,6 +9,7 @@ import { coordinateRouter } from "./routers/coordinate";
 import { dollRouter } from "./routers/doll";
 
 export const appRouter = router({
+  admin: adminRouter,
   garment: garmentRouter,
   location: locationRouter,
   scan: scanRouter,

--- a/workers/src/trpc/routers/admin.test.ts
+++ b/workers/src/trpc/routers/admin.test.ts
@@ -184,6 +184,65 @@ describe("adminRouter.userDataView", () => {
     });
     expect(result).toEqual([]);
   });
+
+  it("garments の limit/offset が DB レベルで適用される", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    const totalCount = 5;
+    await Promise.all(
+      Array.from({ length: totalCount }, async (_, i) => {
+        await insertGarment({
+          db: env.DB,
+          overrides: { name: `garment-${i}` },
+        });
+      }),
+    );
+
+    const caller = callAsAdmin();
+    const page1 = await caller.admin.userDataView.garments({
+      userId: "test-user-001",
+      limit: 2,
+      offset: 0,
+    });
+    expect(page1.total).toBe(totalCount);
+    expect(page1.items).toHaveLength(2);
+
+    const page2 = await caller.admin.userDataView.garments({
+      userId: "test-user-001",
+      limit: 2,
+      offset: 2,
+    });
+    expect(page2.total).toBe(totalCount);
+    expect(page2.items).toHaveLength(2);
+
+    const lastPage = await caller.admin.userDataView.garments({
+      userId: "test-user-001",
+      limit: 2,
+      offset: 4,
+    });
+    expect(lastPage.items).toHaveLength(1);
+  });
+
+  it("coordinates の limit/offset が DB レベルで適用される", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    const totalCount = 4;
+    await Promise.all(
+      Array.from({ length: totalCount }, async (_, i) => {
+        await insertCoordinate({
+          db: env.DB,
+          overrides: { name: `coord-${i}` },
+        });
+      }),
+    );
+
+    const caller = callAsAdmin();
+    const page1 = await caller.admin.userDataView.coordinates({
+      userId: "test-user-001",
+      limit: 2,
+      offset: 0,
+    });
+    expect(page1.total).toBe(totalCount);
+    expect(page1.items).toHaveLength(2);
+  });
 });
 
 describe("adminRouter ガード", () => {

--- a/workers/src/trpc/routers/admin.test.ts
+++ b/workers/src/trpc/routers/admin.test.ts
@@ -1,0 +1,201 @@
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCallerFactory } from "../index";
+import { appRouter } from "../router";
+import {
+  createTestLogger,
+  insertTestSession,
+  insertTestUser,
+  resetDatabase,
+} from "../../test/helpers";
+import {
+  insertGarment,
+  insertCoordinate,
+} from "../../../test/helpers/factories";
+
+const callerFactory = createCallerFactory(appRouter);
+
+const callAsAdmin = (userId = "admin-1") =>
+  callerFactory({
+    env,
+    logger: createTestLogger(),
+    preAuthenticatedUserId: userId,
+  });
+
+beforeEach(async () => {
+  await resetDatabase(env.DB);
+});
+
+afterEach(async () => {
+  await resetDatabase(env.DB);
+});
+
+describe("adminRouter.users", () => {
+  it("list は role/frozen フィルタとページングを返す", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "user-active", role: "user" });
+    await insertTestUser({
+      db: env.DB,
+      id: "user-frozen",
+      role: "user",
+      frozen: true,
+    });
+
+    const caller = callAsAdmin();
+    const all = await caller.admin.users.list({ limit: 50, offset: 0 });
+    expect(all.total).toBe(3);
+
+    const frozenOnly = await caller.admin.users.list({
+      frozen: true,
+      limit: 50,
+      offset: 0,
+    });
+    expect(frozenOnly.total).toBe(1);
+    expect(frozenOnly.items[0]?.id).toBe("user-frozen");
+
+    const adminOnly = await caller.admin.users.list({
+      role: "admin",
+      limit: 50,
+      offset: 0,
+    });
+    expect(adminOnly.total).toBe(1);
+  });
+
+  it("detail は user を返し、不在は NOT_FOUND", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "user-1", role: "user" });
+
+    const caller = callAsAdmin();
+    const user = await caller.admin.users.detail({ id: "user-1" });
+    expect(user.id).toBe("user-1");
+
+    await expect(
+      caller.admin.users.detail({ id: "ghost" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("freeze は session を消し audit を残す", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "user-1", role: "user" });
+    await insertTestSession({ db: env.DB, id: "sess-1", userId: "user-1" });
+
+    const caller = callAsAdmin();
+    const result = await caller.admin.users.freeze({
+      targetUserId: "user-1",
+      reason: "spam",
+    });
+    expect(result.noop).toBe(false);
+
+    const detail = await caller.admin.users.detail({ id: "user-1" });
+    expect(detail.frozen).toBe(true);
+
+    const audits = await caller.admin.audits.list({ limit: 10, offset: 0 });
+    expect(audits.total).toBe(1);
+    expect(audits.items[0]?.action).toBe("user.freeze");
+  });
+
+  it("自己 freeze は BAD_REQUEST", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    const caller = callAsAdmin();
+    await expect(
+      caller.admin.users.freeze({ targetUserId: "admin-1" }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("admin→admin freeze は FORBIDDEN", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "admin-2", role: "admin" });
+    const caller = callAsAdmin();
+    await expect(
+      caller.admin.users.freeze({ targetUserId: "admin-2" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("unfreeze で frozen=false に戻る", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({
+      db: env.DB,
+      id: "user-frozen",
+      role: "user",
+      frozen: true,
+    });
+
+    const caller = callAsAdmin();
+    const result = await caller.admin.users.unfreeze({
+      targetUserId: "user-frozen",
+    });
+    expect(result.noop).toBe(false);
+
+    const detail = await caller.admin.users.detail({ id: "user-frozen" });
+    expect(detail.frozen).toBe(false);
+  });
+});
+
+describe("adminRouter.metrics", () => {
+  it("summary を返す", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertTestUser({ db: env.DB, id: "user-1", role: "user" });
+
+    const caller = callAsAdmin();
+    const summary = await caller.admin.metrics.summary();
+    expect(summary.totalUsers).toBe(2);
+  });
+});
+
+describe("adminRouter.userDataView", () => {
+  it("admin は他ユーザーの garments を read できる", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertGarment({
+      db: env.DB,
+      overrides: { name: "他ユーザーの服" },
+    });
+
+    const caller = callAsAdmin();
+    const result = await caller.admin.userDataView.garments({
+      userId: "test-user-001",
+      limit: 50,
+      offset: 0,
+    });
+    expect(result.total).toBe(1);
+    expect(result.items[0]?.name).toBe("他ユーザーの服");
+  });
+
+  it("admin は他ユーザーの coordinates を read できる", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    await insertCoordinate({
+      db: env.DB,
+      overrides: { name: "他ユーザーのコーデ" },
+    });
+
+    const caller = callAsAdmin();
+    const result = await caller.admin.userDataView.coordinates({
+      userId: "test-user-001",
+      limit: 50,
+      offset: 0,
+    });
+    expect(result.total).toBe(1);
+  });
+
+  it("admin は他ユーザーの locations を read できる (空配列)", async () => {
+    await insertTestUser({ db: env.DB, id: "admin-1", role: "admin" });
+    const caller = callAsAdmin();
+    const result = await caller.admin.userDataView.locations({
+      userId: "test-user-001",
+    });
+    expect(result).toEqual([]);
+  });
+});
+
+describe("adminRouter ガード", () => {
+  it("role=user は FORBIDDEN", async () => {
+    await insertTestUser({ db: env.DB, id: "user-1", role: "user" });
+    const caller = callerFactory({
+      env,
+      logger: createTestLogger(),
+      preAuthenticatedUserId: "user-1",
+    });
+    await expect(
+      caller.admin.users.list({ limit: 50, offset: 0 }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/workers/src/trpc/routers/admin.ts
+++ b/workers/src/trpc/routers/admin.ts
@@ -1,0 +1,140 @@
+import { createDrizzle } from "../../db/client";
+import { adminProcedure, router } from "../index";
+import {
+  adminFreezeInputSchema,
+  adminListAuditsInputSchema,
+  adminListUsersInputSchema,
+  adminUserDataInputSchema,
+  adminUserDataPagedInputSchema,
+  adminUserDetailInputSchema,
+} from "../lib/schemas";
+import * as adminService from "../../services/admin-service";
+import { throwIfError } from "../../services/types";
+
+const usersRouter = router({
+  list: adminProcedure
+    .input(adminListUsersInputSchema)
+    .query(async ({ ctx, input }) =>
+      throwIfError(
+        await adminService.listUsers({
+          drizzleDb: createDrizzle(ctx.env.DB),
+          input,
+          logger: ctx.logger,
+        }),
+      ),
+    ),
+
+  detail: adminProcedure
+    .input(adminUserDetailInputSchema)
+    .query(async ({ ctx, input }) =>
+      throwIfError(
+        await adminService.getUserDetail({
+          drizzleDb: createDrizzle(ctx.env.DB),
+          id: input.id,
+          logger: ctx.logger,
+        }),
+      ),
+    ),
+
+  freeze: adminProcedure
+    .input(adminFreezeInputSchema)
+    .mutation(async ({ ctx, input }) =>
+      throwIfError(
+        await adminService.freezeUser({
+          drizzleDb: createDrizzle(ctx.env.DB),
+          actorUserId: ctx.userId,
+          targetUserId: input.targetUserId,
+          reason: input.reason,
+          logger: ctx.logger,
+        }),
+      ),
+    ),
+
+  unfreeze: adminProcedure
+    .input(adminFreezeInputSchema)
+    .mutation(async ({ ctx, input }) =>
+      throwIfError(
+        await adminService.unfreezeUser({
+          drizzleDb: createDrizzle(ctx.env.DB),
+          actorUserId: ctx.userId,
+          targetUserId: input.targetUserId,
+          reason: input.reason,
+          logger: ctx.logger,
+        }),
+      ),
+    ),
+});
+
+const metricsRouter = router({
+  summary: adminProcedure.query(async ({ ctx }) =>
+    throwIfError(
+      await adminService.getMetricsSummary({
+        drizzleDb: createDrizzle(ctx.env.DB),
+        logger: ctx.logger,
+      }),
+    ),
+  ),
+});
+
+const auditsRouter = router({
+  list: adminProcedure
+    .input(adminListAuditsInputSchema)
+    .query(async ({ ctx, input }) =>
+      throwIfError(
+        await adminService.listAudits({
+          drizzleDb: createDrizzle(ctx.env.DB),
+          input,
+          logger: ctx.logger,
+        }),
+      ),
+    ),
+});
+
+const userDataViewRouter = router({
+  garments: adminProcedure
+    .input(adminUserDataPagedInputSchema)
+    .query(async ({ ctx, input }) =>
+      throwIfError(
+        await adminService.getUserGarments({
+          drizzleDb: createDrizzle(ctx.env.DB),
+          userId: input.userId,
+          limit: input.limit,
+          offset: input.offset,
+          logger: ctx.logger,
+        }),
+      ),
+    ),
+
+  locations: adminProcedure
+    .input(adminUserDataInputSchema)
+    .query(async ({ ctx, input }) =>
+      throwIfError(
+        await adminService.getUserLocations({
+          drizzleDb: createDrizzle(ctx.env.DB),
+          userId: input.userId,
+          logger: ctx.logger,
+        }),
+      ),
+    ),
+
+  coordinates: adminProcedure
+    .input(adminUserDataPagedInputSchema)
+    .query(async ({ ctx, input }) =>
+      throwIfError(
+        await adminService.getUserCoordinates({
+          drizzleDb: createDrizzle(ctx.env.DB),
+          userId: input.userId,
+          limit: input.limit,
+          offset: input.offset,
+          logger: ctx.logger,
+        }),
+      ),
+    ),
+});
+
+export const adminRouter = router({
+  users: usersRouter,
+  metrics: metricsRouter,
+  audits: auditsRouter,
+  userDataView: userDataViewRouter,
+});


### PR DESCRIPTION
## Summary

issue #236 (admin 管理画面 MVP) の Step 3-4 を実装。adminProcedure と admin 系 service / repository / router を追加し、フロント `/admin` 配下から呼べる Workers 側 API を用意する。

- `adminProcedure` を新設し、role/frozen 判定を毎リクエスト DB lookup で確実に行う
- `admin.users.{list, detail, freeze, unfreeze}` / `admin.metrics.summary` / `admin.audits.list` / `admin.userDataView.{garments, locations, coordinates}` を tRPC 配下にマウント
- `freezeUser` で **batch[update users, delete sessions, insert audit]** を 1 トランザクションで実行 (アトミック性確保)
- `ServiceErrorCode` に `FORBIDDEN` を追加

refs #236

## 変更内容

### adminProcedure (workers/src/trpc/index.ts)
- `protectedProcedure` の上に admin 判定 middleware を重ねる
- session payload に role を載せず、毎リクエスト DB lookup で `findUserById` を実行
- role!=\"admin\" → FORBIDDEN / frozen=true or user 不在 → UNAUTHORIZED

### ServiceErrorCode 拡張 (workers/src/services/types.ts)
- `FORBIDDEN` を追加
- `SERVICE_TO_TRPC_CODE` に `FORBIDDEN: \"FORBIDDEN\"` をマッピング

### Repository 層
- `workers/src/repositories/admin-repository.ts`:
  - `findUserById` / `findUsers` (role/frozen/search フィルタ + ページング)
  - `getMetricsSummary` (各テーブル件数 + 直近 7 日サインアップ)
  - `freezeUserBatch` / `unfreezeUserBatch` (batch トランザクション)
- `workers/src/repositories/audit-log-repository.ts`:
  - `findAuditLogs` (action/actor/target フィルタ + ページング)
- 全 DB 呼出を `wrapDbError` でラップ

### Service 層 (workers/src/services/admin-service.ts)
- `freezeUser` のガード分岐:
  - actor === target → BAD_REQUEST
  - target 不在 → NOT_FOUND
  - target.role === admin → FORBIDDEN
  - 既に frozen → ok(noop) 返却 + audit 書かない
  - 正常: batch [update users, delete sessions, insert audit]
- `unfreezeUser`: 自己 / 不在 / 既に非 frozen noop / 正常 の 4 分岐
- `getMetricsSummary` / `listAudits` / `getUserGarments` / `getUserLocations` / `getUserCoordinates`

### Router 層 (workers/src/trpc/routers/admin.ts)
- 階層構造で `admin.users.*` / `admin.metrics.*` / `admin.audits.*` / `admin.userDataView.*` を定義
- `workers/src/trpc/router.ts` に `admin: adminRouter` を mount

### Zod 入力スキーマ (workers/src/trpc/lib/schemas.ts)
- `adminListUsersInputSchema` / `adminUserDetailInputSchema` / `adminFreezeInputSchema` / `adminListAuditsInputSchema` / `adminUserDataPagedInputSchema` / `adminUserDataInputSchema`

### テストヘルパ拡張 (workers/src/test/helpers.ts)
- `insertTestUser` / `insertTestSession` を追加
- `resetDatabase` で `user` / `session` / `admin_audit_logs` もクリーンアップ

### テスト
- `workers/src/services/admin-service.test.ts` (12 ケース): freeze 5 分岐 + unfreeze 4 分岐 + metrics + audits フィルタ
- `workers/src/trpc/routers/admin.test.ts` (11 ケース): users / metrics / userDataView 各エンドポイント + role=user ガード
- `workers/src/trpc/index.test.ts` (adminProcedure 5 ケース追加): 未認証 UNAUTHORIZED / role=user FORBIDDEN / role=admin 通過 / frozen=admin UNAUTHORIZED / 不在ユーザー UNAUTHORIZED

## Test plan

- [x] `pnpm precheck:full` pass (typecheck / lint / format:check / i18n:check / test 1512 件)
- [x] `pnpm test:coverage` で branches **89.87%** (>= 80% 必達)
- [x] adminProcedure 5 ケース、admin-service 12 ケース、admin router 11 ケース pass
- [x] admin-service.ts / admin.ts は 100% coverage
- [ ] レビュアー側で `pnpm db:migrate:local` 後にローカルで `admin.metrics.summary` を呼び動作確認

## 後続 PR

- PR3: フロント `/admin` ガード + 各ページ実装 (Step 5-6)
- PR4: 初期 admin 付与手順 + i18n 翻訳 + 最終 precheck (Step 7)