### PR TITLE
feat(admin): /admin ガード + 各ページ実装 (Step 5-6 of #236)

### DIFF
--- a/src/app/admin/audits/page.test.tsx
+++ b/src/app/admin/audits/page.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { server } from "@/test/mocks/server";
+import { adminSessionHandler } from "@/test/mocks/handlers";
+import { trpcQuery } from "@/test/mocks/trpc/handlerFactory";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import AdminAuditsPage from "./page";
+
+const sampleLog = (
+  overrides: Partial<{ id: string; action: string }> = {},
+) => ({
+  id: overrides.id ?? "log-1",
+  actorUserId: "admin-1",
+  action: overrides.action ?? "user.freeze",
+  targetUserId: "user-x",
+  metadata: '{"reason":"spam"}',
+  createdAt: new Date("2025-06-15T10:00:00Z").getTime(),
+});
+
+describe("AdminAuditsPage", () => {
+  beforeEach(() => {
+    setupNextNavigation({ pathname: "/admin/audits" });
+    server.use(adminSessionHandler);
+  });
+
+  it("監査ログが一覧表示される", async () => {
+    server.use(
+      trpcQuery("admin.audits.list", () => ({
+        items: [
+          sampleLog({ id: "log-1", action: "user.freeze" }),
+          sampleLog({ id: "log-2", action: "user.unfreeze" }),
+        ],
+        total: 2,
+      })),
+    );
+
+    await renderWithProviders(<AdminAuditsPage />);
+
+    expect(await screen.findByText("user.freeze")).toBeInTheDocument();
+    expect(screen.getByText("user.unfreeze")).toBeInTheDocument();
+    expect(screen.getAllByText("admin-1")).toHaveLength(2);
+    expect(screen.getAllByText("user-x")).toHaveLength(2);
+    expect(screen.getAllByText(/spam/)).toHaveLength(2);
+  });
+
+  it("ログが空のとき EmptyState を表示する", async () => {
+    server.use(trpcQuery("admin.audits.list", () => ({ items: [], total: 0 })));
+
+    await renderWithProviders(<AdminAuditsPage />);
+
+    expect(
+      await screen.findByText("監査ログはまだありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("ヘッダーと説明が表示される", async () => {
+    await renderWithProviders(<AdminAuditsPage />);
+
+    expect(await screen.findByText("監査ログ")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /書き込み操作 \(凍結 \/ 解凍 等\) のみが記録されます。閲覧操作は記録されません。/,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/audits/page.test.tsx
+++ b/src/app/admin/audits/page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useHydrateAtoms } from "jotai/utils";
@@ -20,14 +20,6 @@ const HydratedAdminAuditsPage = ({
 }) => {
   useHydrateAtoms([[adminAuditsQueryAtom, initialQuery]]);
   return <AdminAuditsPage />;
-};
-
-type AuditsInput = {
-  readonly action?: string;
-  readonly actorUserId?: string;
-  readonly targetUserId?: string;
-  readonly limit: number;
-  readonly offset: number;
 };
 
 const sampleLog = (
@@ -90,17 +82,12 @@ describe("AdminAuditsPage", () => {
 
   it("Pagination の 次へ ボタンで limit ぶん offset を進めて再 fetch する", async () => {
     const user = userEvent.setup();
-    const calls: AuditsInput[] = [];
     // 1 ページぶんの件数 + 全 total を返して 2 ページ以上ある状態にする
     const page1Items = Array.from({ length: 20 }, (_, i) =>
       sampleLog({ id: `log-${i}`, action: "user.freeze" }),
     );
-    server.use(
-      trpcQuery("admin.audits.list", ({ input }) => {
-        calls.push(input as AuditsInput);
-        return { items: page1Items, total: 60 };
-      }),
-    );
+    const resolver = vi.fn(() => ({ items: page1Items, total: 60 }));
+    server.use(trpcQuery("admin.audits.list", resolver));
 
     await renderWithProviders(
       <HydratedAdminAuditsPage initialQuery={{ limit: 20, offset: 0 }} />,
@@ -116,21 +103,21 @@ describe("AdminAuditsPage", () => {
     await user.click(firstNextButton);
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.offset).toBe(20);
-      expect(lastCall?.limit).toBe(20);
+      expect(resolver).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ limit: 20, offset: 20 }),
+        }),
+      );
     });
   });
 
   it("Pagination で表示件数を変えると limit が更新され offset が 0 にリセットされる", async () => {
     const user = userEvent.setup();
-    const calls: AuditsInput[] = [];
-    server.use(
-      trpcQuery("admin.audits.list", ({ input }) => {
-        calls.push(input as AuditsInput);
-        return { items: [sampleLog({ id: "log-only" })], total: 60 };
-      }),
-    );
+    const resolver = vi.fn(() => ({
+      items: [sampleLog({ id: "log-only" })],
+      total: 60,
+    }));
+    server.use(trpcQuery("admin.audits.list", resolver));
 
     await renderWithProviders(
       <HydratedAdminAuditsPage initialQuery={{ limit: 20, offset: 40 }} />,
@@ -140,9 +127,11 @@ describe("AdminAuditsPage", () => {
     await user.selectOptions(sizeSelect, "50");
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.limit).toBe(50);
-      expect(lastCall?.offset).toBe(0);
+      expect(resolver).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ limit: 50, offset: 0 }),
+        }),
+      );
     });
   });
 });

--- a/src/app/admin/audits/page.test.tsx
+++ b/src/app/admin/audits/page.test.tsx
@@ -1,11 +1,34 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useHydrateAtoms } from "jotai/utils";
 import { server } from "@/test/mocks/server";
 import { adminSessionHandler } from "@/test/mocks/handlers";
 import { trpcQuery } from "@/test/mocks/trpc/handlerFactory";
 import { renderWithProviders } from "@/test/testUtils";
 import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import {
+  adminAuditsQueryAtom,
+  type AdminAuditsQuery,
+} from "@/stores/adminAtoms";
 import AdminAuditsPage from "./page";
+
+const HydratedAdminAuditsPage = ({
+  initialQuery,
+}: {
+  readonly initialQuery: AdminAuditsQuery;
+}) => {
+  useHydrateAtoms([[adminAuditsQueryAtom, initialQuery]]);
+  return <AdminAuditsPage />;
+};
+
+type AuditsInput = {
+  readonly action?: string;
+  readonly actorUserId?: string;
+  readonly targetUserId?: string;
+  readonly limit: number;
+  readonly offset: number;
+};
 
 const sampleLog = (
   overrides: Partial<{ id: string; action: string }> = {},
@@ -63,5 +86,63 @@ describe("AdminAuditsPage", () => {
         /書き込み操作 \(凍結 \/ 解凍 等\) のみが記録されます。閲覧操作は記録されません。/,
       ),
     ).toBeInTheDocument();
+  });
+
+  it("Pagination の 次へ ボタンで limit ぶん offset を進めて再 fetch する", async () => {
+    const user = userEvent.setup();
+    const calls: AuditsInput[] = [];
+    // 1 ページぶんの件数 + 全 total を返して 2 ページ以上ある状態にする
+    const page1Items = Array.from({ length: 20 }, (_, i) =>
+      sampleLog({ id: `log-${i}`, action: "user.freeze" }),
+    );
+    server.use(
+      trpcQuery("admin.audits.list", ({ input }) => {
+        calls.push(input as AuditsInput);
+        return { items: page1Items, total: 60 };
+      }),
+    );
+
+    await renderWithProviders(
+      <HydratedAdminAuditsPage initialQuery={{ limit: 20, offset: 0 }} />,
+    );
+
+    // Pagination が描画されたことを確認 (Suspense 解決後)
+    const nextButtons = await screen.findAllByRole("button", {
+      name: "次のページ",
+    });
+    const firstNextButton = nextButtons.at(0);
+    expect(firstNextButton).toBeInstanceOf(HTMLElement);
+    if (firstNextButton === undefined) return;
+    await user.click(firstNextButton);
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.offset).toBe(20);
+      expect(lastCall?.limit).toBe(20);
+    });
+  });
+
+  it("Pagination で表示件数を変えると limit が更新され offset が 0 にリセットされる", async () => {
+    const user = userEvent.setup();
+    const calls: AuditsInput[] = [];
+    server.use(
+      trpcQuery("admin.audits.list", ({ input }) => {
+        calls.push(input as AuditsInput);
+        return { items: [sampleLog({ id: "log-only" })], total: 60 };
+      }),
+    );
+
+    await renderWithProviders(
+      <HydratedAdminAuditsPage initialQuery={{ limit: 20, offset: 40 }} />,
+    );
+
+    const sizeSelect = await screen.findByLabelText("表示件数");
+    await user.selectOptions(sizeSelect, "50");
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.limit).toBe(50);
+      expect(lastCall?.offset).toBe(0);
+    });
   });
 });

--- a/src/app/admin/audits/page.test.tsx
+++ b/src/app/admin/audits/page.test.tsx
@@ -111,6 +111,26 @@ describe("AdminAuditsPage", () => {
     });
   });
 
+  it("items が空でも total > 0 なら Pagination を残し EmptyState は出さない (offset 範囲外回避)", async () => {
+    server.use(
+      trpcQuery("admin.audits.list", () => ({ items: [], total: 60 })),
+    );
+
+    await renderWithProviders(
+      <HydratedAdminAuditsPage initialQuery={{ limit: 20, offset: 80 }} />,
+    );
+
+    expect(
+      await screen.findByText("このページには表示するログがありません"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("監査ログはまだありません"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: "前のページ" }).length,
+    ).toBeGreaterThan(0);
+  });
+
   it("Pagination で表示件数を変えると limit が更新され offset が 0 にリセットされる", async () => {
     const user = userEvent.setup();
     const resolver = vi.fn(() => ({

--- a/src/app/admin/audits/page.tsx
+++ b/src/app/admin/audits/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { ScrollText } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
@@ -9,14 +9,27 @@ import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import EmptyState from "@/components/ui/EmptyState";
 import Pagination from "@/components/ui/Pagination";
 import Skeleton from "@/components/ui/Skeleton";
+import type { PageSize } from "@/lib/constants";
+import { PAGE_SIZES } from "@/lib/constants";
 import AuditLogTable from "@/components/admin/AuditLogTable";
-import usePagination from "@/hooks/usePagination";
-import { adminAuditsAtom } from "@/stores/adminAtoms";
+import {
+  adminAuditsAtom,
+  adminAuditsQueryAtom,
+  setAdminAuditsPageAtom,
+  setAdminAuditsPageSizeAtom,
+} from "@/stores/adminAtoms";
+
+const isPageSize = (value: number): value is PageSize =>
+  (PAGE_SIZES as readonly number[]).includes(value);
+
+const normalizePageSize = (limit: number): PageSize =>
+  isPageSize(limit) ? limit : PAGE_SIZES[0];
 
 const AuditsContent = () => {
   const result = useAtomValue(adminAuditsAtom);
-  const { paginatedItems, onChangePage, onChangePageSize, ...pagination } =
-    usePagination({ items: result.items });
+  const query = useAtomValue(adminAuditsQueryAtom);
+  const setPage = useSetAtom(setAdminAuditsPageAtom);
+  const setPageSize = useSetAtom(setAdminAuditsPageSizeAtom);
 
   if (result.items.length === 0) {
     return (
@@ -28,13 +41,22 @@ const AuditsContent = () => {
     );
   }
 
+  const pageSize = normalizePageSize(query.limit);
+  const totalPages = Math.max(1, Math.ceil(result.total / query.limit));
+  const currentPage = Math.floor(query.offset / query.limit) + 1;
+
   return (
     <div className="flex flex-col gap-3">
-      <AuditLogTable logs={paginatedItems} />
+      <AuditLogTable logs={result.items} />
       <Pagination
-        pagination={pagination}
-        onChangePage={onChangePage}
-        onChangePageSize={onChangePageSize}
+        pagination={{
+          currentPage,
+          totalPages,
+          pageSize,
+          totalCount: result.total,
+        }}
+        onChangePage={setPage}
+        onChangePageSize={setPageSize}
       />
     </div>
   );

--- a/src/app/admin/audits/page.tsx
+++ b/src/app/admin/audits/page.tsx
@@ -31,7 +31,9 @@ const AuditsContent = () => {
   const setPage = useSetAtom(setAdminAuditsPageAtom);
   const setPageSize = useSetAtom(setAdminAuditsPageSizeAtom);
 
-  if (result.items.length === 0) {
+  // total=0 でしか empty state を出さない。items.length === 0 だが total > 0 の
+  // ときは「offset が範囲外」状態。Pagination を残して別ページに戻れるようにする。
+  if (result.total === 0) {
     return (
       <EmptyState
         icon={ScrollText}
@@ -47,7 +49,13 @@ const AuditsContent = () => {
 
   return (
     <div className="flex flex-col gap-3">
-      <AuditLogTable logs={result.items} />
+      {result.items.length === 0 ? (
+        <p className="py-8 text-center text-sm text-text-tertiary">
+          <Trans>このページには表示するログがありません</Trans>
+        </p>
+      ) : (
+        <AuditLogTable logs={result.items} />
+      )}
       <Pagination
         pagination={{
           currentPage,

--- a/src/app/admin/audits/page.tsx
+++ b/src/app/admin/audits/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Suspense } from "react";
+import { useAtomValue } from "jotai";
+import { ScrollText } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
+import EmptyState from "@/components/ui/EmptyState";
+import Pagination from "@/components/ui/Pagination";
+import Skeleton from "@/components/ui/Skeleton";
+import AuditLogTable from "@/components/admin/AuditLogTable";
+import usePagination from "@/hooks/usePagination";
+import { adminAuditsAtom } from "@/stores/adminAtoms";
+
+const AuditsContent = () => {
+  const result = useAtomValue(adminAuditsAtom);
+  const { paginatedItems, onChangePage, onChangePageSize, ...pagination } =
+    usePagination({ items: result.items });
+
+  if (result.items.length === 0) {
+    return (
+      <EmptyState
+        icon={ScrollText}
+        title={t`監査ログはまだありません`}
+        description={t`凍結・解凍などの書き込み操作を行うとここに表示されます`}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <AuditLogTable logs={paginatedItems} />
+      <Pagination
+        pagination={pagination}
+        onChangePage={onChangePage}
+        onChangePageSize={onChangePageSize}
+      />
+    </div>
+  );
+};
+
+const AdminAuditsPage = () => (
+  <div className="flex flex-col gap-4">
+    <h2 className="font-display text-lg font-bold">
+      <Trans>監査ログ</Trans>
+    </h2>
+    <p className="text-sm text-text-tertiary">
+      <Trans>
+        書き込み操作 (凍結 / 解凍 等)
+        のみが記録されます。閲覧操作は記録されません。
+      </Trans>
+    </p>
+    <ErrorBoundary
+      fallback={
+        <p className="text-sm text-danger">
+          <Trans>監査ログの読み込みに失敗しました</Trans>
+        </p>
+      }
+    >
+      <Suspense fallback={<Skeleton className="h-48 rounded-xl" />}>
+        <AuditsContent />
+      </Suspense>
+    </ErrorBoundary>
+  </div>
+);
+
+export default AdminAuditsPage;

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import AdminGuard from "@/components/admin/AdminGuard";
+import AdminSideNav from "@/components/admin/AdminSideNav";
+import PageHeader from "@/components/ui/PageHeader";
+
+const AdminLayout = ({ children }: { readonly children: React.ReactNode }) => (
+  <AdminGuard>
+    <div className="flex flex-col gap-4 p-4">
+      <PageHeader
+        title={
+          <span className="flex items-center gap-2">
+            <Trans>管理画面</Trans>
+          </span>
+        }
+      />
+      <div className="flex flex-col gap-6 lg:flex-row lg:gap-8">
+        <aside className="lg:flex-shrink-0">
+          <AdminSideNav />
+        </aside>
+        <section className="flex-1 min-w-0">{children}</section>
+      </div>
+    </div>
+  </AdminGuard>
+);
+
+export default AdminLayout;

--- a/src/app/admin/page.test.tsx
+++ b/src/app/admin/page.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { server } from "@/test/mocks/server";
+import { adminSessionHandler } from "@/test/mocks/handlers";
+import { trpcQuery } from "@/test/mocks/trpc/handlerFactory";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import AdminMetricsPage from "./page";
+
+describe("AdminMetricsPage", () => {
+  beforeEach(() => {
+    setupNextNavigation({ pathname: "/admin" });
+    server.use(adminSessionHandler);
+  });
+
+  it("メトリクスの値が KPI カードに表示される", async () => {
+    server.use(
+      trpcQuery("admin.metrics.summary", () => ({
+        totalUsers: 42,
+        frozenUsers: 3,
+        totalGarments: 1234,
+        totalCoordinates: 56,
+        totalLocations: 78,
+        signupsLast7d: 9,
+      })),
+    );
+
+    await renderWithProviders(<AdminMetricsPage />);
+
+    expect(await screen.findByText("42")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+    expect(screen.getByText("56")).toBeInTheDocument();
+    expect(screen.getByText("78")).toBeInTheDocument();
+    expect(screen.getByText("9")).toBeInTheDocument();
+    expect(screen.getByText("総ユーザー数")).toBeInTheDocument();
+    expect(screen.getByText("凍結中ユーザー")).toBeInTheDocument();
+    expect(screen.getByText("直近7日のサインアップ")).toBeInTheDocument();
+  });
+
+  it("デフォルト resolver では全カードが 0 で表示される", async () => {
+    await renderWithProviders(<AdminMetricsPage />);
+
+    const zeros = await screen.findAllByText("0");
+    expect(zeros.length).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Suspense } from "react";
+import { useAtomValue } from "jotai";
+import {
+  Users,
+  Snowflake,
+  Shirt,
+  Sparkles,
+  LayoutGrid,
+  UserPlus,
+} from "lucide-react";
+import { Trans } from "@lingui/react/macro";
+import { useLingui } from "@lingui/react";
+import { msg } from "@lingui/core/macro";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
+import MetricsCard from "@/components/admin/MetricsCard";
+import Skeleton from "@/components/ui/Skeleton";
+import { adminMetricsAtom } from "@/stores/adminAtoms";
+
+const MetricsGrid = () => {
+  const summary = useAtomValue(adminMetricsAtom);
+  const { i18n } = useLingui();
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      <MetricsCard
+        icon={Users}
+        label={i18n._(msg`総ユーザー数`)}
+        value={summary.totalUsers}
+      />
+      <MetricsCard
+        icon={Snowflake}
+        label={i18n._(msg`凍結中ユーザー`)}
+        value={summary.frozenUsers}
+      />
+      <MetricsCard
+        icon={UserPlus}
+        label={i18n._(msg`直近7日のサインアップ`)}
+        value={summary.signupsLast7d}
+      />
+      <MetricsCard
+        icon={Shirt}
+        label={i18n._(msg`登録された服`)}
+        value={summary.totalGarments}
+      />
+      <MetricsCard
+        icon={Sparkles}
+        label={i18n._(msg`コーデ数`)}
+        value={summary.totalCoordinates}
+      />
+      <MetricsCard
+        icon={LayoutGrid}
+        label={i18n._(msg`収納場所数`)}
+        value={summary.totalLocations}
+      />
+    </div>
+  );
+};
+
+const MetricsSkeleton = () => (
+  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+    {Array.from({ length: 6 }).map((_, i) => (
+      <Skeleton key={i} className="h-24 rounded-xl" />
+    ))}
+  </div>
+);
+
+const AdminMetricsPage = () => (
+  <div className="flex flex-col gap-4">
+    <h2 className="font-display text-lg font-bold">
+      <Trans>メトリクスサマリ</Trans>
+    </h2>
+    <p className="text-sm text-text-tertiary">
+      <Trans>
+        リアルタイムの集計値です。サンプル数の少ない指標は今後のスナップショットで補完します。
+      </Trans>
+    </p>
+    <ErrorBoundary
+      fallback={
+        <p className="text-sm text-danger">
+          <Trans>メトリクスの読み込みに失敗しました</Trans>
+        </p>
+      }
+    >
+      <Suspense fallback={<MetricsSkeleton />}>
+        <MetricsGrid />
+      </Suspense>
+    </ErrorBoundary>
+  </div>
+);
+
+export default AdminMetricsPage;

--- a/src/app/admin/users/[id]/page.test.tsx
+++ b/src/app/admin/users/[id]/page.test.tsx
@@ -222,4 +222,40 @@ describe("UserDetailPage", () => {
       expect(callRef.current?.userId).toBe("u-target");
     });
   });
+
+  it("garments が 1 件以上あるとき名前・カテゴリ・件数フッターが表示される", async () => {
+    server.use(
+      trpcQuery("admin.users.detail", () => buildUser({ id: "u-target" })),
+      trpcQuery("admin.userDataView.garments", () => ({
+        items: [
+          {
+            id: "g-1",
+            userId: "u-target",
+            name: "黒ワンピ",
+            category: "onepiece" as const,
+            dollSizes: ["MSD" as const],
+            colors: [],
+            tags: [],
+            imageUrl: undefined,
+            locationId: undefined,
+            status: "stored" as const,
+            lastScannedAt: 0,
+            confidenceDecayDays: 30,
+            brand: undefined,
+            checkedOutAt: undefined,
+            recentCheckoutCount: 0,
+            createdAt: 0,
+            updatedAt: 0,
+          },
+        ],
+        total: 1,
+      })),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
+
+    expect(await screen.findByText("黒ワンピ")).toBeInTheDocument();
+    expect(screen.getByText("onepiece")).toBeInTheDocument();
+    expect(screen.getByText(/1 \/ 1件表示/)).toBeInTheDocument();
+  });
 });

--- a/src/app/admin/users/[id]/page.test.tsx
+++ b/src/app/admin/users/[id]/page.test.tsx
@@ -3,7 +3,11 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "@/test/mocks/server";
 import { adminSessionHandler, sessionHandler } from "@/test/mocks/handlers";
-import { trpcMutation, trpcQuery } from "@/test/mocks/trpc/handlerFactory";
+import {
+  mockTRPCError,
+  trpcMutation,
+  trpcQuery,
+} from "@/test/mocks/trpc/handlerFactory";
 import { renderWithProviders } from "@/test/testUtils";
 import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
 import UserDetailPage from "./page";
@@ -148,13 +152,14 @@ describe("UserDetailPage", () => {
     });
   });
 
-  it("ユーザーが見つからないとき not found メッセージが出る", async () => {
+  it("ユーザーが見つからない (NOT_FOUND) とき not found メッセージが出る", async () => {
     server.use(
-      // 詳細 query が rejection を返すケース。adminAtoms 側で .catch して
-      // undefined にダウングレードする経路を踏む。
+      // NOT_FOUND は adminUserDetailAtomFamily 側で .catch → undefined に
+      // ダウングレードされ、Detail page が「このユーザーは見つかりません」を表示する。
       trpcQuery(
         "admin.users.detail",
-        async () => await Promise.reject(new Error("NOT_FOUND")),
+        async () =>
+          await Promise.reject(mockTRPCError("NOT_FOUND", "User not found")),
       ),
     );
 
@@ -163,6 +168,42 @@ describe("UserDetailPage", () => {
     expect(
       await screen.findByText("このユーザーは見つかりません"),
     ).toBeInTheDocument();
+  });
+
+  it("詳細取得が transient エラー (INTERNAL_SERVER_ERROR) のとき ErrorBoundary fallback が出る", async () => {
+    // React が ErrorBoundary 経由でエラーを console.error にも吐くため、
+    // happy-dom の util.inspect 経路で HTMLAnchorElement の private member
+    // アクセスが落ちる既知バグを踏む。意図的に suppress する。
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    server.use(
+      // NOT_FOUND 以外のエラーは re-throw され、ErrorBoundary に到達する。
+      // not-found 状態としてマスクされないことを確認する回帰テスト。
+      trpcQuery(
+        "admin.users.detail",
+        async () =>
+          await Promise.reject(
+            mockTRPCError("INTERNAL_SERVER_ERROR", "database down"),
+          ),
+      ),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
+
+    expect(
+      await screen.findByText(
+        "ユーザー詳細の読み込みに失敗しました",
+        {},
+        { timeout: 3000 },
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("このユーザーは見つかりません"),
+    ).not.toBeInTheDocument();
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("UserDataTabs の初期タブで garments の空メッセージが表示される", async () => {

--- a/src/app/admin/users/[id]/page.test.tsx
+++ b/src/app/admin/users/[id]/page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "@/test/mocks/server";
@@ -95,15 +95,13 @@ describe("UserDetailPage", () => {
 
   it("凍結ボタンを押すと confirm sheet が出て、確定すると freeze mutation が呼ばれる", async () => {
     const user = userEvent.setup();
-    const callRef: { current: { targetUserId: string } | undefined } = {
-      current: undefined,
-    };
+    const freezeResolver = vi.fn(() => ({
+      ok: true as const,
+      noop: false,
+    }));
     server.use(
       trpcQuery("admin.users.detail", () => buildUser({ id: "u-target" })),
-      trpcMutation("admin.users.freeze", ({ input }) => {
-        callRef.current = input as { targetUserId: string };
-        return { ok: true as const, noop: false };
-      }),
+      trpcMutation("admin.users.freeze", freezeResolver),
     );
 
     await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
@@ -114,23 +112,25 @@ describe("UserDetailPage", () => {
     await user.click(within(dialog).getByRole("button", { name: "凍結する" }));
 
     await waitFor(() => {
-      expect(callRef.current?.targetUserId).toBe("u-target");
+      expect(freezeResolver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ targetUserId: "u-target" }),
+        }),
+      );
     });
   });
 
   it("凍結済みユーザーには 解凍する ボタンが出て、確定すると unfreeze mutation が呼ばれる", async () => {
     const user = userEvent.setup();
-    const callRef: { current: { targetUserId: string } | undefined } = {
-      current: undefined,
-    };
+    const unfreezeResolver = vi.fn(() => ({
+      ok: true as const,
+      noop: false,
+    }));
     server.use(
       trpcQuery("admin.users.detail", () =>
         buildUser({ id: "u-target", frozen: true }),
       ),
-      trpcMutation("admin.users.unfreeze", ({ input }) => {
-        callRef.current = input as { targetUserId: string };
-        return { ok: true as const, noop: false };
-      }),
+      trpcMutation("admin.users.unfreeze", unfreezeResolver),
     );
 
     await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
@@ -140,7 +140,11 @@ describe("UserDetailPage", () => {
     await user.click(within(dialog).getByRole("button", { name: "解凍する" }));
 
     await waitFor(() => {
-      expect(callRef.current?.targetUserId).toBe("u-target");
+      expect(unfreezeResolver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ targetUserId: "u-target" }),
+        }),
+      );
     });
   });
 
@@ -179,15 +183,10 @@ describe("UserDetailPage", () => {
 
   it("収納タブに切り替えると location 用のクエリが発火する", async () => {
     const user = userEvent.setup();
-    const callRef: { current: { userId: string } | undefined } = {
-      current: undefined,
-    };
+    const locationsResolver = vi.fn(() => []);
     server.use(
       trpcQuery("admin.users.detail", () => buildUser({ id: "u-target" })),
-      trpcQuery("admin.userDataView.locations", ({ input }) => {
-        callRef.current = input as { userId: string };
-        return [];
-      }),
+      trpcQuery("admin.userDataView.locations", locationsResolver),
     );
 
     await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
@@ -196,21 +195,20 @@ describe("UserDetailPage", () => {
     await user.click(screen.getByRole("button", { name: "収納" }));
 
     await waitFor(() => {
-      expect(callRef.current?.userId).toBe("u-target");
+      expect(locationsResolver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ userId: "u-target" }),
+        }),
+      );
     });
   });
 
   it("コーデタブに切り替えると coordinates クエリが発火する", async () => {
     const user = userEvent.setup();
-    const callRef: { current: { userId: string } | undefined } = {
-      current: undefined,
-    };
+    const coordinatesResolver = vi.fn(() => ({ items: [], total: 0 }));
     server.use(
       trpcQuery("admin.users.detail", () => buildUser({ id: "u-target" })),
-      trpcQuery("admin.userDataView.coordinates", ({ input }) => {
-        callRef.current = input as { userId: string };
-        return { items: [], total: 0 };
-      }),
+      trpcQuery("admin.userDataView.coordinates", coordinatesResolver),
     );
 
     await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
@@ -219,7 +217,11 @@ describe("UserDetailPage", () => {
     await user.click(screen.getByRole("button", { name: "コーデ" }));
 
     await waitFor(() => {
-      expect(callRef.current?.userId).toBe("u-target");
+      expect(coordinatesResolver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ userId: "u-target" }),
+        }),
+      );
     });
   });
 

--- a/src/app/admin/users/[id]/page.test.tsx
+++ b/src/app/admin/users/[id]/page.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { server } from "@/test/mocks/server";
+import { adminSessionHandler, sessionHandler } from "@/test/mocks/handlers";
+import { trpcMutation, trpcQuery } from "@/test/mocks/trpc/handlerFactory";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import UserDetailPage from "./page";
+
+type BuildUserOverrides = {
+  readonly id?: string;
+  readonly name?: string;
+  readonly email?: string;
+  readonly role?: "admin" | "user";
+  readonly frozen?: boolean;
+};
+
+const buildUser = (overrides: BuildUserOverrides = {}) => {
+  const role: "admin" | "user" = overrides.role ?? "user";
+  return {
+    id: overrides.id ?? "u-target",
+    name: overrides.name ?? "対象ユーザー",
+    email: overrides.email ?? "target@example.com",
+    emailVerified: true,
+    image: undefined,
+    role,
+    frozen: overrides.frozen ?? false,
+    createdAt: new Date("2025-01-01").getTime(),
+    updatedAt: new Date("2025-02-01").getTime(),
+  };
+};
+
+const pageParams = (id: string) => ({
+  params: Promise.resolve({ id }),
+});
+
+describe("UserDetailPage", () => {
+  beforeEach(() => {
+    setupNextNavigation({
+      pathname: "/admin/users/u-target",
+      params: { id: "u-target" },
+    });
+    server.use(adminSessionHandler);
+  });
+
+  it("ユーザー情報と凍結ボタンが表示される (一般ユーザー)", async () => {
+    server.use(
+      trpcQuery("admin.users.detail", () =>
+        buildUser({
+          id: "u-target",
+          name: "Alice",
+          email: "alice@example.com",
+        }),
+      ),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
+
+    expect(await screen.findByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /凍結する/ })).toBeEnabled();
+  });
+
+  it("管理者ユーザーは MVP 上凍結できない (ボタンが disabled)", async () => {
+    server.use(
+      trpcQuery("admin.users.detail", () =>
+        buildUser({ id: "u-target", role: "admin" }),
+      ),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
+
+    const button = await screen.findByRole("button", { name: /凍結する/ });
+    expect(button).toBeDisabled();
+    expect(
+      screen.getByText("管理者の凍結は MVP では未対応です"),
+    ).toBeInTheDocument();
+  });
+
+  it("自分自身のページは凍結できない (ボタンが disabled)", async () => {
+    server.use(sessionHandler({ id: "u-target", role: "admin" }));
+    server.use(
+      trpcQuery("admin.users.detail", () =>
+        buildUser({ id: "u-target", role: "admin" }),
+      ),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
+
+    const button = await screen.findByRole("button", { name: /凍結する/ });
+    expect(button).toBeDisabled();
+    expect(screen.getByText("自分自身は凍結できません")).toBeInTheDocument();
+  });
+
+  it("凍結ボタンを押すと confirm sheet が出て、確定すると freeze mutation が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const callRef: { current: { targetUserId: string } | undefined } = {
+      current: undefined,
+    };
+    server.use(
+      trpcQuery("admin.users.detail", () => buildUser({ id: "u-target" })),
+      trpcMutation("admin.users.freeze", ({ input }) => {
+        callRef.current = input as { targetUserId: string };
+        return { ok: true as const, noop: false };
+      }),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
+
+    await user.click(await screen.findByRole("button", { name: /凍結する/ }));
+    // confirm sheet 内の確定ボタンを押す
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "凍結する" }));
+
+    await waitFor(() => {
+      expect(callRef.current?.targetUserId).toBe("u-target");
+    });
+  });
+
+  it("凍結済みユーザーには 解凍する ボタンが出て、確定すると unfreeze mutation が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const callRef: { current: { targetUserId: string } | undefined } = {
+      current: undefined,
+    };
+    server.use(
+      trpcQuery("admin.users.detail", () =>
+        buildUser({ id: "u-target", frozen: true }),
+      ),
+      trpcMutation("admin.users.unfreeze", ({ input }) => {
+        callRef.current = input as { targetUserId: string };
+        return { ok: true as const, noop: false };
+      }),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
+
+    await user.click(await screen.findByRole("button", { name: /解凍する/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "解凍する" }));
+
+    await waitFor(() => {
+      expect(callRef.current?.targetUserId).toBe("u-target");
+    });
+  });
+
+  it("ユーザーが見つからないとき not found メッセージが出る", async () => {
+    server.use(
+      // 詳細 query が rejection を返すケース。adminAtoms 側で .catch して
+      // undefined にダウングレードする経路を踏む。
+      trpcQuery(
+        "admin.users.detail",
+        async () => await Promise.reject(new Error("NOT_FOUND")),
+      ),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-missing")} />);
+
+    expect(
+      await screen.findByText("このユーザーは見つかりません"),
+    ).toBeInTheDocument();
+  });
+
+  it("UserDataTabs の初期タブで garments の空メッセージが表示される", async () => {
+    server.use(
+      trpcQuery("admin.users.detail", () => buildUser({ id: "u-target" })),
+      trpcQuery("admin.userDataView.garments", () => ({
+        items: [],
+        total: 0,
+      })),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
+
+    expect(
+      await screen.findByText("このユーザーの服はまだ登録されていません"),
+    ).toBeInTheDocument();
+  });
+
+  it("収納タブに切り替えると location 用のクエリが発火する", async () => {
+    const user = userEvent.setup();
+    const callRef: { current: { userId: string } | undefined } = {
+      current: undefined,
+    };
+    server.use(
+      trpcQuery("admin.users.detail", () => buildUser({ id: "u-target" })),
+      trpcQuery("admin.userDataView.locations", ({ input }) => {
+        callRef.current = input as { userId: string };
+        return [];
+      }),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
+    await screen.findByText("対象ユーザー");
+
+    await user.click(screen.getByRole("button", { name: "収納" }));
+
+    await waitFor(() => {
+      expect(callRef.current?.userId).toBe("u-target");
+    });
+  });
+
+  it("コーデタブに切り替えると coordinates クエリが発火する", async () => {
+    const user = userEvent.setup();
+    const callRef: { current: { userId: string } | undefined } = {
+      current: undefined,
+    };
+    server.use(
+      trpcQuery("admin.users.detail", () => buildUser({ id: "u-target" })),
+      trpcQuery("admin.userDataView.coordinates", ({ input }) => {
+        callRef.current = input as { userId: string };
+        return { items: [], total: 0 };
+      }),
+    );
+
+    await renderWithProviders(<UserDetailPage {...pageParams("u-target")} />);
+    await screen.findByText("対象ユーザー");
+
+    await user.click(screen.getByRole("button", { name: "コーデ" }));
+
+    await waitFor(() => {
+      expect(callRef.current?.userId).toBe("u-target");
+    });
+  });
+});

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Suspense, useMemo, use } from "react";
+import { useAtomValue } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { useLingui } from "@lingui/react";
+import { msg } from "@lingui/core/macro";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
+import Badge from "@/components/ui/Badge";
+import Card from "@/components/ui/Card";
+import PageHeader from "@/components/ui/PageHeader";
+import Skeleton from "@/components/ui/Skeleton";
+import UserDataTabs from "@/components/admin/UserDataTabs";
+import UserFreezeButton from "@/components/admin/UserFreezeButton";
+import { adminUserDetailAtomFamily, type AdminUser } from "@/stores/adminAtoms";
+import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
+
+const ISO_DATE_LENGTH = 10;
+
+const formatDate = (ms: number): string =>
+  new Date(ms).toISOString().slice(0, ISO_DATE_LENGTH);
+
+type DetailProps = {
+  readonly userId: string;
+};
+
+const UserHeader = ({ user }: { readonly user: AdminUser }) => (
+  <Card padding="lg">
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wider text-text-tertiary">
+            <Trans>ユーザー</Trans>
+          </p>
+          <h3 className="font-display text-xl font-bold text-text-primary">
+            {user.name}
+          </h3>
+          <p className="text-sm text-text-secondary">{user.email}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {user.role === "admin" ? (
+            <Badge variant="primary">
+              <Trans>管理者</Trans>
+            </Badge>
+          ) : (
+            <Badge>
+              <Trans>一般</Trans>
+            </Badge>
+          )}
+          {user.frozen ? (
+            <Badge variant="unknown">
+              <Trans>凍結中</Trans>
+            </Badge>
+          ) : (
+            <Badge variant="confirmed">
+              <Trans>有効</Trans>
+            </Badge>
+          )}
+        </div>
+      </div>
+      <dl className="grid grid-cols-2 gap-3 text-sm">
+        <div className="flex flex-col gap-0.5">
+          <dt className="text-xs text-text-tertiary">
+            <Trans>登録日</Trans>
+          </dt>
+          <dd className="font-mono tabular-nums">
+            {formatDate(user.createdAt)}
+          </dd>
+        </div>
+        <div className="flex flex-col gap-0.5">
+          <dt className="text-xs text-text-tertiary">
+            <Trans>最終更新</Trans>
+          </dt>
+          <dd className="font-mono tabular-nums">
+            {formatDate(user.updatedAt)}
+          </dd>
+        </div>
+        <div className="col-span-2 flex flex-col gap-0.5">
+          <dt className="text-xs text-text-tertiary">
+            <Trans>ユーザーID</Trans>
+          </dt>
+          <dd className="font-mono text-xs text-text-secondary break-all">
+            {user.id}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </Card>
+);
+
+const UserDetail = ({ userId }: DetailProps) => {
+  const detailAtom = useMemo(() => adminUserDetailAtomFamily(userId), [userId]);
+  const user = useAtomValue(detailAtom);
+  const { user: actor } = useAtomValue(authSessionUnwrappedAtom);
+  const { i18n } = useLingui();
+
+  if (user === undefined) {
+    return (
+      <p className="text-sm text-text-tertiary">
+        <Trans>このユーザーは見つかりません</Trans>
+      </p>
+    );
+  }
+
+  const isSelf = actor?.id === user.id;
+  const isTargetAdmin = user.role === "admin";
+  const disabledReason = isSelf
+    ? i18n._(msg`自分自身は凍結できません`)
+    : isTargetAdmin
+      ? i18n._(msg`管理者の凍結は MVP では未対応です`)
+      : undefined;
+  const freezeDisabled = isSelf || isTargetAdmin;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <UserHeader user={user} />
+      <div className="flex justify-end">
+        <UserFreezeButton
+          targetUserId={user.id}
+          frozen={user.frozen}
+          disabled={freezeDisabled}
+          disabledReason={disabledReason}
+        />
+      </div>
+      <h3 className="font-display text-base font-bold">
+        <Trans>ユーザーデータ閲覧</Trans>
+      </h3>
+      <UserDataTabs userId={user.id} />
+    </div>
+  );
+};
+
+const Page = ({ params }: { readonly params: Promise<{ id: string }> }) => {
+  const { id } = use(params);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PageHeader title={<Trans>ユーザー詳細</Trans>} backHref="/admin/users" />
+      <ErrorBoundary
+        fallback={
+          <p className="text-sm text-danger">
+            <Trans>ユーザー詳細の読み込みに失敗しました</Trans>
+          </p>
+        }
+      >
+        <Suspense fallback={<Skeleton className="h-48 rounded-xl" />}>
+          <UserDetail userId={id} />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/admin/users/page.test.tsx
+++ b/src/app/admin/users/page.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { server } from "@/test/mocks/server";
+import { adminSessionHandler } from "@/test/mocks/handlers";
+import { trpcQuery } from "@/test/mocks/trpc/handlerFactory";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import AdminUsersPage from "./page";
+
+type ListInput = {
+  readonly search?: string;
+  readonly role?: "admin" | "user";
+  readonly frozen?: boolean;
+  readonly limit: number;
+  readonly offset: number;
+};
+
+const buildUser = (
+  overrides: Partial<{
+    id: string;
+    name: string;
+    email: string;
+    role: "admin" | "user";
+    frozen: boolean;
+  }> = {},
+) => ({
+  id: overrides.id ?? "u-1",
+  name: overrides.name ?? "ユーザー名",
+  email: overrides.email ?? "user@example.com",
+  emailVerified: true,
+  image: undefined,
+  role: overrides.role ?? ("user" as const),
+  frozen: overrides.frozen ?? false,
+  createdAt: new Date("2025-01-01").getTime(),
+  updatedAt: new Date("2025-01-02").getTime(),
+});
+
+describe("AdminUsersPage", () => {
+  beforeEach(() => {
+    setupNextNavigation({ pathname: "/admin/users" });
+    server.use(adminSessionHandler);
+  });
+
+  it("ユーザー一覧が表示される", async () => {
+    server.use(
+      trpcQuery("admin.users.list", () => ({
+        items: [
+          buildUser({ id: "u-alice", name: "Alice", email: "alice@x.com" }),
+          buildUser({
+            id: "u-bob",
+            name: "Bob",
+            email: "bob@x.com",
+            role: "admin",
+          }),
+        ],
+        total: 2,
+      })),
+    );
+
+    await renderWithProviders(<AdminUsersPage />);
+
+    expect(await screen.findByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText("alice@x.com")).toBeInTheDocument();
+    expect(screen.getByText("管理者")).toBeInTheDocument();
+  });
+
+  it("該当ユーザーがいないとき EmptyState が出る", async () => {
+    server.use(trpcQuery("admin.users.list", () => ({ items: [], total: 0 })));
+
+    await renderWithProviders(<AdminUsersPage />);
+
+    expect(
+      await screen.findByText("該当するユーザーがいません"),
+    ).toBeInTheDocument();
+  });
+
+  it("検索ボックスに入力するとクエリが更新される", async () => {
+    const user = userEvent.setup();
+    const calls: ListInput[] = [];
+    server.use(
+      trpcQuery("admin.users.list", ({ input }) => {
+        calls.push(input as ListInput);
+        return { items: [], total: 0 };
+      }),
+    );
+
+    await renderWithProviders(<AdminUsersPage />);
+
+    await screen.findByText("該当するユーザーがいません");
+
+    const searchBox = screen.getByPlaceholderText(
+      "メールアドレスや名前で検索...",
+    );
+    await user.type(searchBox, "alice");
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.search).toBe("alice");
+    });
+  });
+
+  it("権限フィルターを切り替えると role が指定された queries が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const calls: ListInput[] = [];
+    server.use(
+      trpcQuery("admin.users.list", ({ input }) => {
+        calls.push(input as ListInput);
+        return { items: [], total: 0 };
+      }),
+    );
+
+    await renderWithProviders(<AdminUsersPage />);
+    await screen.findByText("該当するユーザーがいません");
+
+    await user.click(screen.getByRole("button", { name: "管理者のみ" }));
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.role).toBe("admin");
+    });
+  });
+
+  it("凍結フィルターを 凍結中のみ にすると frozen=true で問い合わせる", async () => {
+    const user = userEvent.setup();
+    const calls: ListInput[] = [];
+    server.use(
+      trpcQuery("admin.users.list", ({ input }) => {
+        calls.push(input as ListInput);
+        return { items: [], total: 0 };
+      }),
+    );
+
+    await renderWithProviders(<AdminUsersPage />);
+    await screen.findByText("該当するユーザーがいません");
+
+    await user.click(screen.getByRole("button", { name: "凍結中のみ" }));
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.frozen).toBe(true);
+    });
+  });
+
+  it("詳細リンクがユーザー個別ページに向いている", async () => {
+    server.use(
+      trpcQuery("admin.users.list", () => ({
+        items: [buildUser({ id: "u-detail-target", name: "Charlie" })],
+        total: 1,
+      })),
+    );
+
+    await renderWithProviders(<AdminUsersPage />);
+
+    const link = await screen.findByRole("link", {
+      name: "ユーザー詳細を開く",
+    });
+    expect(link).toHaveAttribute("href", "/admin/users/u-detail-target");
+  });
+});

--- a/src/app/admin/users/page.test.tsx
+++ b/src/app/admin/users/page.test.tsx
@@ -365,6 +365,28 @@ describe("AdminUsersPage", () => {
     });
   });
 
+  it("items が空でも total > 0 なら Pagination を残し EmptyState は出さない (offset 範囲外回避)", async () => {
+    // total: 60 だが items: [] のとき (offset がページ範囲外で空ページを返したケース)。
+    // 過去の実装は items.length === 0 で EmptyState を出していたため admin が
+    // 別ページに戻れなくなる問題があった。
+    server.use(trpcQuery("admin.users.list", () => ({ items: [], total: 60 })));
+
+    await renderWithProviders(
+      <HydratedAdminUsersPage initialQuery={{ limit: 20, offset: 80 }} />,
+    );
+
+    expect(
+      await screen.findByText("このページには表示するユーザーがいません"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("該当するユーザーがいません"),
+    ).not.toBeInTheDocument();
+    // Pagination の「前のページ」ボタンが残っていることを確認 (= 戻れる)
+    expect(
+      screen.getAllByRole("button", { name: "前のページ" }).length,
+    ).toBeGreaterThan(0);
+  });
+
   it("Pagination で表示件数を変えると limit が更新され offset が 0 にリセットされる", async () => {
     const user = userEvent.setup();
     const resolver = vi.fn(() => ({

--- a/src/app/admin/users/page.test.tsx
+++ b/src/app/admin/users/page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useHydrateAtoms } from "jotai/utils";
@@ -19,13 +19,14 @@ const HydratedAdminUsersPage = ({
   return <AdminUsersPage />;
 };
 
-type ListInput = {
-  readonly search?: string;
-  readonly role?: "admin" | "user";
-  readonly frozen?: boolean;
-  readonly limit: number;
-  readonly offset: number;
-};
+// resolver は input をそのまま返すデフォルト挙動を共有させて、各テストは
+// vi.fn() の spy で呼び出し時の input shape を assert する。
+// (CLAUDE.md「型アサーション禁止」「ミュータブル更新禁止」回避)
+
+const emptyUsersResult = (): { items: []; total: 0 } => ({
+  items: [],
+  total: 0,
+});
 
 const buildUser = (
   overrides: Partial<{
@@ -89,16 +90,10 @@ describe("AdminUsersPage", () => {
 
   it("検索ボックスに入力するとクエリが更新される", async () => {
     const user = userEvent.setup();
-    const calls: ListInput[] = [];
-    server.use(
-      trpcQuery("admin.users.list", ({ input }) => {
-        calls.push(input as ListInput);
-        return { items: [], total: 0 };
-      }),
-    );
+    const resolver = vi.fn(() => emptyUsersResult());
+    server.use(trpcQuery("admin.users.list", resolver));
 
     await renderWithProviders(<AdminUsersPage />);
-
     await screen.findByText("該当するユーザーがいません");
 
     const searchBox = screen.getByPlaceholderText(
@@ -107,20 +102,18 @@ describe("AdminUsersPage", () => {
     await user.type(searchBox, "alice");
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.search).toBe("alice");
+      expect(resolver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ search: "alice" }),
+        }),
+      );
     });
   });
 
   it("権限フィルターを切り替えると role が指定された queries が呼ばれる", async () => {
     const user = userEvent.setup();
-    const calls: ListInput[] = [];
-    server.use(
-      trpcQuery("admin.users.list", ({ input }) => {
-        calls.push(input as ListInput);
-        return { items: [], total: 0 };
-      }),
-    );
+    const resolver = vi.fn(() => emptyUsersResult());
+    server.use(trpcQuery("admin.users.list", resolver));
 
     await renderWithProviders(<AdminUsersPage />);
     await screen.findByText("該当するユーザーがいません");
@@ -128,20 +121,18 @@ describe("AdminUsersPage", () => {
     await user.click(screen.getByRole("button", { name: "管理者のみ" }));
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.role).toBe("admin");
+      expect(resolver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ role: "admin" }),
+        }),
+      );
     });
   });
 
   it("凍結フィルターを 凍結中のみ にすると frozen=true で問い合わせる", async () => {
     const user = userEvent.setup();
-    const calls: ListInput[] = [];
-    server.use(
-      trpcQuery("admin.users.list", ({ input }) => {
-        calls.push(input as ListInput);
-        return { items: [], total: 0 };
-      }),
-    );
+    const resolver = vi.fn(() => emptyUsersResult());
+    server.use(trpcQuery("admin.users.list", resolver));
 
     await renderWithProviders(<AdminUsersPage />);
     await screen.findByText("該当するユーザーがいません");
@@ -149,8 +140,11 @@ describe("AdminUsersPage", () => {
     await user.click(screen.getByRole("button", { name: "凍結中のみ" }));
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.frozen).toBe(true);
+      expect(resolver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ frozen: true }),
+        }),
+      );
     });
   });
 
@@ -190,13 +184,8 @@ describe("AdminUsersPage", () => {
 
   it("Enter キーで form submit すると applyFilters 経由でクエリが投げられる", async () => {
     const user = userEvent.setup();
-    const calls: ListInput[] = [];
-    server.use(
-      trpcQuery("admin.users.list", ({ input }) => {
-        calls.push(input as ListInput);
-        return { items: [], total: 0 };
-      }),
-    );
+    const resolver = vi.fn(() => emptyUsersResult());
+    server.use(trpcQuery("admin.users.list", resolver));
 
     await renderWithProviders(<AdminUsersPage />);
     await screen.findByText("該当するユーザーがいません");
@@ -208,21 +197,18 @@ describe("AdminUsersPage", () => {
     await user.type(searchBox, "alice{Enter}");
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.search).toBe("alice");
-      expect(lastCall?.offset).toBe(0);
+      expect(resolver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ search: "alice", offset: 0 }),
+        }),
+      );
     });
   });
 
   it("検索を空文字に戻すと search=undefined で問い合わせる", async () => {
     const user = userEvent.setup();
-    const calls: ListInput[] = [];
-    server.use(
-      trpcQuery("admin.users.list", ({ input }) => {
-        calls.push(input as ListInput);
-        return { items: [], total: 0 };
-      }),
-    );
+    const resolver = vi.fn(() => emptyUsersResult());
+    server.use(trpcQuery("admin.users.list", resolver));
 
     await renderWithProviders(<AdminUsersPage />);
     await screen.findByText("該当するユーザーがいません");
@@ -234,20 +220,20 @@ describe("AdminUsersPage", () => {
     await user.clear(searchBox);
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.search).toBeUndefined();
+      // search が空文字に戻ったときは undefined になり、input から search キーが
+      // 落ちる (handleSearchChange が `value === "" ? undefined : value` を渡すため)。
+      expect(resolver).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          input: expect.not.objectContaining({ search: expect.anything() }),
+        }),
+      );
     });
   });
 
   it("凍結フィルタを 有効のみ にすると frozen=false が指定される", async () => {
     const user = userEvent.setup();
-    const calls: ListInput[] = [];
-    server.use(
-      trpcQuery("admin.users.list", ({ input }) => {
-        calls.push(input as ListInput);
-        return { items: [], total: 0 };
-      }),
-    );
+    const resolver = vi.fn(() => emptyUsersResult());
+    server.use(trpcQuery("admin.users.list", resolver));
 
     await renderWithProviders(<AdminUsersPage />);
     await screen.findByText("該当するユーザーがいません");
@@ -255,8 +241,11 @@ describe("AdminUsersPage", () => {
     await user.click(screen.getByRole("button", { name: "有効のみ" }));
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.frozen).toBe(false);
+      expect(resolver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ frozen: false }),
+        }),
+      );
     });
   });
 
@@ -324,13 +313,8 @@ describe("AdminUsersPage", () => {
 
   it("全権限 を選び直すと role=undefined にリセットされる", async () => {
     const user = userEvent.setup();
-    const calls: ListInput[] = [];
-    server.use(
-      trpcQuery("admin.users.list", ({ input }) => {
-        calls.push(input as ListInput);
-        return { items: [], total: 0 };
-      }),
-    );
+    const resolver = vi.fn(() => emptyUsersResult());
+    server.use(trpcQuery("admin.users.list", resolver));
 
     await renderWithProviders(<AdminUsersPage />);
     await screen.findByText("該当するユーザーがいません");
@@ -339,24 +323,22 @@ describe("AdminUsersPage", () => {
     await user.click(screen.getByRole("button", { name: "全権限" }));
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.role).toBeUndefined();
+      expect(resolver).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          input: expect.not.objectContaining({ role: expect.anything() }),
+        }),
+      );
     });
   });
 
   it("Pagination の 次へ ボタンで limit ぶん offset を進めて再 fetch する", async () => {
     const user = userEvent.setup();
-    const calls: ListInput[] = [];
     // 1 ページぶんの件数 + 全 total を返して 2 ページ以上ある状態にする
     const page1Items = Array.from({ length: 20 }, (_, i) =>
       buildUser({ id: `u-${i}`, name: `User ${i}` }),
     );
-    server.use(
-      trpcQuery("admin.users.list", ({ input }) => {
-        calls.push(input as ListInput);
-        return { items: page1Items, total: 60 };
-      }),
-    );
+    const resolver = vi.fn(() => ({ items: page1Items, total: 60 }));
+    server.use(trpcQuery("admin.users.list", resolver));
 
     await renderWithProviders(
       <HydratedAdminUsersPage initialQuery={{ limit: 20, offset: 0 }} />,
@@ -375,24 +357,21 @@ describe("AdminUsersPage", () => {
     await user.click(firstNextButton);
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.offset).toBe(20);
-      expect(lastCall?.limit).toBe(20);
+      expect(resolver).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ limit: 20, offset: 20 }),
+        }),
+      );
     });
   });
 
   it("Pagination で表示件数を変えると limit が更新され offset が 0 にリセットされる", async () => {
     const user = userEvent.setup();
-    const calls: ListInput[] = [];
-    server.use(
-      trpcQuery("admin.users.list", ({ input }) => {
-        calls.push(input as ListInput);
-        return {
-          items: [buildUser({ id: "u-only", name: "Only" })],
-          total: 60,
-        };
-      }),
-    );
+    const resolver = vi.fn(() => ({
+      items: [buildUser({ id: "u-only", name: "Only" })],
+      total: 60,
+    }));
+    server.use(trpcQuery("admin.users.list", resolver));
 
     await renderWithProviders(
       <HydratedAdminUsersPage initialQuery={{ limit: 20, offset: 40 }} />,
@@ -404,9 +383,11 @@ describe("AdminUsersPage", () => {
     await user.selectOptions(sizeSelect, "50");
 
     await waitFor(() => {
-      const lastCall = calls.at(-1);
-      expect(lastCall?.limit).toBe(50);
-      expect(lastCall?.offset).toBe(0);
+      expect(resolver).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ limit: 50, offset: 0 }),
+        }),
+      );
     });
   });
 });

--- a/src/app/admin/users/page.test.tsx
+++ b/src/app/admin/users/page.test.tsx
@@ -1,12 +1,23 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useHydrateAtoms } from "jotai/utils";
 import { server } from "@/test/mocks/server";
 import { adminSessionHandler } from "@/test/mocks/handlers";
 import { trpcQuery } from "@/test/mocks/trpc/handlerFactory";
 import { renderWithProviders } from "@/test/testUtils";
 import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import { adminUsersQueryAtom, type AdminUsersQuery } from "@/stores/adminAtoms";
 import AdminUsersPage from "./page";
+
+const HydratedAdminUsersPage = ({
+  initialQuery,
+}: {
+  readonly initialQuery: AdminUsersQuery;
+}) => {
+  useHydrateAtoms([[adminUsersQueryAtom, initialQuery]]);
+  return <AdminUsersPage />;
+};
 
 type ListInput = {
   readonly search?: string;
@@ -157,5 +168,179 @@ describe("AdminUsersPage", () => {
       name: "ユーザー詳細を開く",
     });
     expect(link).toHaveAttribute("href", "/admin/users/u-detail-target");
+  });
+
+  it("frozen=true のユーザーは 凍結中 バッジが表示される (テーブル分岐)", async () => {
+    server.use(
+      trpcQuery("admin.users.list", () => ({
+        items: [
+          buildUser({ id: "u-frozen", name: "Frozen", frozen: true }),
+          buildUser({ id: "u-active", name: "Active", frozen: false }),
+        ],
+        total: 2,
+      })),
+    );
+
+    await renderWithProviders(<AdminUsersPage />);
+
+    expect(await screen.findByText("Frozen")).toBeInTheDocument();
+    expect(screen.getByText("凍結中")).toBeInTheDocument();
+    expect(screen.getByText("有効")).toBeInTheDocument();
+  });
+
+  it("Enter キーで form submit すると applyFilters 経由でクエリが投げられる", async () => {
+    const user = userEvent.setup();
+    const calls: ListInput[] = [];
+    server.use(
+      trpcQuery("admin.users.list", ({ input }) => {
+        calls.push(input as ListInput);
+        return { items: [], total: 0 };
+      }),
+    );
+
+    await renderWithProviders(<AdminUsersPage />);
+    await screen.findByText("該当するユーザーがいません");
+
+    const searchBox = screen.getByPlaceholderText(
+      "メールアドレスや名前で検索...",
+    );
+    // 検索文字を入力後 Enter で submit すると form の onSubmit -> applyFilters が走る
+    await user.type(searchBox, "alice{Enter}");
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.search).toBe("alice");
+      expect(lastCall?.offset).toBe(0);
+    });
+  });
+
+  it("検索を空文字に戻すと search=undefined で問い合わせる", async () => {
+    const user = userEvent.setup();
+    const calls: ListInput[] = [];
+    server.use(
+      trpcQuery("admin.users.list", ({ input }) => {
+        calls.push(input as ListInput);
+        return { items: [], total: 0 };
+      }),
+    );
+
+    await renderWithProviders(<AdminUsersPage />);
+    await screen.findByText("該当するユーザーがいません");
+
+    const searchBox = screen.getByPlaceholderText(
+      "メールアドレスや名前で検索...",
+    );
+    await user.type(searchBox, "a");
+    await user.clear(searchBox);
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.search).toBeUndefined();
+    });
+  });
+
+  it("凍結フィルタを 有効のみ にすると frozen=false が指定される", async () => {
+    const user = userEvent.setup();
+    const calls: ListInput[] = [];
+    server.use(
+      trpcQuery("admin.users.list", ({ input }) => {
+        calls.push(input as ListInput);
+        return { items: [], total: 0 };
+      }),
+    );
+
+    await renderWithProviders(<AdminUsersPage />);
+    await screen.findByText("該当するユーザーがいません");
+
+    await user.click(screen.getByRole("button", { name: "有効のみ" }));
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.frozen).toBe(false);
+    });
+  });
+
+  it("初期 query で frozen=true が指定されているとき 凍結中のみ チップが selected になる", async () => {
+    server.use(trpcQuery("admin.users.list", () => ({ items: [], total: 0 })));
+
+    await renderWithProviders(
+      <HydratedAdminUsersPage
+        initialQuery={{ frozen: true, limit: 50, offset: 0 }}
+      />,
+    );
+
+    await screen.findByText("該当するユーザーがいません");
+
+    const frozenOnlyChip = screen.getByRole("button", { name: "凍結中のみ" });
+    expect(frozenOnlyChip.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("初期 query で frozen=false が指定されているとき 有効のみ チップが selected になる", async () => {
+    server.use(trpcQuery("admin.users.list", () => ({ items: [], total: 0 })));
+
+    await renderWithProviders(
+      <HydratedAdminUsersPage
+        initialQuery={{ frozen: false, limit: 50, offset: 0 }}
+      />,
+    );
+
+    await screen.findByText("該当するユーザーがいません");
+
+    const activeOnlyChip = screen.getByRole("button", { name: "有効のみ" });
+    expect(activeOnlyChip.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("初期 query で role=admin が指定されているとき 管理者のみ チップが selected になる", async () => {
+    server.use(trpcQuery("admin.users.list", () => ({ items: [], total: 0 })));
+
+    await renderWithProviders(
+      <HydratedAdminUsersPage
+        initialQuery={{ role: "admin", limit: 50, offset: 0 }}
+      />,
+    );
+
+    await screen.findByText("該当するユーザーがいません");
+
+    const adminOnlyChip = screen.getByRole("button", { name: "管理者のみ" });
+    expect(adminOnlyChip.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("初期 query で search が指定されているとき 検索 box にその値が入っている", async () => {
+    server.use(trpcQuery("admin.users.list", () => ({ items: [], total: 0 })));
+
+    await renderWithProviders(
+      <HydratedAdminUsersPage
+        initialQuery={{ search: "preset", limit: 50, offset: 0 }}
+      />,
+    );
+
+    await screen.findByText("該当するユーザーがいません");
+
+    const searchBox = screen.getByPlaceholderText(
+      "メールアドレスや名前で検索...",
+    );
+    expect(searchBox).toHaveValue("preset");
+  });
+
+  it("全権限 を選び直すと role=undefined にリセットされる", async () => {
+    const user = userEvent.setup();
+    const calls: ListInput[] = [];
+    server.use(
+      trpcQuery("admin.users.list", ({ input }) => {
+        calls.push(input as ListInput);
+        return { items: [], total: 0 };
+      }),
+    );
+
+    await renderWithProviders(<AdminUsersPage />);
+    await screen.findByText("該当するユーザーがいません");
+
+    await user.click(screen.getByRole("button", { name: "管理者のみ" }));
+    await user.click(screen.getByRole("button", { name: "全権限" }));
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.role).toBeUndefined();
+    });
   });
 });

--- a/src/app/admin/users/page.test.tsx
+++ b/src/app/admin/users/page.test.tsx
@@ -343,4 +343,70 @@ describe("AdminUsersPage", () => {
       expect(lastCall?.role).toBeUndefined();
     });
   });
+
+  it("Pagination の 次へ ボタンで limit ぶん offset を進めて再 fetch する", async () => {
+    const user = userEvent.setup();
+    const calls: ListInput[] = [];
+    // 1 ページぶんの件数 + 全 total を返して 2 ページ以上ある状態にする
+    const page1Items = Array.from({ length: 20 }, (_, i) =>
+      buildUser({ id: `u-${i}`, name: `User ${i}` }),
+    );
+    server.use(
+      trpcQuery("admin.users.list", ({ input }) => {
+        calls.push(input as ListInput);
+        return { items: page1Items, total: 60 };
+      }),
+    );
+
+    await renderWithProviders(
+      <HydratedAdminUsersPage initialQuery={{ limit: 20, offset: 0 }} />,
+    );
+
+    expect(await screen.findByText("User 0")).toBeInTheDocument();
+
+    // モバイル / lg 両方のレイアウトに同じ aria-label が付くので、片方の
+    // "次のページ" を押せば atom が更新されて再 fetch が走る。
+    const nextButtons = await screen.findAllByRole("button", {
+      name: "次のページ",
+    });
+    const firstNextButton = nextButtons.at(0);
+    expect(firstNextButton).toBeInstanceOf(HTMLElement);
+    if (firstNextButton === undefined) return;
+    await user.click(firstNextButton);
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.offset).toBe(20);
+      expect(lastCall?.limit).toBe(20);
+    });
+  });
+
+  it("Pagination で表示件数を変えると limit が更新され offset が 0 にリセットされる", async () => {
+    const user = userEvent.setup();
+    const calls: ListInput[] = [];
+    server.use(
+      trpcQuery("admin.users.list", ({ input }) => {
+        calls.push(input as ListInput);
+        return {
+          items: [buildUser({ id: "u-only", name: "Only" })],
+          total: 60,
+        };
+      }),
+    );
+
+    await renderWithProviders(
+      <HydratedAdminUsersPage initialQuery={{ limit: 20, offset: 40 }} />,
+    );
+
+    await screen.findByText("Only");
+
+    const sizeSelect = await screen.findByLabelText("表示件数");
+    await user.selectOptions(sizeSelect, "50");
+
+    await waitFor(() => {
+      const lastCall = calls.at(-1);
+      expect(lastCall?.limit).toBe(50);
+      expect(lastCall?.offset).toBe(0);
+    });
+  });
 });

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { Suspense, useMemo, useState } from "react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { useLingui } from "@lingui/react";
+import { msg, t } from "@lingui/core/macro";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
+import SearchInput from "@/components/ui/SearchInput";
+import ChipGroup from "@/components/ui/ChipGroup";
+import Skeleton from "@/components/ui/Skeleton";
+import EmptyState from "@/components/ui/EmptyState";
+import Pagination from "@/components/ui/Pagination";
+import { Users as UsersIcon } from "lucide-react";
+import UserTable from "@/components/admin/UserTable";
+import usePagination from "@/hooks/usePagination";
+import {
+  adminUsersAtom,
+  adminUsersQueryAtom,
+  type AdminUserRole,
+} from "@/stores/adminAtoms";
+
+const ROLE_FILTERS = [
+  { value: "all" as const, label: msg`全権限` },
+  { value: "admin" as const, label: msg`管理者のみ` },
+  { value: "user" as const, label: msg`一般のみ` },
+];
+
+const FROZEN_FILTERS = [
+  { value: "all" as const, label: msg`全状態` },
+  { value: "active" as const, label: msg`有効のみ` },
+  { value: "frozen" as const, label: msg`凍結中のみ` },
+];
+
+type RoleFilter = (typeof ROLE_FILTERS)[number]["value"];
+type FrozenFilter = (typeof FROZEN_FILTERS)[number]["value"];
+
+const toRoleQuery = (value: RoleFilter): AdminUserRole | undefined =>
+  value === "all" ? undefined : value;
+
+const toFrozenQuery = (value: FrozenFilter): boolean | undefined => {
+  if (value === "all") return undefined;
+  return value === "frozen";
+};
+
+const UsersListContent = () => {
+  const result = useAtomValue(adminUsersAtom);
+  const { paginatedItems, onChangePage, onChangePageSize, ...pagination } =
+    usePagination({ items: result.items });
+
+  if (result.items.length === 0) {
+    return (
+      <EmptyState
+        icon={UsersIcon}
+        title={t`該当するユーザーがいません`}
+        description={t`検索条件を変更してもう一度お試しください`}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <UserTable users={paginatedItems} />
+      <Pagination
+        pagination={pagination}
+        onChangePage={onChangePage}
+        onChangePageSize={onChangePageSize}
+      />
+    </div>
+  );
+};
+
+const AdminUsersPage = () => {
+  const setQuery = useSetAtom(adminUsersQueryAtom);
+  const [currentQuery] = useAtom(adminUsersQueryAtom);
+  const [search, setSearch] = useState(currentQuery.search ?? "");
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>(
+    currentQuery.role ?? "all",
+  );
+  const [frozenFilter, setFrozenFilter] = useState<FrozenFilter>(() => {
+    if (currentQuery.frozen === undefined) return "all";
+    return currentQuery.frozen ? "frozen" : "active";
+  });
+  const { i18n } = useLingui();
+
+  const roleChips = useMemo(
+    () =>
+      ROLE_FILTERS.map(({ value, label }) => ({
+        value,
+        label: i18n._(label),
+      })),
+    [i18n],
+  );
+  const frozenChips = useMemo(
+    () =>
+      FROZEN_FILTERS.map(({ value, label }) => ({
+        value,
+        label: i18n._(label),
+      })),
+    [i18n],
+  );
+
+  const applyFilters = () => {
+    setQuery({
+      search: search === "" ? undefined : search,
+      role: toRoleQuery(roleFilter),
+      frozen: toFrozenQuery(frozenFilter),
+      limit: currentQuery.limit,
+      offset: 0,
+    });
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setQuery({
+      search: value === "" ? undefined : value,
+      role: toRoleQuery(roleFilter),
+      frozen: toFrozenQuery(frozenFilter),
+      limit: currentQuery.limit,
+      offset: 0,
+    });
+  };
+
+  const handleRoleChange = (value: RoleFilter) => {
+    setRoleFilter(value);
+    setQuery({
+      search: search === "" ? undefined : search,
+      role: toRoleQuery(value),
+      frozen: toFrozenQuery(frozenFilter),
+      limit: currentQuery.limit,
+      offset: 0,
+    });
+  };
+
+  const handleFrozenChange = (value: FrozenFilter) => {
+    setFrozenFilter(value);
+    setQuery({
+      search: search === "" ? undefined : search,
+      role: toRoleQuery(roleFilter),
+      frozen: toFrozenQuery(value),
+      limit: currentQuery.limit,
+      offset: 0,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h2 className="font-display text-lg font-bold">
+        <Trans>ユーザー管理</Trans>
+      </h2>
+
+      <form
+        className="flex flex-col gap-3"
+        onSubmit={(e) => {
+          e.preventDefault();
+          applyFilters();
+        }}
+      >
+        <SearchInput
+          value={search}
+          onChangeValue={handleSearchChange}
+          placeholder={i18n._(msg`メールアドレスや名前で検索...`)}
+        />
+        <div className="flex flex-wrap gap-3">
+          <div>
+            <p className="mb-1 text-xs font-medium text-text-tertiary">
+              <Trans>権限</Trans>
+            </p>
+            <ChipGroup
+              options={roleChips}
+              value={roleFilter}
+              onSelect={handleRoleChange}
+            />
+          </div>
+          <div>
+            <p className="mb-1 text-xs font-medium text-text-tertiary">
+              <Trans>状態</Trans>
+            </p>
+            <ChipGroup
+              options={frozenChips}
+              value={frozenFilter}
+              onSelect={handleFrozenChange}
+            />
+          </div>
+        </div>
+      </form>
+
+      <ErrorBoundary
+        fallback={
+          <p className="text-sm text-danger">
+            <Trans>ユーザー一覧の読み込みに失敗しました</Trans>
+          </p>
+        }
+      >
+        <Suspense fallback={<Skeleton className="h-48 rounded-xl" />}>
+          <UsersListContent />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+};
+
+export default AdminUsersPage;

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -58,7 +58,9 @@ const UsersListContent = () => {
   const setPage = useSetAtom(setAdminUsersPageAtom);
   const setPageSize = useSetAtom(setAdminUsersPageSizeAtom);
 
-  if (result.items.length === 0) {
+  // total=0 でしか empty state を出さない。items.length === 0 だが total > 0 の
+  // ときは「offset が範囲外」状態。Pagination を残して別ページに戻れるようにする。
+  if (result.total === 0) {
     return (
       <EmptyState
         icon={UsersIcon}
@@ -69,13 +71,18 @@ const UsersListContent = () => {
   }
 
   const pageSize = normalizePageSize(query.limit);
-  // ceil で末尾の余り行ぶんを 1 ページ確保する。total=0 のとき empty branch に入るのでここは items.length>0 が保証されている。
   const totalPages = Math.max(1, Math.ceil(result.total / query.limit));
   const currentPage = Math.floor(query.offset / query.limit) + 1;
 
   return (
     <div className="flex flex-col gap-3">
-      <UserTable users={result.items} />
+      {result.items.length === 0 ? (
+        <p className="py-8 text-center text-sm text-text-tertiary">
+          <Trans>このページには表示するユーザーがいません</Trans>
+        </p>
+      ) : (
+        <UserTable users={result.items} />
+      )}
       <Pagination
         pagination={{
           currentPage,

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -11,12 +11,15 @@ import ChipGroup from "@/components/ui/ChipGroup";
 import Skeleton from "@/components/ui/Skeleton";
 import EmptyState from "@/components/ui/EmptyState";
 import Pagination from "@/components/ui/Pagination";
+import type { PageSize } from "@/lib/constants";
+import { PAGE_SIZES } from "@/lib/constants";
 import { Users as UsersIcon } from "lucide-react";
 import UserTable from "@/components/admin/UserTable";
-import usePagination from "@/hooks/usePagination";
 import {
   adminUsersAtom,
   adminUsersQueryAtom,
+  setAdminUsersPageAtom,
+  setAdminUsersPageSizeAtom,
   type AdminUserRole,
 } from "@/stores/adminAtoms";
 
@@ -43,10 +46,17 @@ const toFrozenQuery = (value: FrozenFilter): boolean | undefined => {
   return value === "frozen";
 };
 
+const isPageSize = (value: number): value is PageSize =>
+  (PAGE_SIZES as readonly number[]).includes(value);
+
+const normalizePageSize = (limit: number): PageSize =>
+  isPageSize(limit) ? limit : PAGE_SIZES[0];
+
 const UsersListContent = () => {
   const result = useAtomValue(adminUsersAtom);
-  const { paginatedItems, onChangePage, onChangePageSize, ...pagination } =
-    usePagination({ items: result.items });
+  const query = useAtomValue(adminUsersQueryAtom);
+  const setPage = useSetAtom(setAdminUsersPageAtom);
+  const setPageSize = useSetAtom(setAdminUsersPageSizeAtom);
 
   if (result.items.length === 0) {
     return (
@@ -58,13 +68,23 @@ const UsersListContent = () => {
     );
   }
 
+  const pageSize = normalizePageSize(query.limit);
+  // ceil で末尾の余り行ぶんを 1 ページ確保する。total=0 のとき empty branch に入るのでここは items.length>0 が保証されている。
+  const totalPages = Math.max(1, Math.ceil(result.total / query.limit));
+  const currentPage = Math.floor(query.offset / query.limit) + 1;
+
   return (
     <div className="flex flex-col gap-3">
-      <UserTable users={paginatedItems} />
+      <UserTable users={result.items} />
       <Pagination
-        pagination={pagination}
-        onChangePage={onChangePage}
-        onChangePageSize={onChangePageSize}
+        pagination={{
+          currentPage,
+          totalPages,
+          pageSize,
+          totalCount: result.total,
+        }}
+        onChangePage={setPage}
+        onChangePageSize={setPageSize}
       />
     </div>
   );

--- a/src/components/admin/AdminGuard.test.tsx
+++ b/src/components/admin/AdminGuard.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { server } from "@/test/mocks/server";
+import {
+  adminSessionHandler,
+  frozenSessionHandler,
+  sessionFetchFailureHandler,
+  sessionHandler,
+  unauthenticatedHandler,
+} from "@/test/mocks/handlers";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import AdminGuard from "./AdminGuard";
+
+describe("AdminGuard", () => {
+  beforeEach(() => {
+    setupNextNavigation({ pathname: "/admin" });
+  });
+
+  it("admin ロールのときは子要素を描画する", async () => {
+    server.use(adminSessionHandler);
+
+    await renderWithProviders(
+      <AdminGuard>
+        <p data-testid="admin-content">管理画面コンテンツ</p>
+      </AdminGuard>,
+    );
+
+    expect(await screen.findByTestId("admin-content")).toBeInTheDocument();
+  });
+
+  it("role=user のときは /dashboard にリダイレクトされ子要素は描画されない", async () => {
+    const { router } = setupNextNavigation({ pathname: "/admin" });
+
+    await renderWithProviders(
+      <AdminGuard>
+        <p data-testid="admin-content">管理画面コンテンツ</p>
+      </AdminGuard>,
+    );
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(screen.queryByTestId("admin-content")).not.toBeInTheDocument();
+    expect(screen.getByText("管理者権限が必要です")).toBeInTheDocument();
+  });
+
+  it("未認証のときは /signin?redirect=%2Fadmin にリダイレクトされる", async () => {
+    server.use(unauthenticatedHandler);
+    const { router } = setupNextNavigation({ pathname: "/admin" });
+
+    await renderWithProviders(
+      <AdminGuard>
+        <p data-testid="admin-content">管理画面コンテンツ</p>
+      </AdminGuard>,
+    );
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/signin?redirect=%2Fadmin");
+    });
+    expect(screen.queryByTestId("admin-content")).not.toBeInTheDocument();
+  });
+
+  it("admin かつ frozen のときは /dashboard にリダイレクトされる", async () => {
+    server.use(sessionHandler({ role: "admin", frozen: true }));
+    const { router } = setupNextNavigation({ pathname: "/admin" });
+
+    await renderWithProviders(
+      <AdminGuard>
+        <p data-testid="admin-content">管理画面コンテンツ</p>
+      </AdminGuard>,
+    );
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(screen.queryByTestId("admin-content")).not.toBeInTheDocument();
+  });
+
+  it("frozen な一般ユーザーも /dashboard にリダイレクトされる", async () => {
+    server.use(frozenSessionHandler);
+    const { router } = setupNextNavigation({ pathname: "/admin" });
+
+    await renderWithProviders(
+      <AdminGuard>
+        <p data-testid="admin-content">管理画面コンテンツ</p>
+      </AdminGuard>,
+    );
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(screen.queryByTestId("admin-content")).not.toBeInTheDocument();
+  });
+
+  it("セッション取得が transient エラーのときは redirect せず案内文を表示する", async () => {
+    server.use(sessionFetchFailureHandler);
+    const { router } = setupNextNavigation({ pathname: "/admin" });
+
+    await renderWithProviders(
+      <AdminGuard>
+        <p data-testid="admin-content">管理画面コンテンツ</p>
+      </AdminGuard>,
+    );
+
+    expect(
+      await screen.findByText("セッションを確認できませんでした"),
+    ).toBeInTheDocument();
+    expect(router.replace).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("admin-content")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/admin/AdminGuard.tsx
+++ b/src/components/admin/AdminGuard.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { useAtomValue } from "jotai";
+import { Trans } from "@lingui/react/macro";
+import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
+import { USER_ROLE } from "@/lib/auth";
+
+type Props = {
+  readonly children: ReactNode;
+};
+
+// /admin 配下の UX ガード。真の防御は Workers 側の adminProcedure が握っている。
+// 未認証 → /signin、role!="admin" or frozen → /dashboard へリダイレクト。
+const AdminGuard = ({ children }: Props) => {
+  const router = useRouter();
+  const { user, isLoading, hasError } = useAtomValue(authSessionUnwrappedAtom);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const isAdmin = user?.role === USER_ROLE.ADMIN && !user.frozen;
+
+  useEffect(() => {
+    if (!isMounted || isLoading || hasError) return;
+    if (user === undefined) {
+      router.replace("/signin?redirect=%2Fadmin");
+      return;
+    }
+    if (!isAdmin) {
+      router.replace("/dashboard");
+    }
+  }, [isMounted, isLoading, hasError, user, isAdmin, router]);
+
+  if (!isMounted || isLoading) {
+    return undefined;
+  }
+
+  if (hasError) {
+    return (
+      <div
+        role="status"
+        className="mx-auto flex max-w-md flex-col items-center gap-3 px-5 py-12 text-center"
+      >
+        <p className="text-base font-medium text-text-primary">
+          <Trans>セッションを確認できませんでした</Trans>
+        </p>
+        <p className="text-sm text-text-secondary">
+          <Trans>通信状況を確認してから再読み込みしてください</Trans>
+        </p>
+      </div>
+    );
+  }
+
+  if (user === undefined || !isAdmin) {
+    return (
+      <div
+        role="status"
+        className="mx-auto flex max-w-md flex-col items-center gap-3 px-5 py-12 text-center"
+      >
+        <p className="text-base font-medium text-text-primary">
+          <Trans>管理者権限が必要です</Trans>
+        </p>
+        <p className="text-sm text-text-secondary">
+          <Trans>権限のあるアカウントで再ログインしてください</Trans>
+        </p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export default AdminGuard;

--- a/src/components/admin/AdminSideNav.test.tsx
+++ b/src/components/admin/AdminSideNav.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import AdminSideNav from "./AdminSideNav";
+
+const getLink = (href: string) => {
+  const link = screen
+    .getAllByRole("link")
+    .find((el) => el.getAttribute("href") === href);
+  expect(link, `Nav link not found for href: ${href}`).toBeDefined();
+  return link!;
+};
+
+describe("AdminSideNav", () => {
+  beforeEach(() => {
+    setupNextNavigation({ pathname: "/admin" });
+  });
+
+  it("メトリクス・ユーザー・監査ログの 3 リンクを表示する", async () => {
+    await renderWithProviders(<AdminSideNav />);
+
+    expect(getLink("/admin")).toBeInTheDocument();
+    expect(getLink("/admin/users")).toBeInTheDocument();
+    expect(getLink("/admin/audits")).toBeInTheDocument();
+    expect(screen.getByText("メトリクス")).toBeInTheDocument();
+    expect(screen.getByText("ユーザー")).toBeInTheDocument();
+    expect(screen.getByText("監査ログ")).toBeInTheDocument();
+  });
+
+  it("pathname が /admin のときメトリクスのみが active になる (完全一致)", async () => {
+    setupNextNavigation({ pathname: "/admin" });
+    await renderWithProviders(<AdminSideNav />);
+
+    expect(getLink("/admin").getAttribute("aria-current")).toBe("page");
+    expect(getLink("/admin/users").getAttribute("aria-current")).toBeNull();
+    expect(getLink("/admin/audits").getAttribute("aria-current")).toBeNull();
+  });
+
+  it("pathname が /admin/users のときユーザーが active になり、メトリクスは active にならない", async () => {
+    setupNextNavigation({ pathname: "/admin/users" });
+    await renderWithProviders(<AdminSideNav />);
+
+    expect(getLink("/admin/users").getAttribute("aria-current")).toBe("page");
+    expect(getLink("/admin").getAttribute("aria-current")).toBeNull();
+  });
+
+  it("pathname が /admin/users/<id> のときユーザーが active のままになる (前方一致)", async () => {
+    setupNextNavigation({ pathname: "/admin/users/u-1" });
+    await renderWithProviders(<AdminSideNav />);
+
+    expect(getLink("/admin/users").getAttribute("aria-current")).toBe("page");
+    expect(getLink("/admin").getAttribute("aria-current")).toBeNull();
+  });
+
+  it("pathname が /admin/audits のとき監査ログが active になる", async () => {
+    setupNextNavigation({ pathname: "/admin/audits" });
+    await renderWithProviders(<AdminSideNav />);
+
+    expect(getLink("/admin/audits").getAttribute("aria-current")).toBe("page");
+    expect(getLink("/admin").getAttribute("aria-current")).toBeNull();
+    expect(getLink("/admin/users").getAttribute("aria-current")).toBeNull();
+  });
+
+  it("pathname が /dashboard のときどのリンクも active にならない", async () => {
+    setupNextNavigation({ pathname: "/dashboard" });
+    await renderWithProviders(<AdminSideNav />);
+
+    expect(getLink("/admin").getAttribute("aria-current")).toBeNull();
+    expect(getLink("/admin/users").getAttribute("aria-current")).toBeNull();
+    expect(getLink("/admin/audits").getAttribute("aria-current")).toBeNull();
+  });
+});

--- a/src/components/admin/AdminSideNav.tsx
+++ b/src/components/admin/AdminSideNav.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { BarChart3, Users, ScrollText } from "lucide-react";
+import clsx from "clsx";
+import { Trans } from "@lingui/react/macro";
+import { msg } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+
+const ADMIN_NAV_LINKS = [
+  { href: "/admin", icon: BarChart3, label: msg`メトリクス` },
+  { href: "/admin/users", icon: Users, label: msg`ユーザー` },
+  { href: "/admin/audits", icon: ScrollText, label: msg`監査ログ` },
+];
+
+const isActiveAdminPath = (current: string, target: string): boolean =>
+  target === "/admin"
+    ? current === "/admin"
+    : current === target || current.startsWith(`${target}/`);
+
+const AdminSideNav = () => {
+  const pathname = usePathname();
+  const { i18n } = useLingui();
+
+  return (
+    <nav
+      aria-label={i18n._(msg`管理画面ナビゲーション`)}
+      className="flex flex-col gap-1 lg:w-56"
+    >
+      <p className="px-3 pb-1 pt-2 text-xs font-semibold uppercase tracking-wider text-text-tertiary">
+        <Trans>管理</Trans>
+      </p>
+      <ul className="flex flex-row gap-1 overflow-x-auto lg:flex-col lg:overflow-x-visible">
+        {ADMIN_NAV_LINKS.map(({ href, icon: Icon, label }) => {
+          const isActive = isActiveAdminPath(pathname, href);
+          return (
+            <li key={href}>
+              <Link
+                href={href}
+                aria-current={isActive ? "page" : undefined}
+                className={clsx(
+                  "flex items-center gap-2 whitespace-nowrap rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-primary-100 text-primary-700"
+                    : "text-text-secondary hover:bg-primary-50 hover:text-text-primary",
+                )}
+              >
+                <Icon className="size-4" />
+                {i18n._(label)}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};
+
+export default AdminSideNav;

--- a/src/components/admin/AuditLogTable.test.tsx
+++ b/src/components/admin/AuditLogTable.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/testUtils";
+import AuditLogTable from "./AuditLogTable";
+import type { AdminAuditLog } from "@/stores/adminAtoms";
+
+const buildLog = (overrides: Partial<AdminAuditLog> = {}): AdminAuditLog => ({
+  id: overrides.id ?? "log-1",
+  actorUserId: overrides.actorUserId ?? "admin-1",
+  action: overrides.action ?? "user.freeze",
+  targetUserId: overrides.targetUserId,
+  metadata: overrides.metadata,
+  createdAt: overrides.createdAt ?? new Date("2025-06-15T10:00:00Z").getTime(),
+});
+
+describe("AuditLogTable", () => {
+  it("ヘッダーと action / actor / target / metadata が表示される", async () => {
+    await renderWithProviders(
+      <AuditLogTable
+        logs={[
+          buildLog({
+            id: "log-1",
+            actorUserId: "actor-A",
+            targetUserId: "target-B",
+            metadata: '{"reason":"spam"}',
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("発生日時")).toBeInTheDocument();
+    expect(screen.getByText("操作")).toBeInTheDocument();
+    expect(screen.getByText("実行者")).toBeInTheDocument();
+    expect(screen.getByText("対象")).toBeInTheDocument();
+    expect(screen.getByText("メタデータ")).toBeInTheDocument();
+
+    expect(screen.getByText("actor-A")).toBeInTheDocument();
+    expect(screen.getByText("target-B")).toBeInTheDocument();
+    expect(screen.getByText('{"reason":"spam"}')).toBeInTheDocument();
+    expect(screen.getByText("user.freeze")).toBeInTheDocument();
+  });
+
+  it("targetUserId が undefined のとき — 表示になる", async () => {
+    await renderWithProviders(
+      <AuditLogTable
+        logs={[
+          buildLog({
+            id: "log-no-target",
+            targetUserId: undefined,
+          }),
+        ]}
+      />,
+    );
+
+    // 対象セルは — になる。metadata も undefined のときも — になる。
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("metadata が undefined または 空文字列のとき — 表示になる", async () => {
+    await renderWithProviders(
+      <AuditLogTable
+        logs={[
+          buildLog({
+            id: "log-meta-undef",
+            targetUserId: "t-1",
+            metadata: undefined,
+          }),
+          buildLog({
+            id: "log-meta-empty",
+            targetUserId: "t-2",
+            metadata: "",
+          }),
+        ]}
+      />,
+    );
+
+    // 各 log の metadata セルがそれぞれ — を出す
+    expect(screen.getAllByText("—")).toHaveLength(2);
+  });
+
+  it("UTC 形式の日時文字列が表示される", async () => {
+    await renderWithProviders(
+      <AuditLogTable
+        logs={[
+          buildLog({
+            id: "log-time",
+            createdAt: new Date("2025-06-15T10:00:00.000Z").getTime(),
+          }),
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText(/2025-06-15 10:00:00\.000 UTC/),
+    ).toBeInTheDocument();
+  });
+
+  it("logs が 空のときヘッダーのみで本文行は出ない", async () => {
+    await renderWithProviders(<AuditLogTable logs={[]} />);
+
+    // ヘッダー以外の行が存在しないことを確認
+    expect(screen.getByText("操作")).toBeInTheDocument();
+    expect(screen.queryAllByText("user.freeze")).toHaveLength(0);
+  });
+});

--- a/src/components/admin/AuditLogTable.tsx
+++ b/src/components/admin/AuditLogTable.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import Badge from "@/components/ui/Badge";
+import type { AdminAuditLog } from "@/stores/adminAtoms";
+
+type Props = {
+  readonly logs: readonly AdminAuditLog[];
+};
+
+const formatDateTime = (ms: number): string =>
+  new Date(ms).toISOString().replace("T", " ").replace("Z", " UTC");
+
+const formatMetadata = (raw: string | undefined): string => {
+  if (raw === undefined || raw === "") return "—";
+  return raw;
+};
+
+const AuditLogTable = ({ logs }: Props) => (
+  <div className="overflow-x-auto rounded-xl border border-border-default bg-surface-overlay">
+    <table className="w-full text-left text-sm">
+      <thead className="bg-surface-base text-xs font-medium uppercase tracking-wider text-text-tertiary">
+        <tr>
+          <th scope="col" className="px-4 py-3">
+            <Trans>発生日時</Trans>
+          </th>
+          <th scope="col" className="px-4 py-3">
+            <Trans>操作</Trans>
+          </th>
+          <th scope="col" className="px-4 py-3">
+            <Trans>実行者</Trans>
+          </th>
+          <th scope="col" className="px-4 py-3">
+            <Trans>対象</Trans>
+          </th>
+          <th scope="col" className="px-4 py-3">
+            <Trans>メタデータ</Trans>
+          </th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-border-default">
+        {logs.map((log) => (
+          <tr key={log.id} className="hover:bg-primary-50/50 align-top">
+            <td className="px-4 py-3 text-text-tertiary tabular-nums whitespace-nowrap">
+              {formatDateTime(log.createdAt)}
+            </td>
+            <td className="px-4 py-3">
+              <Badge variant="primary">{log.action}</Badge>
+            </td>
+            <td className="px-4 py-3 text-text-secondary font-mono text-xs">
+              {log.actorUserId}
+            </td>
+            <td className="px-4 py-3 text-text-secondary font-mono text-xs">
+              {log.targetUserId ?? "—"}
+            </td>
+            <td className="px-4 py-3 text-text-tertiary font-mono text-xs break-all">
+              {formatMetadata(log.metadata)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default AuditLogTable;

--- a/src/components/admin/MetricsCard.test.tsx
+++ b/src/components/admin/MetricsCard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { Users } from "lucide-react";
+import { renderWithProviders } from "@/test/testUtils";
+import MetricsCard from "./MetricsCard";
+
+describe("MetricsCard", () => {
+  it("label と value (toLocaleString) を表示する", async () => {
+    await renderWithProviders(
+      <MetricsCard icon={Users} label="総ユーザー数" value={1234567} />,
+    );
+
+    expect(screen.getByText("総ユーザー数")).toBeInTheDocument();
+    expect(screen.getByText("1,234,567")).toBeInTheDocument();
+  });
+
+  it("hint プロパティを指定すると補足文として描画される", async () => {
+    await renderWithProviders(
+      <MetricsCard
+        icon={Users}
+        label="アクティブ"
+        value={42}
+        hint="直近30日で 1 回以上スキャン"
+      />,
+    );
+
+    expect(screen.getByText("直近30日で 1 回以上スキャン")).toBeInTheDocument();
+  });
+
+  it("hint を指定しないと補足文は描画されない", async () => {
+    await renderWithProviders(
+      <MetricsCard icon={Users} label="シンプル" value={0} />,
+    );
+
+    expect(
+      screen.queryByText("直近30日で 1 回以上スキャン"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+});

--- a/src/components/admin/MetricsCard.tsx
+++ b/src/components/admin/MetricsCard.tsx
@@ -1,0 +1,32 @@
+import type { LucideIcon } from "lucide-react";
+import Card from "@/components/ui/Card";
+
+type Props = {
+  readonly icon: LucideIcon;
+  readonly label: string;
+  readonly value: number;
+  readonly hint?: string;
+};
+
+const MetricsCard = ({ icon: Icon, label, value, hint }: Props) => (
+  <Card>
+    <div className="flex items-start justify-between gap-3">
+      <div className="flex flex-col gap-1">
+        <p className="text-xs font-medium uppercase tracking-wider text-text-tertiary">
+          {label}
+        </p>
+        <p className="font-display text-2xl font-bold text-text-primary tabular-nums">
+          {value.toLocaleString()}
+        </p>
+        {hint !== undefined && (
+          <p className="text-xs text-text-tertiary">{hint}</p>
+        )}
+      </div>
+      <div className="flex size-10 items-center justify-center rounded-xl bg-primary-50 text-primary-600">
+        <Icon className="size-5" />
+      </div>
+    </div>
+  </Card>
+);
+
+export default MetricsCard;

--- a/src/components/admin/UserDataTabs.test.tsx
+++ b/src/components/admin/UserDataTabs.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { server } from "@/test/mocks/server";
+import { adminSessionHandler } from "@/test/mocks/handlers";
+import { trpcQuery } from "@/test/mocks/trpc/handlerFactory";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import UserDataTabs from "./UserDataTabs";
+
+describe("UserDataTabs", () => {
+  beforeEach(() => {
+    setupNextNavigation({ pathname: "/admin/users/u-target" });
+    server.use(adminSessionHandler);
+  });
+
+  it("初期は 服 タブで garments 用クエリが発火し、空メッセージが表示される", async () => {
+    server.use(
+      trpcQuery("admin.userDataView.garments", () => ({
+        items: [],
+        total: 0,
+      })),
+    );
+
+    await renderWithProviders(<UserDataTabs userId="u-target" />);
+
+    expect(
+      await screen.findByText("このユーザーの服はまだ登録されていません"),
+    ).toBeInTheDocument();
+  });
+
+  it("garments に複数件あるとき名前・カテゴリ・件数フッターが表示される", async () => {
+    server.use(
+      trpcQuery("admin.userDataView.garments", () => ({
+        items: [
+          {
+            id: "g-1",
+            userId: "u-target",
+            name: "黒ワンピ",
+            category: "onepiece" as const,
+            dollSizes: ["MSD" as const],
+            colors: [],
+            tags: [],
+            imageUrl: undefined,
+            locationId: undefined,
+            status: "stored" as const,
+            lastScannedAt: 0,
+            confidenceDecayDays: 30,
+            brand: undefined,
+            checkedOutAt: undefined,
+            recentCheckoutCount: 0,
+            createdAt: 0,
+            updatedAt: 0,
+          },
+        ],
+        total: 3,
+      })),
+    );
+
+    await renderWithProviders(<UserDataTabs userId="u-target" />);
+
+    expect(await screen.findByText("黒ワンピ")).toBeInTheDocument();
+    expect(screen.getByText("onepiece")).toBeInTheDocument();
+    expect(screen.getByText(/1 \/ 3件表示/)).toBeInTheDocument();
+  });
+
+  it("収納 タブをクリックすると locations 用クエリが発火する", async () => {
+    const user = userEvent.setup();
+    const callRef: { current: { userId: string } | undefined } = {
+      current: undefined,
+    };
+    server.use(
+      trpcQuery("admin.userDataView.locations", ({ input }) => {
+        callRef.current = input as { userId: string };
+        return [];
+      }),
+    );
+
+    await renderWithProviders(<UserDataTabs userId="u-target" />);
+
+    // 初期 garments が解決するまで待ち、それから 収納 タブをクリック
+    await screen.findByText("このユーザーの服はまだ登録されていません");
+    await user.click(screen.getByRole("button", { name: "収納" }));
+
+    await waitFor(() => {
+      expect(callRef.current?.userId).toBe("u-target");
+    });
+  });
+
+  it("コーデ タブをクリックすると coordinates 用クエリが発火する", async () => {
+    const user = userEvent.setup();
+    const callRef: { current: { userId: string } | undefined } = {
+      current: undefined,
+    };
+    server.use(
+      trpcQuery("admin.userDataView.coordinates", ({ input }) => {
+        callRef.current = input as { userId: string };
+        return { items: [], total: 0 };
+      }),
+    );
+
+    await renderWithProviders(<UserDataTabs userId="u-target" />);
+
+    await screen.findByText("このユーザーの服はまだ登録されていません");
+    await user.click(screen.getByRole("button", { name: "コーデ" }));
+
+    await waitFor(() => {
+      expect(callRef.current?.userId).toBe("u-target");
+    });
+  });
+
+  it("aria-current が active なタブのみに 設定される", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<UserDataTabs userId="u-target" />);
+
+    await screen.findByText("このユーザーの服はまだ登録されていません");
+
+    const garmentsTab = screen.getByRole("button", { name: "服" });
+    const locationsTab = screen.getByRole("button", { name: "収納" });
+    const coordinatesTab = screen.getByRole("button", { name: "コーデ" });
+
+    // 初期 active = garments
+    expect(garmentsTab.getAttribute("aria-current")).toBe("page");
+    expect(locationsTab.getAttribute("aria-current")).toBeNull();
+    expect(coordinatesTab.getAttribute("aria-current")).toBeNull();
+
+    // 収納 タブをクリック
+    await user.click(locationsTab);
+
+    await waitFor(() => {
+      expect(locationsTab.getAttribute("aria-current")).toBe("page");
+    });
+    expect(garmentsTab.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("閲覧専用 バッジが常に表示される", async () => {
+    await renderWithProviders(<UserDataTabs userId="u-target" />);
+
+    expect(await screen.findByText("閲覧専用")).toBeInTheDocument();
+  });
+
+  it("ユーザーデータ閲覧 という aria-label の nav が描画される", async () => {
+    await renderWithProviders(<UserDataTabs userId="u-target" />);
+
+    expect(
+      await screen.findByRole("navigation", { name: "ユーザーデータ閲覧" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/admin/UserDataTabs.tsx
+++ b/src/components/admin/UserDataTabs.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { Suspense, useMemo, useState } from "react";
+import { useAtomValue } from "jotai";
+import { Eye } from "lucide-react";
+import clsx from "clsx";
+import { Trans } from "@lingui/react/macro";
+import { useLingui } from "@lingui/react";
+import { msg } from "@lingui/core/macro";
+import Badge from "@/components/ui/Badge";
+import Skeleton from "@/components/ui/Skeleton";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
+import {
+  adminUserCoordinatesAtomFamily,
+  adminUserGarmentsAtomFamily,
+  adminUserLocationsAtomFamily,
+} from "@/stores/adminAtoms";
+
+type TabKey = "garments" | "locations" | "coordinates";
+
+type Props = {
+  readonly userId: string;
+};
+
+const TAB_DEFS = [
+  { key: "garments" as const, label: msg`服` },
+  { key: "locations" as const, label: msg`収納` },
+  { key: "coordinates" as const, label: msg`コーデ` },
+];
+
+const ReadOnlyBadge = () => (
+  <Badge variant="default">
+    <Eye className="size-3" />
+    <Trans>閲覧専用</Trans>
+  </Badge>
+);
+
+const GarmentsView = ({ userId }: { readonly userId: string }) => {
+  const garmentsAtom = useMemo(
+    () => adminUserGarmentsAtomFamily(userId, 0),
+    [userId],
+  );
+  const result = useAtomValue(garmentsAtom);
+
+  if (result.items.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-text-tertiary">
+        <Trans>このユーザーの服はまだ登録されていません</Trans>
+      </p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-border-default rounded-xl border border-border-default bg-surface-overlay">
+      {result.items.map((g) => (
+        <li
+          key={g.id}
+          className="flex items-center justify-between gap-3 px-4 py-3 text-sm"
+        >
+          <div className="flex flex-col">
+            <span className="font-medium text-text-primary">{g.name}</span>
+            <span className="text-xs text-text-tertiary">{g.category}</span>
+          </div>
+          <span className="font-mono text-xs text-text-tertiary">{g.id}</span>
+        </li>
+      ))}
+      <li className="px-4 py-2 text-xs text-text-tertiary">
+        <Trans>
+          {result.items.length} / {result.total}件表示
+        </Trans>
+      </li>
+    </ul>
+  );
+};
+
+const LocationsView = ({ userId }: { readonly userId: string }) => {
+  const locationsAtom = useMemo(
+    () => adminUserLocationsAtomFamily(userId),
+    [userId],
+  );
+  const items = useAtomValue(locationsAtom);
+
+  if (items.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-text-tertiary">
+        <Trans>このユーザーの収納場所はまだ登録されていません</Trans>
+      </p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-border-default rounded-xl border border-border-default bg-surface-overlay">
+      {items.map((loc) => (
+        <li
+          key={loc.id}
+          className="flex items-center justify-between gap-3 px-4 py-3 text-sm"
+        >
+          <span className="font-medium text-text-primary">{loc.label}</span>
+          <span className="font-mono text-xs text-text-tertiary">{loc.id}</span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+const CoordinatesView = ({ userId }: { readonly userId: string }) => {
+  const coordinatesAtom = useMemo(
+    () => adminUserCoordinatesAtomFamily(userId, 0),
+    [userId],
+  );
+  const result = useAtomValue(coordinatesAtom);
+
+  if (result.items.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-text-tertiary">
+        <Trans>このユーザーのコーデはまだ登録されていません</Trans>
+      </p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-border-default rounded-xl border border-border-default bg-surface-overlay">
+      {result.items.map((c) => (
+        <li
+          key={c.id}
+          className="flex items-center justify-between gap-3 px-4 py-3 text-sm"
+        >
+          <div className="flex flex-col">
+            <span className="font-medium text-text-primary">{c.name}</span>
+            <span className="text-xs text-text-tertiary">
+              <Trans>{c.garmentIds.length}件の服</Trans>
+            </span>
+          </div>
+          <span className="font-mono text-xs text-text-tertiary">{c.id}</span>
+        </li>
+      ))}
+      <li className="px-4 py-2 text-xs text-text-tertiary">
+        <Trans>
+          {result.items.length} / {result.total}件表示
+        </Trans>
+      </li>
+    </ul>
+  );
+};
+
+const UserDataTabs = ({ userId }: Props) => {
+  const [active, setActive] = useState<TabKey>("garments");
+  const { i18n } = useLingui();
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <nav
+          aria-label={i18n._(msg`ユーザーデータ閲覧`)}
+          className="inline-flex rounded-xl bg-primary-50 p-1 text-sm font-medium"
+        >
+          {TAB_DEFS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setActive(key)}
+              aria-current={active === key ? "page" : undefined}
+              className={clsx(
+                "rounded-lg px-4 py-1.5 transition-colors",
+                active === key
+                  ? "bg-surface-overlay text-text-primary shadow-sm"
+                  : "text-text-secondary hover:text-text-primary",
+              )}
+            >
+              {i18n._(label)}
+            </button>
+          ))}
+        </nav>
+        <ReadOnlyBadge />
+      </div>
+
+      <ErrorBoundary
+        fallback={
+          <p className="text-sm text-danger">
+            <Trans>読み込みに失敗しました</Trans>
+          </p>
+        }
+      >
+        <Suspense fallback={<Skeleton className="h-32 rounded-xl" />}>
+          {active === "garments" && <GarmentsView userId={userId} />}
+          {active === "locations" && <LocationsView userId={userId} />}
+          {active === "coordinates" && <CoordinatesView userId={userId} />}
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+};
+
+export default UserDataTabs;

--- a/src/components/admin/UserFreezeButton.test.tsx
+++ b/src/components/admin/UserFreezeButton.test.tsx
@@ -1,11 +1,21 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { server } from "@/test/mocks/server";
 import { trpcMutation } from "@/test/mocks/trpc/handlerFactory";
 import { renderWithProviders } from "@/test/testUtils";
 import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import ToastContainer from "@/components/ui/Toast";
 import UserFreezeButton from "./UserFreezeButton";
+
+// Toast は本番では AppShell 配下で描画されるため、テストでも一緒に mount しないと
+// addToast が atom を更新しても画面に出ない。
+const WithToast = ({ children }: { readonly children: React.ReactNode }) => (
+  <>
+    {children}
+    <ToastContainer />
+  </>
+);
 
 describe("UserFreezeButton", () => {
   beforeEach(() => {
@@ -60,13 +70,8 @@ describe("UserFreezeButton", () => {
 
   it("ConfirmSheet で キャンセル を押すと mutation は呼ばれない", async () => {
     const user = userEvent.setup();
-    const callRef: { current: boolean } = { current: false };
-    server.use(
-      trpcMutation("admin.users.freeze", () => {
-        callRef.current = true;
-        return { ok: true as const, noop: false };
-      }),
-    );
+    const resolver = vi.fn(() => ({ ok: true as const, noop: false }));
+    server.use(trpcMutation("admin.users.freeze", resolver));
 
     await renderWithProviders(
       <UserFreezeButton targetUserId="u-target" frozen={false} />,
@@ -82,7 +87,59 @@ describe("UserFreezeButton", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
-    expect(callRef.current).toBe(false);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it("freeze mutation が reject されたとき toast でエラーを表示する", async () => {
+    const user = userEvent.setup();
+    server.use(
+      trpcMutation(
+        "admin.users.freeze",
+        async () => await Promise.reject(new Error("FORBIDDEN: admin->admin")),
+      ),
+    );
+
+    await renderWithProviders(
+      <WithToast>
+        <UserFreezeButton targetUserId="u-target" frozen={false} />
+      </WithToast>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /凍結する/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "凍結する" }));
+
+    expect(
+      await screen.findByText(
+        "凍結に失敗しました。時間をおいて再度お試しください",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("unfreeze mutation が reject されたとき 解凍失敗 toast を表示する", async () => {
+    const user = userEvent.setup();
+    server.use(
+      trpcMutation(
+        "admin.users.unfreeze",
+        async () => await Promise.reject(new Error("INTERNAL_ERROR")),
+      ),
+    );
+
+    await renderWithProviders(
+      <WithToast>
+        <UserFreezeButton targetUserId="u-target" frozen={true} />
+      </WithToast>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /解凍する/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "解凍する" }));
+
+    expect(
+      await screen.findByText(
+        "解凍に失敗しました。時間をおいて再度お試しください",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("frozen=true の場合は 解凍する ラベルと message が出る", async () => {

--- a/src/components/admin/UserFreezeButton.test.tsx
+++ b/src/components/admin/UserFreezeButton.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { server } from "@/test/mocks/server";
+import { trpcMutation } from "@/test/mocks/trpc/handlerFactory";
+import { renderWithProviders } from "@/test/testUtils";
+import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
+import UserFreezeButton from "./UserFreezeButton";
+
+describe("UserFreezeButton", () => {
+  beforeEach(() => {
+    setupNextNavigation({ pathname: "/admin/users/u-target" });
+  });
+
+  it("disabled を渡さない場合は デフォルト false としてボタンが押せる", async () => {
+    await renderWithProviders(
+      <UserFreezeButton targetUserId="u-target" frozen={false} />,
+    );
+
+    expect(screen.getByRole("button", { name: /凍結する/ })).toBeEnabled();
+  });
+
+  it("disabled=false のとき disabledReason を渡しても補足文は表示されない", async () => {
+    await renderWithProviders(
+      <UserFreezeButton
+        targetUserId="u-target"
+        frozen={false}
+        disabled={false}
+        disabledReason="表示されないはず"
+      />,
+    );
+
+    expect(screen.queryByText("表示されないはず")).not.toBeInTheDocument();
+  });
+
+  it("disabled=true で disabledReason を渡すと補足文が表示され、ボタンは押せない", async () => {
+    await renderWithProviders(
+      <UserFreezeButton
+        targetUserId="u-target"
+        frozen={false}
+        disabled={true}
+        disabledReason="自分自身は凍結できません"
+      />,
+    );
+
+    expect(screen.getByText("自分自身は凍結できません")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /凍結する/ })).toBeDisabled();
+  });
+
+  it("disabled=true で disabledReason が未指定だと補足文は出ない", async () => {
+    await renderWithProviders(
+      <UserFreezeButton targetUserId="u-target" frozen={false} disabled />,
+    );
+
+    expect(
+      screen.queryByText("自分自身は凍結できません"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /凍結する/ })).toBeDisabled();
+  });
+
+  it("ConfirmSheet で キャンセル を押すと mutation は呼ばれない", async () => {
+    const user = userEvent.setup();
+    const callRef: { current: boolean } = { current: false };
+    server.use(
+      trpcMutation("admin.users.freeze", () => {
+        callRef.current = true;
+        return { ok: true as const, noop: false };
+      }),
+    );
+
+    await renderWithProviders(
+      <UserFreezeButton targetUserId="u-target" frozen={false} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /凍結する/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "キャンセル" }),
+    );
+
+    // dialog が閉じる
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(callRef.current).toBe(false);
+  });
+
+  it("frozen=true の場合は 解凍する ラベルと message が出る", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(
+      <UserFreezeButton targetUserId="u-target" frozen={true} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /解凍する/ }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText("このユーザーを解凍しますか？"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        "解凍すると再びログインできるようになります。データは保持されます。",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/admin/UserFreezeButton.tsx
+++ b/src/components/admin/UserFreezeButton.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { Snowflake, Sun } from "lucide-react";
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { useLingui } from "@lingui/react";
+import type { I18n } from "@lingui/core";
+import Button from "@/components/ui/Button";
+import ConfirmSheet from "@/components/ui/ConfirmSheet";
+import { freezeUserAtom, unfreezeUserAtom } from "@/stores/adminAtoms";
+
+type Props = {
+  readonly targetUserId: string;
+  readonly frozen: boolean;
+  readonly disabled?: boolean;
+  readonly disabledReason?: string;
+};
+
+type DialogCopy = {
+  readonly title: string;
+  readonly message: string;
+  readonly confirmLabel: string;
+  readonly confirmVariant: "primary" | "danger";
+};
+
+const buildDialogCopy = (i18n: I18n, frozen: boolean): DialogCopy =>
+  frozen
+    ? {
+        title: i18n._(t`このユーザーを解凍しますか？`),
+        message: i18n._(
+          t`解凍すると再びログインできるようになります。データは保持されます。`,
+        ),
+        confirmLabel: i18n._(t`解凍する`),
+        confirmVariant: "primary",
+      }
+    : {
+        title: i18n._(t`このユーザーを凍結しますか？`),
+        message: i18n._(
+          t`凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。`,
+        ),
+        confirmLabel: i18n._(t`凍結する`),
+        confirmVariant: "danger",
+      };
+
+const UserFreezeButton = ({
+  targetUserId,
+  frozen,
+  disabled = false,
+  disabledReason,
+}: Props) => {
+  const freezeUser = useSetAtom(freezeUserAtom);
+  const unfreezeUser = useSetAtom(unfreezeUserAtom);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const { i18n } = useLingui();
+
+  const handleConfirm = () => {
+    const fire = frozen ? unfreezeUser : freezeUser;
+    fire({ targetUserId });
+  };
+
+  const copy = buildDialogCopy(i18n, frozen);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Button
+        variant={frozen ? "secondary" : "danger"}
+        size="md"
+        onClick={() => setIsConfirmOpen(true)}
+        disabled={disabled}
+      >
+        {frozen ? <Sun className="size-4" /> : <Snowflake className="size-4" />}
+        {frozen ? <Trans>解凍する</Trans> : <Trans>凍結する</Trans>}
+      </Button>
+      {disabled && disabledReason !== undefined && (
+        <p className="text-xs text-text-tertiary">{disabledReason}</p>
+      )}
+      <ConfirmSheet
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={handleConfirm}
+        title={copy.title}
+        message={copy.message}
+        confirmLabel={copy.confirmLabel}
+        confirmVariant={copy.confirmVariant}
+      />
+    </div>
+  );
+};
+
+export default UserFreezeButton;

--- a/src/components/admin/UserFreezeButton.tsx
+++ b/src/components/admin/UserFreezeButton.tsx
@@ -9,6 +9,7 @@ import { useLingui } from "@lingui/react";
 import type { I18n } from "@lingui/core";
 import Button from "@/components/ui/Button";
 import ConfirmSheet from "@/components/ui/ConfirmSheet";
+import { addToastAtom } from "@/stores/toastAtoms";
 import { freezeUserAtom, unfreezeUserAtom } from "@/stores/adminAtoms";
 
 type Props = {
@@ -23,6 +24,7 @@ type DialogCopy = {
   readonly message: string;
   readonly confirmLabel: string;
   readonly confirmVariant: "primary" | "danger";
+  readonly errorMessage: string;
 };
 
 const buildDialogCopy = (i18n: I18n, frozen: boolean): DialogCopy =>
@@ -34,6 +36,9 @@ const buildDialogCopy = (i18n: I18n, frozen: boolean): DialogCopy =>
         ),
         confirmLabel: i18n._(t`解凍する`),
         confirmVariant: "primary",
+        errorMessage: i18n._(
+          t`解凍に失敗しました。時間をおいて再度お試しください`,
+        ),
       }
     : {
         title: i18n._(t`このユーザーを凍結しますか？`),
@@ -42,7 +47,14 @@ const buildDialogCopy = (i18n: I18n, frozen: boolean): DialogCopy =>
         ),
         confirmLabel: i18n._(t`凍結する`),
         confirmVariant: "danger",
+        errorMessage: i18n._(
+          t`凍結に失敗しました。時間をおいて再度お試しください`,
+        ),
       };
+
+// mutate が reject されたかを判別する sentinel。await の値が success/failure
+// どちらも void なので、try/catch を使わず .catch のみで判別するために使う。
+const FAIL_SENTINEL = Symbol("user-freeze-fail");
 
 const UserFreezeButton = ({
   targetUserId,
@@ -52,15 +64,19 @@ const UserFreezeButton = ({
 }: Props) => {
   const freezeUser = useSetAtom(freezeUserAtom);
   const unfreezeUser = useSetAtom(unfreezeUserAtom);
+  const addToast = useSetAtom(addToastAtom);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const { i18n } = useLingui();
 
-  const handleConfirm = () => {
-    const fire = frozen ? unfreezeUser : freezeUser;
-    fire({ targetUserId });
-  };
-
   const copy = buildDialogCopy(i18n, frozen);
+
+  const handleConfirm = async () => {
+    const fire = frozen ? unfreezeUser : freezeUser;
+    const outcome = await fire({ targetUserId }).catch(() => FAIL_SENTINEL);
+    if (outcome === FAIL_SENTINEL) {
+      addToast({ message: copy.errorMessage });
+    }
+  };
 
   return (
     <div className="flex flex-col gap-1">
@@ -79,7 +95,9 @@ const UserFreezeButton = ({
       <ConfirmSheet
         isOpen={isConfirmOpen}
         onClose={() => setIsConfirmOpen(false)}
-        onConfirm={handleConfirm}
+        onConfirm={() => {
+          void handleConfirm();
+        }}
         title={copy.title}
         message={copy.message}
         confirmLabel={copy.confirmLabel}

--- a/src/components/admin/UserTable.test.tsx
+++ b/src/components/admin/UserTable.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/testUtils";
+import UserTable from "./UserTable";
+import type { AdminUser } from "@/stores/adminAtoms";
+
+const buildUser = (overrides: Partial<AdminUser> = {}): AdminUser => ({
+  id: overrides.id ?? "u-1",
+  name: overrides.name ?? "ユーザー名",
+  email: overrides.email ?? "user@example.com",
+  emailVerified: overrides.emailVerified ?? true,
+  image: overrides.image,
+  role: overrides.role ?? "user",
+  frozen: overrides.frozen ?? false,
+  createdAt: overrides.createdAt ?? new Date("2025-01-01").getTime(),
+  updatedAt: overrides.updatedAt ?? new Date("2025-01-02").getTime(),
+});
+
+describe("UserTable", () => {
+  it("一般ユーザーと管理者で role バッジが切り替わる", async () => {
+    await renderWithProviders(
+      <UserTable
+        users={[
+          buildUser({ id: "u-user", role: "user" }),
+          buildUser({
+            id: "u-admin",
+            role: "admin",
+            email: "admin@example.com",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("一般")).toBeInTheDocument();
+    expect(screen.getByText("管理者")).toBeInTheDocument();
+  });
+
+  it("frozen=true のユーザーは 凍結中 バッジが、false のユーザーは 有効 バッジが表示される", async () => {
+    await renderWithProviders(
+      <UserTable
+        users={[
+          buildUser({ id: "u-active", frozen: false }),
+          buildUser({
+            id: "u-frozen",
+            frozen: true,
+            email: "frozen@example.com",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("有効")).toBeInTheDocument();
+    expect(screen.getByText("凍結中")).toBeInTheDocument();
+  });
+
+  it("詳細リンクは /admin/users/<id> を指す", async () => {
+    await renderWithProviders(
+      <UserTable users={[buildUser({ id: "u-target" })]} />,
+    );
+
+    const link = screen.getByRole("link", { name: "ユーザー詳細を開く" });
+    expect(link).toHaveAttribute("href", "/admin/users/u-target");
+  });
+
+  it("登録日が ISO の年月日形式で表示される", async () => {
+    await renderWithProviders(
+      <UserTable
+        users={[
+          buildUser({
+            id: "u-date",
+            createdAt: new Date("2025-03-15T00:00:00Z").getTime(),
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("2025-03-15")).toBeInTheDocument();
+  });
+
+  it("users が空のとき本文行は出ない (ヘッダーのみ)", async () => {
+    await renderWithProviders(<UserTable users={[]} />);
+
+    expect(screen.getByText("名前")).toBeInTheDocument();
+    expect(screen.queryByText("一般")).not.toBeInTheDocument();
+    expect(screen.queryByText("管理者")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/admin/UserTable.tsx
+++ b/src/components/admin/UserTable.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import Link from "next/link";
+import { Trans } from "@lingui/react/macro";
+import { useLingui } from "@lingui/react";
+import { msg } from "@lingui/core/macro";
+import Badge from "@/components/ui/Badge";
+import type { AdminUser } from "@/stores/adminAtoms";
+
+type Props = {
+  readonly users: readonly AdminUser[];
+};
+
+const ISO_DATE_LENGTH = 10;
+
+const formatDate = (ms: number): string =>
+  new Date(ms).toISOString().slice(0, ISO_DATE_LENGTH);
+
+const UserTable = ({ users }: Props) => {
+  const { i18n } = useLingui();
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-border-default bg-surface-overlay">
+      <table className="w-full text-left text-sm">
+        <thead className="bg-surface-base text-xs font-medium uppercase tracking-wider text-text-tertiary">
+          <tr>
+            <th scope="col" className="px-4 py-3">
+              <Trans>名前</Trans>
+            </th>
+            <th scope="col" className="px-4 py-3">
+              <Trans>メール</Trans>
+            </th>
+            <th scope="col" className="px-4 py-3">
+              <Trans>権限</Trans>
+            </th>
+            <th scope="col" className="px-4 py-3">
+              <Trans>状態</Trans>
+            </th>
+            <th scope="col" className="px-4 py-3">
+              <Trans>登録日</Trans>
+            </th>
+            <th scope="col" className="px-4 py-3 text-right">
+              <span className="sr-only">
+                <Trans>操作</Trans>
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border-default">
+          {users.map((u) => (
+            <tr key={u.id} className="hover:bg-primary-50/50">
+              <td className="px-4 py-3 font-medium text-text-primary">
+                {u.name}
+              </td>
+              <td className="px-4 py-3 text-text-secondary">{u.email}</td>
+              <td className="px-4 py-3">
+                {u.role === "admin" ? (
+                  <Badge variant="primary">
+                    <Trans>管理者</Trans>
+                  </Badge>
+                ) : (
+                  <Badge>
+                    <Trans>一般</Trans>
+                  </Badge>
+                )}
+              </td>
+              <td className="px-4 py-3">
+                {u.frozen ? (
+                  <Badge variant="unknown">
+                    <Trans>凍結中</Trans>
+                  </Badge>
+                ) : (
+                  <Badge variant="confirmed">
+                    <Trans>有効</Trans>
+                  </Badge>
+                )}
+              </td>
+              <td className="px-4 py-3 text-text-tertiary tabular-nums">
+                {formatDate(u.createdAt)}
+              </td>
+              <td className="px-4 py-3 text-right">
+                <Link
+                  href={`/admin/users/${u.id}`}
+                  aria-label={i18n._(msg`ユーザー詳細を開く`)}
+                  className="text-sm font-medium text-primary-600 hover:underline"
+                >
+                  <Trans>詳細</Trans>
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default UserTable;

--- a/src/components/layout/BottomNav.test.tsx
+++ b/src/components/layout/BottomNav.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import { server } from "@/test/mocks/server";
+import { adminSessionHandler } from "@/test/mocks/handlers";
 import { renderWithProviders } from "@/test/testUtils";
 import { setupNextNavigation } from "@/test/mocks/modules/nextNavigation";
 import BottomNav from "./BottomNav";
@@ -135,5 +137,25 @@ describe("BottomNav", () => {
 
     expect(getNavLink("/locations").className).toContain(ACTIVE_CLASS);
     expect(getNavLink("/dashboard").className).toContain(INACTIVE_CLASS);
+  });
+
+  it("一般ユーザーには /admin リンクが表示されない", async () => {
+    setPathname("/dashboard");
+    await renderNav();
+
+    const adminLinks = screen
+      .getAllByRole("link")
+      .filter((el) => el.getAttribute("href") === "/admin");
+    expect(adminLinks).toHaveLength(0);
+  });
+
+  it("admin ユーザーには /admin リンクが追加表示される", async () => {
+    server.use(adminSessionHandler);
+    setPathname("/dashboard");
+    await renderNav();
+
+    await waitFor(() => {
+      expect(getNavLink("/admin")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -2,13 +2,17 @@
 
 import { usePathname } from "next/navigation";
 import Link from "next/link";
+import { useAtomValue } from "jotai";
 import clsx from "clsx";
 import { useLingui } from "@lingui/react";
-import { NAV_ITEMS } from "@/lib/nav-items";
+import { getNavItems } from "@/lib/nav-items";
+import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
 
 const BottomNav = () => {
   const pathname = usePathname();
   const { i18n } = useLingui();
+  const { user } = useAtomValue(authSessionUnwrappedAtom);
+  const navItems = getNavItems(user?.role);
 
   return (
     <nav
@@ -16,7 +20,7 @@ const BottomNav = () => {
       style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
     >
       <div className="flex h-16 items-center justify-around">
-        {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+        {navItems.map(({ href, label, icon: Icon }) => {
           const isActive =
             href === "/" ? pathname === "/" : pathname.startsWith(href);
           const isScan = href === "/scan";

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -7,8 +7,9 @@ import { Cloud, CloudOff, Loader2 } from "lucide-react";
 import clsx from "clsx";
 import { useLingui } from "@lingui/react";
 import { syncStatusAtom } from "@/stores/syncAtoms";
+import { authSessionUnwrappedAtom } from "@/stores/authAtoms";
 import { APP_NAME, SYNC_STATUS } from "@/lib/constants";
-import { NAV_ITEMS } from "@/lib/nav-items";
+import { getNavItems } from "@/lib/nav-items";
 import { useOnlineSync } from "@/hooks/useOnlineSync";
 import LocaleSelector from "@/components/settings/LocaleSelector";
 import UserMenu from "@/components/auth/UserMenu";
@@ -31,6 +32,8 @@ const TopBar = () => {
   useOnlineSync();
   const pathname = usePathname();
   const { i18n } = useLingui();
+  const { user } = useAtomValue(authSessionUnwrappedAtom);
+  const navItems = getNavItems(user?.role);
 
   return (
     <header className="sticky top-0 z-40 border-b border-border-default bg-surface-overlay/80 backdrop-blur-xl">
@@ -40,7 +43,7 @@ const TopBar = () => {
             {APP_NAME}
           </h1>
           <nav className="hidden items-center gap-1 lg:flex">
-            {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+            {navItems.map(({ href, label, icon: Icon }) => {
               const isActive =
                 href === "/" ? pathname === "/" : pathname.startsWith(href);
 

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -5,14 +5,46 @@ import {
   LayoutGrid,
   Users,
   Sparkles,
+  ShieldCheck,
 } from "lucide-react";
 import { msg } from "@lingui/core/macro";
+import type { MessageDescriptor } from "@lingui/core";
+import type { LucideIcon } from "lucide-react";
+import type { UserRole } from "@/lib/auth";
+import { USER_ROLE } from "@/lib/auth";
 
-export const NAV_ITEMS = [
-  { href: "/dashboard", label: msg`ホーム`, icon: Home },
-  { href: "/garments", label: msg`ワードローブ`, icon: Shirt },
-  { href: "/coordinates", label: msg`コーデ`, icon: Sparkles },
-  { href: "/scan", label: msg`スキャン`, icon: ScanLine },
-  { href: "/dolls", label: msg`ドール`, icon: Users },
-  { href: "/locations", label: msg`収納`, icon: LayoutGrid },
+// href / label / icon を保持する nav エントリ。
+// `icon` が関数型 (LucideIcon は ForwardRefExoticComponent) のため、
+// `functional/no-mixed-types` が落ちるが、ここでは構造の単純さを優先して許容する。
+// eslint-disable-next-line functional/no-mixed-types -- icon は関数型コンポーネント
+export type NavItem = {
+  readonly href: string;
+  readonly label: MessageDescriptor;
+  readonly icon: LucideIcon;
+};
+
+const navItem = (
+  href: string,
+  label: MessageDescriptor,
+  icon: LucideIcon,
+): NavItem => ({ href, label, icon });
+
+const BASE_NAV_ITEMS: readonly NavItem[] = [
+  navItem("/dashboard", msg`ホーム`, Home),
+  navItem("/garments", msg`ワードローブ`, Shirt),
+  navItem("/coordinates", msg`コーデ`, Sparkles),
+  navItem("/scan", msg`スキャン`, ScanLine),
+  navItem("/dolls", msg`ドール`, Users),
+  navItem("/locations", msg`収納`, LayoutGrid),
 ];
+
+const ADMIN_NAV_ITEM: NavItem = navItem("/admin", msg`管理`, ShieldCheck);
+
+export const getNavItems = (role: UserRole | undefined): readonly NavItem[] =>
+  role === USER_ROLE.ADMIN
+    ? [...BASE_NAV_ITEMS, ADMIN_NAV_ITEM]
+    : BASE_NAV_ITEMS;
+
+// 既存呼び出しの互換用 (role 未考慮の最小集合)。
+// admin 入口が必要なナビゲーション (TopBar / BottomNav) は getNavItems(role) を使うこと。
+export const NAV_ITEMS = BASE_NAV_ITEMS;

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1577,6 +1577,10 @@ msgstr "Freeze"
 msgid "凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。"
 msgstr "Freezing immediately invalidates the current session and blocks re-login. Data is retained."
 
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結に失敗しました。時間をおいて再度お試しください"
+msgstr "Failed to freeze the user. Please try again in a moment"
+
 #: src/app/admin/users/[id]/page.tsx
 #: src/components/admin/UserTable.tsx
 msgid "凍結中"
@@ -2352,6 +2356,10 @@ msgstr "Unfreeze"
 #: src/components/admin/UserFreezeButton.tsx
 msgid "解凍すると再びログインできるようになります。データは保持されます。"
 msgstr "Unfreezing lets the user sign in again. Data is retained."
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍に失敗しました。時間をおいて再度お試しください"
+msgstr "Failed to unfreeze the user. Please try again in a moment"
 
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -47,10 +47,22 @@ msgstr "{0}"
 msgid "{0} {1}"
 msgstr "{0} {1}"
 
+#. placeholder {0}: result.items.length
+#. placeholder {1}: result.total
+#: src/components/admin/UserDataTabs.tsx
+#: src/components/admin/UserDataTabs.tsx
+msgid "{0} / {1}件表示"
+msgstr "{0} / {1} shown"
+
 #. placeholder {0}: i18n._(DOLL_SIZE_LABEL[dollBodySize])
 #: src/components/doll/CompatibleGarmentList.tsx
 msgid "{0} サイズ対応の服を登録すると、ここに表示されます"
 msgstr "Register garments compatible with {0} size to see them here"
+
+#. placeholder {0}: c.garmentIds.length
+#: src/components/admin/UserDataTabs.tsx
+msgid "{0}件の服"
+msgstr "{0} garments"
 
 #. placeholder {0}: result.failed
 #. placeholder {0}: status.failed
@@ -628,6 +640,7 @@ msgid "ケース詳細"
 msgstr "Case details"
 
 #: src/app/coordinates/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 #: src/lib/nav-items.ts
 msgid "コーデ"
 msgstr "Outfits"
@@ -649,6 +662,10 @@ msgstr "Delete outfit"
 msgid "コーデ名"
 msgstr "Outfit name"
 
+#: src/app/admin/page.tsx
+msgid "コーデ数"
+msgstr "Outfits"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "コーデ詳細"
 msgstr "Outfit details"
@@ -664,6 +681,30 @@ msgstr "This device does not support NFC writing. Please use Android Chrome."
 #: src/app/locations/[caseId]/page.tsx
 msgid "このボックスには服がありません"
 msgstr "No garments in this box"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーのコーデはまだ登録されていません"
+msgstr "This user hasn't registered any outfits yet"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーの収納場所はまだ登録されていません"
+msgstr "This user hasn't registered any storage locations yet"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーの服はまだ登録されていません"
+msgstr "This user hasn't registered any garments yet"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "このユーザーは見つかりません"
+msgstr "User not found"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "このユーザーを凍結しますか？"
+msgstr "Freeze this user?"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "このユーザーを解凍しますか？"
+msgstr "Unfreeze this user?"
 
 #: src/components/location/StorageGrid.tsx
 msgid "この場所には服がありません"
@@ -785,6 +826,7 @@ msgstr "View all"
 msgid "ズレを直す"
 msgstr "Fix discrepancy"
 
+#: src/components/admin/AdminGuard.tsx
 #: src/components/auth/RequireAuth.tsx
 msgid "セッションを確認できませんでした"
 msgstr "Could not verify session"
@@ -1137,6 +1179,10 @@ msgstr "Doll garments on a miniature wooden rack with one empty hanger in the ce
 msgid "メーカー"
 msgstr "Maker"
 
+#: src/components/admin/UserTable.tsx
+msgid "メール"
+msgstr "Email"
+
 #: src/app/settings/account/page.tsx
 #: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/SignUpForm.tsx
@@ -1155,6 +1201,10 @@ msgstr "Failed to change email"
 msgid "メールアドレスまたはパスワードが正しくありません"
 msgstr "Email or password is incorrect"
 
+#: src/app/admin/users/page.tsx
+msgid "メールアドレスや名前で検索..."
+msgstr "Search by email or name..."
+
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "メールアドレスを再入力"
 msgstr "Re-enter Email Address"
@@ -1166,6 +1216,22 @@ msgstr "Change Email"
 #: src/components/settings/account/EmailChangeForm.tsx
 msgid "メールアドレスを変更しました"
 msgstr "Email changed"
+
+#: src/components/admin/AuditLogTable.tsx
+msgid "メタデータ"
+msgstr "Metadata"
+
+#: src/components/admin/AdminSideNav.tsx
+msgid "メトリクス"
+msgstr "Metrics"
+
+#: src/app/admin/page.tsx
+msgid "メトリクスサマリ"
+msgstr "Metrics summary"
+
+#: src/app/admin/page.tsx
+msgid "メトリクスの読み込みに失敗しました"
+msgstr "Failed to load metrics"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/components/coordinate/CoordinateBuilder.tsx
@@ -1180,6 +1246,40 @@ msgstr "Memo"
 msgid "もう1枚書き込む"
 msgstr "Write another tag"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/AdminSideNav.tsx
+msgid "ユーザー"
+msgstr "Users"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザーID"
+msgstr "User ID"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserDataTabs.tsx
+msgid "ユーザーデータ閲覧"
+msgstr "User data viewer"
+
+#: src/app/admin/users/page.tsx
+msgid "ユーザー一覧の読み込みに失敗しました"
+msgstr "Failed to load user list"
+
+#: src/app/admin/users/page.tsx
+msgid "ユーザー管理"
+msgstr "User management"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザー詳細"
+msgstr "User details"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザー詳細の読み込みに失敗しました"
+msgstr "Failed to load user details"
+
+#: src/components/admin/UserTable.tsx
+msgid "ユーザー詳細を開く"
+msgstr "Open user details"
+
 #: src/lib/i18n-labels.ts
 msgid "よく着る服 (14日)"
 msgstr "Frequently worn (14 days)"
@@ -1192,6 +1292,10 @@ msgstr "Choose from Library"
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "ラベル: {0}"
 msgstr "Label: {0}"
+
+#: src/app/admin/page.tsx
+msgid "リアルタイムの集計値です。サンプル数の少ない指標は今後のスナップショットで補完します。"
+msgstr "These are real-time aggregates. Metrics with small samples will be supplemented by future snapshots."
 
 #: src/components/ui/ViewToggle.tsx
 msgid "リスト表示"
@@ -1265,6 +1369,15 @@ msgstr "No matching dolls found"
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "一致する服が見つかりません"
 msgstr "No matching garments found"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "一般"
+msgstr "Member"
+
+#: src/app/admin/users/page.tsx
+msgid "一般のみ"
+msgstr "Members only"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/app/dolls/[id]/edit/page.tsx
@@ -1402,6 +1515,14 @@ msgstr "Please create a storage location first"
 msgid "全ドール"
 msgstr "All dolls"
 
+#: src/app/admin/users/page.tsx
+msgid "全権限"
+msgstr "All roles"
+
+#: src/app/admin/users/page.tsx
+msgid "全状態"
+msgstr "All statuses"
+
 #: src/components/scan/CheckoutConfirmSheet.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
@@ -1427,6 +1548,10 @@ msgstr "Register your first doll garment"
 msgid "最終使用日時"
 msgstr "Last used"
 
+#: src/app/admin/users/[id]/page.tsx
+msgid "最終更新"
+msgstr "Last updated"
+
 #: src/components/dashboard/RecentItems.tsx
 msgid "最近のアイテム"
 msgstr "Recent items"
@@ -1438,6 +1563,32 @@ msgstr "Surfaces clothes you haven't checked recently"
 #: src/components/garment/ImageUpload.tsx
 msgid "写真を追加"
 msgstr "Add photo"
+
+#: src/app/admin/audits/page.tsx
+msgid "凍結・解凍などの書き込み操作を行うとここに表示されます"
+msgstr "Write actions such as freeze and unfreeze will appear here"
+
+#: src/components/admin/UserFreezeButton.tsx
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結する"
+msgstr "Freeze"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。"
+msgstr "Freezing immediately invalidates the current session and blocks re-login. Data is retained."
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "凍結中"
+msgstr "Frozen"
+
+#: src/app/admin/users/page.tsx
+msgid "凍結中のみ"
+msgstr "Frozen only"
+
+#: src/app/admin/page.tsx
+msgid "凍結中ユーザー"
+msgstr "Frozen users"
 
 #: src/components/marketing/StepsSection.tsx
 msgid "出し入れの度に場所の QR を読むだけで、居場所が常に最新の状態に保たれます。"
@@ -1483,6 +1634,7 @@ msgstr "Print"
 msgid "印刷する QR コードが選択されていません"
 msgstr "No QR codes selected for printing"
 
+#: src/components/admin/UserDataTabs.tsx
 #: src/lib/nav-items.ts
 msgid "収納"
 msgstr "Storage"
@@ -1524,6 +1676,10 @@ msgstr "No storage locations"
 msgid "収納場所を選択"
 msgstr "Select storage location"
 
+#: src/app/admin/page.tsx
+msgid "収納場所数"
+msgstr "Storage locations"
+
 #: src/components/marketing/FeatureGrid.tsx
 msgid "取り出したまま忘れている服を検知"
 msgstr "Detects clothes left out and forgotten"
@@ -1554,6 +1710,7 @@ msgstr "Oldest first"
 msgid "合計"
 msgstr "Total"
 
+#: src/components/admin/UserTable.tsx
 #: src/components/doll/DollForm.tsx
 #: src/components/garment/bulk/BulkMetadataFormFields.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
@@ -1648,6 +1805,14 @@ msgstr "Delete permanently"
 msgid "定期的な更新を推奨します。"
 msgstr "Regular updates are recommended."
 
+#: src/components/admin/AuditLogTable.tsx
+msgid "実行者"
+msgstr "Performed by"
+
+#: src/components/admin/AuditLogTable.tsx
+msgid "対象"
+msgstr "Target"
+
 #: src/lib/i18n-labels.ts
 msgid "帽子/ヘッドドレス"
 msgstr "Hats/Headdress"
@@ -1697,6 +1862,11 @@ msgstr "Manual"
 #: src/components/marketing/StepsSection.tsx
 msgid "撮影台に並べたドール服とスマホの俯瞰写真"
 msgstr "Top-down view of doll garments and a smartphone laid out on a shooting surface"
+
+#: src/components/admin/AuditLogTable.tsx
+#: src/components/admin/UserTable.tsx
+msgid "操作"
+msgstr "Action"
 
 #: src/components/marketing/StepsSection.tsx
 msgid "整然と整理された 12 コンパートメントの引き出し"
@@ -1766,6 +1936,10 @@ msgstr "Write failed"
 msgid "書き込み対象"
 msgstr "Write target"
 
+#: src/app/admin/audits/page.tsx
+msgid "書き込み操作 (凍結 / 解凍 等) のみが記録されます。閲覧操作は記録されません。"
+msgstr "Only write actions (freeze / unfreeze, etc.) are recorded. View actions are not recorded."
+
 #: src/app/nfc-write/page.tsx
 msgid "書き込む"
 msgstr "Write"
@@ -1782,7 +1956,17 @@ msgstr "Please select a target to write"
 msgid "書き込む服を選択"
 msgstr "Select garment to write"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "有効"
+msgstr "Active"
+
+#: src/app/admin/users/page.tsx
+msgid "有効のみ"
+msgstr "Active only"
+
 #: src/app/nfc-write/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 msgid "服"
 msgstr "Garment"
 
@@ -1850,6 +2034,19 @@ msgstr "Unassign"
 msgid "本当に削除しますか？"
 msgstr "Are you sure you want to delete?"
 
+#: src/app/admin/users/page.tsx
+msgid "検索条件を変更してもう一度お試しください"
+msgstr "Try changing your search filters and try again"
+
+#: src/app/admin/users/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "権限"
+msgstr "Role"
+
+#: src/components/admin/AdminGuard.tsx
+msgid "権限のあるアカウントで再ログインしてください"
+msgstr "Please sign in with an authorized account"
+
 #: src/components/digest/DigestCard.tsx
 msgid "次に引き出しを開けたときに自動で確認されます"
 msgstr "Will be confirmed automatically the next time you open the drawer"
@@ -1887,6 +2084,8 @@ msgstr "Get started for free"
 msgid "片付けの度に場所が変わり、アプリの記録と現実の居場所がすぐに合わなくなる。"
 msgstr "Each tidy-up shifts items, and the app's record drifts from reality."
 
+#: src/app/admin/users/page.tsx
+#: src/components/admin/UserTable.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "状態"
 msgstr "Status"
@@ -1909,9 +2108,17 @@ msgstr "The raw key is shown only once right after issuance. Keep it in a safe p
 msgid "画像をアップロードしています ({0}/{1})"
 msgstr "Uploading images ({0}/{1})"
 
+#: src/components/admin/AuditLogTable.tsx
+msgid "発生日時"
+msgstr "Timestamp"
+
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "発行"
 msgstr "Issue"
+
+#: src/app/admin/page.tsx
+msgid "登録された服"
+msgstr "Registered garments"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "登録された服がありません"
@@ -1942,6 +2149,11 @@ msgstr "Registering…"
 msgid "登録完了"
 msgstr "Registration complete"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "登録日"
+msgstr "Joined"
+
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 msgid "登録開始"
 msgstr "Start registration"
@@ -1949,6 +2161,23 @@ msgstr "Start registration"
 #: src/lib/i18n-labels.ts
 msgid "白"
 msgstr "White"
+
+#: src/app/admin/audits/page.tsx
+#: src/components/admin/AdminSideNav.tsx
+msgid "監査ログ"
+msgstr "Audit logs"
+
+#: src/app/admin/audits/page.tsx
+msgid "監査ログの読み込みに失敗しました"
+msgstr "Failed to load audit logs"
+
+#: src/app/admin/audits/page.tsx
+msgid "監査ログはまだありません"
+msgstr "No audit logs yet"
+
+#: src/app/admin/page.tsx
+msgid "直近7日のサインアップ"
+msgstr "Signups (last 7 days)"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #~ msgid "着"
@@ -1977,9 +2206,39 @@ msgstr "Confirm"
 #~ msgid "確認"
 #~ msgstr "Check"
 
+#: src/components/admin/AdminSideNav.tsx
+#: src/lib/nav-items.ts
+msgid "管理"
+msgstr "Admin"
+
 #: src/components/digest/DigestCard.tsx
 #~ msgid "管理中の服: {0}着"
 #~ msgstr "Managed garments: {0}"
+
+#: src/app/admin/layout.tsx
+msgid "管理画面"
+msgstr "Admin console"
+
+#: src/components/admin/AdminSideNav.tsx
+msgid "管理画面ナビゲーション"
+msgstr "Admin console navigation"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "管理者"
+msgstr "Admin"
+
+#: src/app/admin/users/page.tsx
+msgid "管理者のみ"
+msgstr "Admins only"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "管理者の凍結は MVP では未対応です"
+msgstr "Freezing admins is not supported in this MVP"
+
+#: src/components/admin/AdminGuard.tsx
+msgid "管理者権限が必要です"
+msgstr "Admin privileges required"
 
 #: src/components/dashboard/CheckedOutSection.tsx
 #: src/lib/i18n-labels.ts
@@ -2006,6 +2265,10 @@ msgstr "Continue importing"
 msgid "続けて撮影する"
 msgstr "Continue capturing"
 
+#: src/app/admin/page.tsx
+msgid "総ユーザー数"
+msgstr "Total users"
+
 #: src/lib/i18n-labels.ts
 msgid "緑"
 msgstr "Green"
@@ -2017,6 +2280,10 @@ msgstr "Green"
 #: src/components/location/StorageGrid.tsx
 msgid "編集"
 msgstr "Edit"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "自分自身は凍結できません"
+msgstr "You can't freeze yourself"
 
 #: src/components/doll/DollForm.tsx
 msgid "自由にメモを入力..."
@@ -2077,6 +2344,15 @@ msgstr "Needs review"
 msgid "要確認のアイテム（{0}件）"
 msgstr "Items needing review ({0})"
 
+#: src/components/admin/UserFreezeButton.tsx
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍する"
+msgstr "Unfreeze"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍すると再びログインできるようになります。データは保持されます。"
+msgstr "Unfreezing lets the user sign in again. Data is retained."
+
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"
 msgstr "Language"
@@ -2091,8 +2367,13 @@ msgstr "Settings"
 msgid "該当するドールがありません"
 msgstr "No matching dolls found"
 
+#: src/app/admin/users/page.tsx
+msgid "該当するユーザーがいません"
+msgstr "No matching users"
+
 #: src/app/dolls/[id]/page.tsx
 #: src/app/garments/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "詳細"
 msgstr "Details"
@@ -2121,6 +2402,7 @@ msgstr "Description"
 #: src/app/garments/page.tsx
 #: src/app/locations/[caseId]/page.tsx
 #: src/app/locations/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 msgid "読み込みに失敗しました"
 msgstr "Failed to load"
 
@@ -2128,6 +2410,7 @@ msgstr "Failed to load"
 msgid "赤"
 msgstr "Red"
 
+#: src/components/admin/AdminGuard.tsx
 #: src/components/auth/RequireAuth.tsx
 msgid "通信状況を確認してから再読み込みしてください"
 msgstr "Check your network connection and reload the page"
@@ -2173,6 +2456,10 @@ msgstr "A smartphone held above an open drawer to scan"
 #: src/app/coordinates/[id]/page.tsx
 msgid "関連する服がありません（削除された可能性があります）"
 msgstr "No linked garments (they may have been deleted)."
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "閲覧専用"
+msgstr "Read-only"
 
 #: src/lib/i18n-labels.ts
 msgid "青"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -678,6 +678,14 @@ msgstr "This API key is shown only once. Make sure to copy it before closing."
 msgid "このデバイスは NFC 書き込みに対応していません。Android Chrome をご利用ください。"
 msgstr "This device does not support NFC writing. Please use Android Chrome."
 
+#: src/app/admin/users/page.tsx
+msgid "このページには表示するユーザーがいません"
+msgstr "No users to show on this page"
+
+#: src/app/admin/audits/page.tsx
+msgid "このページには表示するログがありません"
+msgstr "No log entries to show on this page"
+
 #: src/app/locations/[caseId]/page.tsx
 msgid "このボックスには服がありません"
 msgstr "No garments in this box"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1577,6 +1577,10 @@ msgstr "凍結する"
 msgid "凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。"
 msgstr "凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。"
 
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結に失敗しました。時間をおいて再度お試しください"
+msgstr "凍結に失敗しました。時間をおいて再度お試しください"
+
 #: src/app/admin/users/[id]/page.tsx
 #: src/components/admin/UserTable.tsx
 msgid "凍結中"
@@ -2352,6 +2356,10 @@ msgstr "解凍する"
 #: src/components/admin/UserFreezeButton.tsx
 msgid "解凍すると再びログインできるようになります。データは保持されます。"
 msgstr "解凍すると再びログインできるようになります。データは保持されます。"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍に失敗しました。時間をおいて再度お試しください"
+msgstr "解凍に失敗しました。時間をおいて再度お試しください"
 
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -47,10 +47,22 @@ msgstr "{0}"
 msgid "{0} {1}"
 msgstr "{0} {1}"
 
+#. placeholder {0}: result.items.length
+#. placeholder {1}: result.total
+#: src/components/admin/UserDataTabs.tsx
+#: src/components/admin/UserDataTabs.tsx
+msgid "{0} / {1}件表示"
+msgstr "{0} / {1}件表示"
+
 #. placeholder {0}: i18n._(DOLL_SIZE_LABEL[dollBodySize])
 #: src/components/doll/CompatibleGarmentList.tsx
 msgid "{0} サイズ対応の服を登録すると、ここに表示されます"
 msgstr "{0} サイズ対応の服を登録すると、ここに表示されます"
+
+#. placeholder {0}: c.garmentIds.length
+#: src/components/admin/UserDataTabs.tsx
+msgid "{0}件の服"
+msgstr "{0}件の服"
 
 #. placeholder {0}: result.failed
 #. placeholder {0}: status.failed
@@ -628,6 +640,7 @@ msgid "ケース詳細"
 msgstr "ケース詳細"
 
 #: src/app/coordinates/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 #: src/lib/nav-items.ts
 msgid "コーデ"
 msgstr "コーデ"
@@ -649,6 +662,10 @@ msgstr "コーデを削除"
 msgid "コーデ名"
 msgstr "コーデ名"
 
+#: src/app/admin/page.tsx
+msgid "コーデ数"
+msgstr "コーデ数"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "コーデ詳細"
 msgstr "コーデ詳細"
@@ -664,6 +681,30 @@ msgstr "このデバイスは NFC 書き込みに対応していません。Andr
 #: src/app/locations/[caseId]/page.tsx
 msgid "このボックスには服がありません"
 msgstr "このボックスには服がありません"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーのコーデはまだ登録されていません"
+msgstr "このユーザーのコーデはまだ登録されていません"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーの収納場所はまだ登録されていません"
+msgstr "このユーザーの収納場所はまだ登録されていません"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーの服はまだ登録されていません"
+msgstr "このユーザーの服はまだ登録されていません"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "このユーザーは見つかりません"
+msgstr "このユーザーは見つかりません"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "このユーザーを凍結しますか？"
+msgstr "このユーザーを凍結しますか？"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "このユーザーを解凍しますか？"
+msgstr "このユーザーを解凍しますか？"
 
 #: src/components/location/StorageGrid.tsx
 msgid "この場所には服がありません"
@@ -785,6 +826,7 @@ msgstr "すべて見る"
 msgid "ズレを直す"
 msgstr "ズレを直す"
 
+#: src/components/admin/AdminGuard.tsx
 #: src/components/auth/RequireAuth.tsx
 msgid "セッションを確認できませんでした"
 msgstr "セッションを確認できませんでした"
@@ -1137,6 +1179,10 @@ msgstr "ミニチュアの木製ラックに並ぶドール服と、中央の空
 msgid "メーカー"
 msgstr "メーカー"
 
+#: src/components/admin/UserTable.tsx
+msgid "メール"
+msgstr "メール"
+
 #: src/app/settings/account/page.tsx
 #: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/SignUpForm.tsx
@@ -1155,6 +1201,10 @@ msgstr "メールアドレスの変更に失敗しました"
 msgid "メールアドレスまたはパスワードが正しくありません"
 msgstr "メールアドレスまたはパスワードが正しくありません"
 
+#: src/app/admin/users/page.tsx
+msgid "メールアドレスや名前で検索..."
+msgstr "メールアドレスや名前で検索..."
+
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "メールアドレスを再入力"
 msgstr "メールアドレスを再入力"
@@ -1166,6 +1216,22 @@ msgstr "メールアドレスを変更"
 #: src/components/settings/account/EmailChangeForm.tsx
 msgid "メールアドレスを変更しました"
 msgstr "メールアドレスを変更しました"
+
+#: src/components/admin/AuditLogTable.tsx
+msgid "メタデータ"
+msgstr "メタデータ"
+
+#: src/components/admin/AdminSideNav.tsx
+msgid "メトリクス"
+msgstr "メトリクス"
+
+#: src/app/admin/page.tsx
+msgid "メトリクスサマリ"
+msgstr "メトリクスサマリ"
+
+#: src/app/admin/page.tsx
+msgid "メトリクスの読み込みに失敗しました"
+msgstr "メトリクスの読み込みに失敗しました"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/components/coordinate/CoordinateBuilder.tsx
@@ -1180,6 +1246,40 @@ msgstr "メモ"
 msgid "もう1枚書き込む"
 msgstr "もう1枚書き込む"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/AdminSideNav.tsx
+msgid "ユーザー"
+msgstr "ユーザー"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザーID"
+msgstr "ユーザーID"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserDataTabs.tsx
+msgid "ユーザーデータ閲覧"
+msgstr "ユーザーデータ閲覧"
+
+#: src/app/admin/users/page.tsx
+msgid "ユーザー一覧の読み込みに失敗しました"
+msgstr "ユーザー一覧の読み込みに失敗しました"
+
+#: src/app/admin/users/page.tsx
+msgid "ユーザー管理"
+msgstr "ユーザー管理"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザー詳細"
+msgstr "ユーザー詳細"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザー詳細の読み込みに失敗しました"
+msgstr "ユーザー詳細の読み込みに失敗しました"
+
+#: src/components/admin/UserTable.tsx
+msgid "ユーザー詳細を開く"
+msgstr "ユーザー詳細を開く"
+
 #: src/lib/i18n-labels.ts
 msgid "よく着る服 (14日)"
 msgstr "よく着る服 (14日)"
@@ -1192,6 +1292,10 @@ msgstr "ライブラリから選択"
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "ラベル: {0}"
 msgstr "ラベル: {0}"
+
+#: src/app/admin/page.tsx
+msgid "リアルタイムの集計値です。サンプル数の少ない指標は今後のスナップショットで補完します。"
+msgstr "リアルタイムの集計値です。サンプル数の少ない指標は今後のスナップショットで補完します。"
 
 #: src/components/ui/ViewToggle.tsx
 msgid "リスト表示"
@@ -1265,6 +1369,15 @@ msgstr "一致するドールが見つかりません"
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "一致する服が見つかりません"
 msgstr "一致する服が見つかりません"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "一般"
+msgstr "一般"
+
+#: src/app/admin/users/page.tsx
+msgid "一般のみ"
+msgstr "一般のみ"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/app/dolls/[id]/edit/page.tsx
@@ -1402,6 +1515,14 @@ msgstr "先に収納場所を作成してください"
 msgid "全ドール"
 msgstr "全ドール"
 
+#: src/app/admin/users/page.tsx
+msgid "全権限"
+msgstr "全権限"
+
+#: src/app/admin/users/page.tsx
+msgid "全状態"
+msgstr "全状態"
+
 #: src/components/scan/CheckoutConfirmSheet.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
@@ -1427,6 +1548,10 @@ msgstr "最初のドール服を登録してみましょう"
 msgid "最終使用日時"
 msgstr "最終使用日時"
 
+#: src/app/admin/users/[id]/page.tsx
+msgid "最終更新"
+msgstr "最終更新"
+
 #: src/components/dashboard/RecentItems.tsx
 msgid "最近のアイテム"
 msgstr "最近のアイテム"
@@ -1438,6 +1563,32 @@ msgstr "最近確認していない服を教えてくれる"
 #: src/components/garment/ImageUpload.tsx
 msgid "写真を追加"
 msgstr "写真を追加"
+
+#: src/app/admin/audits/page.tsx
+msgid "凍結・解凍などの書き込み操作を行うとここに表示されます"
+msgstr "凍結・解凍などの書き込み操作を行うとここに表示されます"
+
+#: src/components/admin/UserFreezeButton.tsx
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結する"
+msgstr "凍結する"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。"
+msgstr "凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "凍結中"
+msgstr "凍結中"
+
+#: src/app/admin/users/page.tsx
+msgid "凍結中のみ"
+msgstr "凍結中のみ"
+
+#: src/app/admin/page.tsx
+msgid "凍結中ユーザー"
+msgstr "凍結中ユーザー"
 
 #: src/components/marketing/StepsSection.tsx
 msgid "出し入れの度に場所の QR を読むだけで、居場所が常に最新の状態に保たれます。"
@@ -1483,6 +1634,7 @@ msgstr "印刷"
 msgid "印刷する QR コードが選択されていません"
 msgstr "印刷する QR コードが選択されていません"
 
+#: src/components/admin/UserDataTabs.tsx
 #: src/lib/nav-items.ts
 msgid "収納"
 msgstr "収納"
@@ -1524,6 +1676,10 @@ msgstr "収納場所がありません"
 msgid "収納場所を選択"
 msgstr "収納場所を選択"
 
+#: src/app/admin/page.tsx
+msgid "収納場所数"
+msgstr "収納場所数"
+
 #: src/components/marketing/FeatureGrid.tsx
 msgid "取り出したまま忘れている服を検知"
 msgstr "取り出したまま忘れている服を検知"
@@ -1554,6 +1710,7 @@ msgstr "古い順"
 msgid "合計"
 msgstr "合計"
 
+#: src/components/admin/UserTable.tsx
 #: src/components/doll/DollForm.tsx
 #: src/components/garment/bulk/BulkMetadataFormFields.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
@@ -1648,6 +1805,14 @@ msgstr "完全に削除"
 msgid "定期的な更新を推奨します。"
 msgstr "定期的な更新を推奨します。"
 
+#: src/components/admin/AuditLogTable.tsx
+msgid "実行者"
+msgstr "実行者"
+
+#: src/components/admin/AuditLogTable.tsx
+msgid "対象"
+msgstr "対象"
+
 #: src/lib/i18n-labels.ts
 msgid "帽子/ヘッドドレス"
 msgstr "帽子/ヘッドドレス"
@@ -1697,6 +1862,11 @@ msgstr "手動"
 #: src/components/marketing/StepsSection.tsx
 msgid "撮影台に並べたドール服とスマホの俯瞰写真"
 msgstr "撮影台に並べたドール服とスマホの俯瞰写真"
+
+#: src/components/admin/AuditLogTable.tsx
+#: src/components/admin/UserTable.tsx
+msgid "操作"
+msgstr "操作"
 
 #: src/components/marketing/StepsSection.tsx
 msgid "整然と整理された 12 コンパートメントの引き出し"
@@ -1766,6 +1936,10 @@ msgstr "書き込みに失敗しました"
 msgid "書き込み対象"
 msgstr "書き込み対象"
 
+#: src/app/admin/audits/page.tsx
+msgid "書き込み操作 (凍結 / 解凍 等) のみが記録されます。閲覧操作は記録されません。"
+msgstr "書き込み操作 (凍結 / 解凍 等) のみが記録されます。閲覧操作は記録されません。"
+
 #: src/app/nfc-write/page.tsx
 msgid "書き込む"
 msgstr "書き込む"
@@ -1782,7 +1956,17 @@ msgstr "書き込む対象を選択してください"
 msgid "書き込む服を選択"
 msgstr "書き込む服を選択"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "有効"
+msgstr "有効"
+
+#: src/app/admin/users/page.tsx
+msgid "有効のみ"
+msgstr "有効のみ"
+
 #: src/app/nfc-write/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 msgid "服"
 msgstr "服"
 
@@ -1850,6 +2034,19 @@ msgstr "未配置にする"
 msgid "本当に削除しますか？"
 msgstr "本当に削除しますか？"
 
+#: src/app/admin/users/page.tsx
+msgid "検索条件を変更してもう一度お試しください"
+msgstr "検索条件を変更してもう一度お試しください"
+
+#: src/app/admin/users/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "権限"
+msgstr "権限"
+
+#: src/components/admin/AdminGuard.tsx
+msgid "権限のあるアカウントで再ログインしてください"
+msgstr "権限のあるアカウントで再ログインしてください"
+
 #: src/components/digest/DigestCard.tsx
 msgid "次に引き出しを開けたときに自動で確認されます"
 msgstr "次に引き出しを開けたときに自動で確認されます"
@@ -1887,6 +2084,8 @@ msgstr "無料で始める"
 msgid "片付けの度に場所が変わり、アプリの記録と現実の居場所がすぐに合わなくなる。"
 msgstr "片付けの度に場所が変わり、アプリの記録と現実の居場所がすぐに合わなくなる。"
 
+#: src/app/admin/users/page.tsx
+#: src/components/admin/UserTable.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "状態"
 msgstr "状態"
@@ -1909,9 +2108,17 @@ msgstr "生キーは発行直後の一度しか表示されません。安全な
 msgid "画像をアップロードしています ({0}/{1})"
 msgstr "画像をアップロードしています ({0}/{1})"
 
+#: src/components/admin/AuditLogTable.tsx
+msgid "発生日時"
+msgstr "発生日時"
+
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "発行"
 msgstr "発行"
+
+#: src/app/admin/page.tsx
+msgid "登録された服"
+msgstr "登録された服"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "登録された服がありません"
@@ -1942,6 +2149,11 @@ msgstr "登録中…"
 msgid "登録完了"
 msgstr "登録完了"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "登録日"
+msgstr "登録日"
+
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 msgid "登録開始"
 msgstr "登録開始"
@@ -1949,6 +2161,23 @@ msgstr "登録開始"
 #: src/lib/i18n-labels.ts
 msgid "白"
 msgstr "白"
+
+#: src/app/admin/audits/page.tsx
+#: src/components/admin/AdminSideNav.tsx
+msgid "監査ログ"
+msgstr "監査ログ"
+
+#: src/app/admin/audits/page.tsx
+msgid "監査ログの読み込みに失敗しました"
+msgstr "監査ログの読み込みに失敗しました"
+
+#: src/app/admin/audits/page.tsx
+msgid "監査ログはまだありません"
+msgstr "監査ログはまだありません"
+
+#: src/app/admin/page.tsx
+msgid "直近7日のサインアップ"
+msgstr "直近7日のサインアップ"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #~ msgid "着"
@@ -1977,9 +2206,39 @@ msgstr "確定する"
 #~ msgid "確認"
 #~ msgstr "確認"
 
+#: src/components/admin/AdminSideNav.tsx
+#: src/lib/nav-items.ts
+msgid "管理"
+msgstr "管理"
+
 #: src/components/digest/DigestCard.tsx
 #~ msgid "管理中の服: {0}着"
 #~ msgstr "管理中の服: {0}着"
+
+#: src/app/admin/layout.tsx
+msgid "管理画面"
+msgstr "管理画面"
+
+#: src/components/admin/AdminSideNav.tsx
+msgid "管理画面ナビゲーション"
+msgstr "管理画面ナビゲーション"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "管理者"
+msgstr "管理者"
+
+#: src/app/admin/users/page.tsx
+msgid "管理者のみ"
+msgstr "管理者のみ"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "管理者の凍結は MVP では未対応です"
+msgstr "管理者の凍結は MVP では未対応です"
+
+#: src/components/admin/AdminGuard.tsx
+msgid "管理者権限が必要です"
+msgstr "管理者権限が必要です"
 
 #: src/components/dashboard/CheckedOutSection.tsx
 #: src/lib/i18n-labels.ts
@@ -2006,6 +2265,10 @@ msgstr "続けてインポート"
 msgid "続けて撮影する"
 msgstr "続けて撮影する"
 
+#: src/app/admin/page.tsx
+msgid "総ユーザー数"
+msgstr "総ユーザー数"
+
 #: src/lib/i18n-labels.ts
 msgid "緑"
 msgstr "緑"
@@ -2017,6 +2280,10 @@ msgstr "緑"
 #: src/components/location/StorageGrid.tsx
 msgid "編集"
 msgstr "編集"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "自分自身は凍結できません"
+msgstr "自分自身は凍結できません"
 
 #: src/components/doll/DollForm.tsx
 msgid "自由にメモを入力..."
@@ -2077,6 +2344,15 @@ msgstr "要確認"
 msgid "要確認のアイテム（{0}件）"
 msgstr "要確認のアイテム（{0}件）"
 
+#: src/components/admin/UserFreezeButton.tsx
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍する"
+msgstr "解凍する"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍すると再びログインできるようになります。データは保持されます。"
+msgstr "解凍すると再びログインできるようになります。データは保持されます。"
+
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"
 msgstr "言語"
@@ -2091,8 +2367,13 @@ msgstr "設定"
 msgid "該当するドールがありません"
 msgstr "該当するドールがありません"
 
+#: src/app/admin/users/page.tsx
+msgid "該当するユーザーがいません"
+msgstr "該当するユーザーがいません"
+
 #: src/app/dolls/[id]/page.tsx
 #: src/app/garments/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "詳細"
 msgstr "詳細"
@@ -2121,6 +2402,7 @@ msgstr "説明"
 #: src/app/garments/page.tsx
 #: src/app/locations/[caseId]/page.tsx
 #: src/app/locations/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 msgid "読み込みに失敗しました"
 msgstr "読み込みに失敗しました"
 
@@ -2128,6 +2410,7 @@ msgstr "読み込みに失敗しました"
 msgid "赤"
 msgstr "赤"
 
+#: src/components/admin/AdminGuard.tsx
 #: src/components/auth/RequireAuth.tsx
 msgid "通信状況を確認してから再読み込みしてください"
 msgstr "通信状況を確認してから再読み込みしてください"
@@ -2173,6 +2456,10 @@ msgstr "開いた引き出しの上にスマホを構えてスキャンする場
 #: src/app/coordinates/[id]/page.tsx
 msgid "関連する服がありません（削除された可能性があります）"
 msgstr "関連する服がありません（削除された可能性があります）"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "閲覧専用"
+msgstr "閲覧専用"
 
 #: src/lib/i18n-labels.ts
 msgid "青"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -678,6 +678,14 @@ msgstr "この API キーは一度だけ表示されます。閉じる前に必�
 msgid "このデバイスは NFC 書き込みに対応していません。Android Chrome をご利用ください。"
 msgstr "このデバイスは NFC 書き込みに対応していません。Android Chrome をご利用ください。"
 
+#: src/app/admin/users/page.tsx
+msgid "このページには表示するユーザーがいません"
+msgstr "このページには表示するユーザーがいません"
+
+#: src/app/admin/audits/page.tsx
+msgid "このページには表示するログがありません"
+msgstr "このページには表示するログがありません"
+
 #: src/app/locations/[caseId]/page.tsx
 msgid "このボックスには服がありません"
 msgstr "このボックスには服がありません"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -1577,6 +1577,10 @@ msgstr "동결하기"
 msgid "凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。"
 msgstr "동결하면 현재 세션이 즉시 만료되고 재로그인도 차단됩니다. 데이터는 보존됩니다."
 
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結に失敗しました。時間をおいて再度お試しください"
+msgstr "동결에 실패했습니다. 잠시 후 다시 시도해 주세요"
+
 #: src/app/admin/users/[id]/page.tsx
 #: src/components/admin/UserTable.tsx
 msgid "凍結中"
@@ -2352,6 +2356,10 @@ msgstr "해동하기"
 #: src/components/admin/UserFreezeButton.tsx
 msgid "解凍すると再びログインできるようになります。データは保持されます。"
 msgstr "해동하면 다시 로그인할 수 있게 됩니다. 데이터는 보존됩니다."
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍に失敗しました。時間をおいて再度お試しください"
+msgstr "해동에 실패했습니다. 잠시 후 다시 시도해 주세요"
 
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -47,10 +47,22 @@ msgstr "{0}"
 msgid "{0} {1}"
 msgstr "{0} {1}"
 
+#. placeholder {0}: result.items.length
+#. placeholder {1}: result.total
+#: src/components/admin/UserDataTabs.tsx
+#: src/components/admin/UserDataTabs.tsx
+msgid "{0} / {1}件表示"
+msgstr "{0} / {1}건 표시"
+
 #. placeholder {0}: i18n._(DOLL_SIZE_LABEL[dollBodySize])
 #: src/components/doll/CompatibleGarmentList.tsx
 msgid "{0} サイズ対応の服を登録すると、ここに表示されます"
 msgstr "{0} 사이즈에 맞는 옷을 등록하면 여기에 표시됩니다"
+
+#. placeholder {0}: c.garmentIds.length
+#: src/components/admin/UserDataTabs.tsx
+msgid "{0}件の服"
+msgstr "옷 {0}벌"
 
 #. placeholder {0}: result.failed
 #. placeholder {0}: status.failed
@@ -628,6 +640,7 @@ msgid "ケース詳細"
 msgstr "케이스 상세"
 
 #: src/app/coordinates/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 #: src/lib/nav-items.ts
 msgid "コーデ"
 msgstr "코디"
@@ -649,6 +662,10 @@ msgstr "코디 삭제"
 msgid "コーデ名"
 msgstr "코디 이름"
 
+#: src/app/admin/page.tsx
+msgid "コーデ数"
+msgstr "코디 수"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "コーデ詳細"
 msgstr "코디 상세"
@@ -664,6 +681,30 @@ msgstr "이 기기는 NFC 쓰기를 지원하지 않습니다. Android Chrome을
 #: src/app/locations/[caseId]/page.tsx
 msgid "このボックスには服がありません"
 msgstr "이 박스에 의류가 없습니다"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーのコーデはまだ登録されていません"
+msgstr "이 사용자의 코디가 아직 등록되지 않았습니다"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーの収納場所はまだ登録されていません"
+msgstr "이 사용자의 수납 장소가 아직 등록되지 않았습니다"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーの服はまだ登録されていません"
+msgstr "이 사용자의 옷이 아직 등록되지 않았습니다"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "このユーザーは見つかりません"
+msgstr "해당 사용자를 찾을 수 없습니다"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "このユーザーを凍結しますか？"
+msgstr "이 사용자를 동결하시겠습니까?"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "このユーザーを解凍しますか？"
+msgstr "이 사용자를 해동하시겠습니까?"
 
 #: src/components/location/StorageGrid.tsx
 msgid "この場所には服がありません"
@@ -785,6 +826,7 @@ msgstr "모두 보기"
 msgid "ズレを直す"
 msgstr "차이 수정"
 
+#: src/components/admin/AdminGuard.tsx
 #: src/components/auth/RequireAuth.tsx
 msgid "セッションを確認できませんでした"
 msgstr "세션을 확인할 수 없습니다"
@@ -1137,6 +1179,10 @@ msgstr "미니어처 나무 행거에 걸린 인형 옷과 중앙의 빈 옷걸�
 msgid "メーカー"
 msgstr "메이커"
 
+#: src/components/admin/UserTable.tsx
+msgid "メール"
+msgstr "이메일"
+
 #: src/app/settings/account/page.tsx
 #: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/SignUpForm.tsx
@@ -1155,6 +1201,10 @@ msgstr "이메일 변경에 실패했습니다"
 msgid "メールアドレスまたはパスワードが正しくありません"
 msgstr "이메일 또는 비밀번호가 올바르지 않습니다"
 
+#: src/app/admin/users/page.tsx
+msgid "メールアドレスや名前で検索..."
+msgstr "이메일 또는 이름으로 검색..."
+
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "メールアドレスを再入力"
 msgstr "이메일 주소 재입력"
@@ -1166,6 +1216,22 @@ msgstr "이메일 변경"
 #: src/components/settings/account/EmailChangeForm.tsx
 msgid "メールアドレスを変更しました"
 msgstr "이메일이 변경되었습니다"
+
+#: src/components/admin/AuditLogTable.tsx
+msgid "メタデータ"
+msgstr "메타데이터"
+
+#: src/components/admin/AdminSideNav.tsx
+msgid "メトリクス"
+msgstr "메트릭"
+
+#: src/app/admin/page.tsx
+msgid "メトリクスサマリ"
+msgstr "메트릭 요약"
+
+#: src/app/admin/page.tsx
+msgid "メトリクスの読み込みに失敗しました"
+msgstr "메트릭을 불러오지 못했습니다"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/components/coordinate/CoordinateBuilder.tsx
@@ -1180,6 +1246,40 @@ msgstr "메모"
 msgid "もう1枚書き込む"
 msgstr "한 장 더 쓰기"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/AdminSideNav.tsx
+msgid "ユーザー"
+msgstr "사용자"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザーID"
+msgstr "사용자 ID"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserDataTabs.tsx
+msgid "ユーザーデータ閲覧"
+msgstr "사용자 데이터 열람"
+
+#: src/app/admin/users/page.tsx
+msgid "ユーザー一覧の読み込みに失敗しました"
+msgstr "사용자 목록을 불러오지 못했습니다"
+
+#: src/app/admin/users/page.tsx
+msgid "ユーザー管理"
+msgstr "사용자 관리"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザー詳細"
+msgstr "사용자 상세"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザー詳細の読み込みに失敗しました"
+msgstr "사용자 상세 정보를 불러오지 못했습니다"
+
+#: src/components/admin/UserTable.tsx
+msgid "ユーザー詳細を開く"
+msgstr "사용자 상세 열기"
+
 #: src/lib/i18n-labels.ts
 msgid "よく着る服 (14日)"
 msgstr "자주 입는 옷 (14일)"
@@ -1192,6 +1292,10 @@ msgstr "라이브러리에서 선택"
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "ラベル: {0}"
 msgstr "라벨: {0}"
+
+#: src/app/admin/page.tsx
+msgid "リアルタイムの集計値です。サンプル数の少ない指標は今後のスナップショットで補完します。"
+msgstr "실시간 집계 값입니다. 표본이 적은 지표는 향후 스냅숏으로 보완됩니다."
 
 #: src/components/ui/ViewToggle.tsx
 msgid "リスト表示"
@@ -1265,6 +1369,15 @@ msgstr "일치하는 인형을 찾을 수 없습니다"
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "一致する服が見つかりません"
 msgstr "일치하는 옷을 찾을 수 없습니다"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "一般"
+msgstr "일반"
+
+#: src/app/admin/users/page.tsx
+msgid "一般のみ"
+msgstr "일반만"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/app/dolls/[id]/edit/page.tsx
@@ -1402,6 +1515,14 @@ msgstr "먼저 수납 장소를 만들어 주세요"
 msgid "全ドール"
 msgstr "모든 인형"
 
+#: src/app/admin/users/page.tsx
+msgid "全権限"
+msgstr "모든 권한"
+
+#: src/app/admin/users/page.tsx
+msgid "全状態"
+msgstr "모든 상태"
+
 #: src/components/scan/CheckoutConfirmSheet.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
@@ -1427,6 +1548,10 @@ msgstr "첫 번째 인형 옷을 등록해 보세요"
 msgid "最終使用日時"
 msgstr "마지막 사용"
 
+#: src/app/admin/users/[id]/page.tsx
+msgid "最終更新"
+msgstr "최종 업데이트"
+
 #: src/components/dashboard/RecentItems.tsx
 msgid "最近のアイテム"
 msgstr "최근 아이템"
@@ -1438,6 +1563,32 @@ msgstr "최근 확인하지 않은 옷을 알려줌"
 #: src/components/garment/ImageUpload.tsx
 msgid "写真を追加"
 msgstr "사진 추가"
+
+#: src/app/admin/audits/page.tsx
+msgid "凍結・解凍などの書き込み操作を行うとここに表示されます"
+msgstr "동결·해동 등 쓰기 작업을 수행하면 여기에 표시됩니다"
+
+#: src/components/admin/UserFreezeButton.tsx
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結する"
+msgstr "동결하기"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。"
+msgstr "동결하면 현재 세션이 즉시 만료되고 재로그인도 차단됩니다. 데이터는 보존됩니다."
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "凍結中"
+msgstr "동결됨"
+
+#: src/app/admin/users/page.tsx
+msgid "凍結中のみ"
+msgstr "동결됨만"
+
+#: src/app/admin/page.tsx
+msgid "凍結中ユーザー"
+msgstr "동결된 사용자"
 
 #: src/components/marketing/StepsSection.tsx
 msgid "出し入れの度に場所の QR を読むだけで、居場所が常に最新の状態に保たれます。"
@@ -1483,6 +1634,7 @@ msgstr "인쇄"
 msgid "印刷する QR コードが選択されていません"
 msgstr "인쇄할 QR 코드가 선택되지 않았습니다"
 
+#: src/components/admin/UserDataTabs.tsx
 #: src/lib/nav-items.ts
 msgid "収納"
 msgstr "수납"
@@ -1524,6 +1676,10 @@ msgstr "수납 장소가 없습니다"
 msgid "収納場所を選択"
 msgstr "수납 장소 선택"
 
+#: src/app/admin/page.tsx
+msgid "収納場所数"
+msgstr "수납 장소 수"
+
 #: src/components/marketing/FeatureGrid.tsx
 msgid "取り出したまま忘れている服を検知"
 msgstr "꺼낸 채 잊고 있는 옷을 감지"
@@ -1554,6 +1710,7 @@ msgstr "오래된 순"
 msgid "合計"
 msgstr "합계"
 
+#: src/components/admin/UserTable.tsx
 #: src/components/doll/DollForm.tsx
 #: src/components/garment/bulk/BulkMetadataFormFields.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
@@ -1648,6 +1805,14 @@ msgstr "영구 삭제"
 msgid "定期的な更新を推奨します。"
 msgstr "정기적인 업데이트를 권장합니다."
 
+#: src/components/admin/AuditLogTable.tsx
+msgid "実行者"
+msgstr "실행자"
+
+#: src/components/admin/AuditLogTable.tsx
+msgid "対象"
+msgstr "대상"
+
 #: src/lib/i18n-labels.ts
 msgid "帽子/ヘッドドレス"
 msgstr "모자/헤드드레스"
@@ -1697,6 +1862,11 @@ msgstr "수동"
 #: src/components/marketing/StepsSection.tsx
 msgid "撮影台に並べたドール服とスマホの俯瞰写真"
 msgstr "촬영대에 펼친 인형 옷과 스마트폰을 위에서 본 사진"
+
+#: src/components/admin/AuditLogTable.tsx
+#: src/components/admin/UserTable.tsx
+msgid "操作"
+msgstr "작업"
 
 #: src/components/marketing/StepsSection.tsx
 msgid "整然と整理された 12 コンパートメントの引き出し"
@@ -1766,6 +1936,10 @@ msgstr "쓰기에 실패했습니다"
 msgid "書き込み対象"
 msgstr "쓰기 대상"
 
+#: src/app/admin/audits/page.tsx
+msgid "書き込み操作 (凍結 / 解凍 等) のみが記録されます。閲覧操作は記録されません。"
+msgstr "쓰기 작업 (동결 / 해동 등) 만 기록됩니다. 열람 작업은 기록되지 않습니다."
+
 #: src/app/nfc-write/page.tsx
 msgid "書き込む"
 msgstr "쓰기"
@@ -1782,7 +1956,17 @@ msgstr "쓸 대상을 선택해 주세요"
 msgid "書き込む服を選択"
 msgstr "쓸 옷 선택"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "有効"
+msgstr "활성"
+
+#: src/app/admin/users/page.tsx
+msgid "有効のみ"
+msgstr "활성만"
+
 #: src/app/nfc-write/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 msgid "服"
 msgstr "옷"
 
@@ -1850,6 +2034,19 @@ msgstr "미배치로 설정"
 msgid "本当に削除しますか？"
 msgstr "정말 삭제하시겠습니까?"
 
+#: src/app/admin/users/page.tsx
+msgid "検索条件を変更してもう一度お試しください"
+msgstr "검색 조건을 변경하여 다시 시도해 주세요"
+
+#: src/app/admin/users/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "権限"
+msgstr "권한"
+
+#: src/components/admin/AdminGuard.tsx
+msgid "権限のあるアカウントで再ログインしてください"
+msgstr "권한이 있는 계정으로 다시 로그인해 주세요"
+
 #: src/components/digest/DigestCard.tsx
 msgid "次に引き出しを開けたときに自動で確認されます"
 msgstr "다음에 서랍을 열 때 자동으로 확인됩니다"
@@ -1887,6 +2084,8 @@ msgstr "무료로 시작하기"
 msgid "片付けの度に場所が変わり、アプリの記録と現実の居場所がすぐに合わなくなる。"
 msgstr "정리할 때마다 위치가 바뀌어, 앱 기록과 현실 위치가 금세 어긋납니다."
 
+#: src/app/admin/users/page.tsx
+#: src/components/admin/UserTable.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "状態"
 msgstr "상태"
@@ -1909,9 +2108,17 @@ msgstr "원본 키는 발급 직후 한 번만 표시됩니다. 안전한 곳에
 msgid "画像をアップロードしています ({0}/{1})"
 msgstr "이미지를 업로드하고 있습니다 ({0}/{1})"
 
+#: src/components/admin/AuditLogTable.tsx
+msgid "発生日時"
+msgstr "발생 일시"
+
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "発行"
 msgstr "발급"
+
+#: src/app/admin/page.tsx
+msgid "登録された服"
+msgstr "등록된 옷"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "登録された服がありません"
@@ -1942,6 +2149,11 @@ msgstr "등록 중…"
 msgid "登録完了"
 msgstr "등록 완료"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "登録日"
+msgstr "가입일"
+
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 msgid "登録開始"
 msgstr "등록 시작"
@@ -1949,6 +2161,23 @@ msgstr "등록 시작"
 #: src/lib/i18n-labels.ts
 msgid "白"
 msgstr "흰색"
+
+#: src/app/admin/audits/page.tsx
+#: src/components/admin/AdminSideNav.tsx
+msgid "監査ログ"
+msgstr "감사 로그"
+
+#: src/app/admin/audits/page.tsx
+msgid "監査ログの読み込みに失敗しました"
+msgstr "감사 로그를 불러오지 못했습니다"
+
+#: src/app/admin/audits/page.tsx
+msgid "監査ログはまだありません"
+msgstr "감사 로그가 아직 없습니다"
+
+#: src/app/admin/page.tsx
+msgid "直近7日のサインアップ"
+msgstr "최근 7일 가입"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #~ msgid "着"
@@ -1977,9 +2206,39 @@ msgstr "확정"
 #~ msgid "確認"
 #~ msgstr "확인"
 
+#: src/components/admin/AdminSideNav.tsx
+#: src/lib/nav-items.ts
+msgid "管理"
+msgstr "관리"
+
 #: src/components/digest/DigestCard.tsx
 #~ msgid "管理中の服: {0}着"
 #~ msgstr "관리 중인 옷: {0}벌"
+
+#: src/app/admin/layout.tsx
+msgid "管理画面"
+msgstr "관리 화면"
+
+#: src/components/admin/AdminSideNav.tsx
+msgid "管理画面ナビゲーション"
+msgstr "관리 화면 내비게이션"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "管理者"
+msgstr "관리자"
+
+#: src/app/admin/users/page.tsx
+msgid "管理者のみ"
+msgstr "관리자만"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "管理者の凍結は MVP では未対応です"
+msgstr "관리자 동결은 MVP에서 지원되지 않습니다"
+
+#: src/components/admin/AdminGuard.tsx
+msgid "管理者権限が必要です"
+msgstr "관리자 권한이 필요합니다"
 
 #: src/components/dashboard/CheckedOutSection.tsx
 #: src/lib/i18n-labels.ts
@@ -2006,6 +2265,10 @@ msgstr "계속 가져오기"
 msgid "続けて撮影する"
 msgstr "계속 촬영하기"
 
+#: src/app/admin/page.tsx
+msgid "総ユーザー数"
+msgstr "총 사용자 수"
+
 #: src/lib/i18n-labels.ts
 msgid "緑"
 msgstr "초록"
@@ -2017,6 +2280,10 @@ msgstr "초록"
 #: src/components/location/StorageGrid.tsx
 msgid "編集"
 msgstr "편집"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "自分自身は凍結できません"
+msgstr "자기 자신은 동결할 수 없습니다"
 
 #: src/components/doll/DollForm.tsx
 msgid "自由にメモを入力..."
@@ -2077,6 +2344,15 @@ msgstr "확인 필요"
 msgid "要確認のアイテム（{0}件）"
 msgstr "확인 필요 아이템 ({0}건)"
 
+#: src/components/admin/UserFreezeButton.tsx
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍する"
+msgstr "해동하기"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍すると再びログインできるようになります。データは保持されます。"
+msgstr "해동하면 다시 로그인할 수 있게 됩니다. 데이터는 보존됩니다."
+
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"
 msgstr "언어"
@@ -2091,8 +2367,13 @@ msgstr "설정"
 msgid "該当するドールがありません"
 msgstr "해당하는 인형이 없습니다"
 
+#: src/app/admin/users/page.tsx
+msgid "該当するユーザーがいません"
+msgstr "해당하는 사용자가 없습니다"
+
 #: src/app/dolls/[id]/page.tsx
 #: src/app/garments/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "詳細"
 msgstr "상세"
@@ -2121,6 +2402,7 @@ msgstr "설명"
 #: src/app/garments/page.tsx
 #: src/app/locations/[caseId]/page.tsx
 #: src/app/locations/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 msgid "読み込みに失敗しました"
 msgstr "로딩에 실패했습니다"
 
@@ -2128,6 +2410,7 @@ msgstr "로딩에 실패했습니다"
 msgid "赤"
 msgstr "빨강"
 
+#: src/components/admin/AdminGuard.tsx
 #: src/components/auth/RequireAuth.tsx
 msgid "通信状況を確認してから再読み込みしてください"
 msgstr "네트워크 연결을 확인한 후 페이지를 다시 로드하세요"
@@ -2173,6 +2456,10 @@ msgstr "열린 서랍 위에 스마트폰을 들고 스캔하는 장면"
 #: src/app/coordinates/[id]/page.tsx
 msgid "関連する服がありません（削除された可能性があります）"
 msgstr "관련된 옷이 없습니다 (삭제되었을 수 있습니다)."
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "閲覧専用"
+msgstr "읽기 전용"
 
 #: src/lib/i18n-labels.ts
 msgid "青"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -678,6 +678,14 @@ msgstr "이 API 키는 한 번만 표시됩니다. 닫기 전에 반드시 복�
 msgid "このデバイスは NFC 書き込みに対応していません。Android Chrome をご利用ください。"
 msgstr "이 기기는 NFC 쓰기를 지원하지 않습니다. Android Chrome을 이용해 주세요."
 
+#: src/app/admin/users/page.tsx
+msgid "このページには表示するユーザーがいません"
+msgstr "이 페이지에 표시할 사용자가 없습니다"
+
+#: src/app/admin/audits/page.tsx
+msgid "このページには表示するログがありません"
+msgstr "이 페이지에 표시할 로그가 없습니다"
+
 #: src/app/locations/[caseId]/page.tsx
 msgid "このボックスには服がありません"
 msgstr "이 박스에 의류가 없습니다"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -678,6 +678,14 @@ msgstr "此 API 密钥仅显示一次。请在关闭前务必复制。"
 msgid "このデバイスは NFC 書き込みに対応していません。Android Chrome をご利用ください。"
 msgstr "此设备不支持NFC写入。请使用Android Chrome。"
 
+#: src/app/admin/users/page.tsx
+msgid "このページには表示するユーザーがいません"
+msgstr "本页没有可显示的用户"
+
+#: src/app/admin/audits/page.tsx
+msgid "このページには表示するログがありません"
+msgstr "本页没有可显示的日志"
+
 #: src/app/locations/[caseId]/page.tsx
 msgid "このボックスには服がありません"
 msgstr "这个盒子里没有衣服"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1577,6 +1577,10 @@ msgstr "冻结"
 msgid "凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。"
 msgstr "冻结后当前会话立即失效，且会拒绝再次登录。数据将保留。"
 
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結に失敗しました。時間をおいて再度お試しください"
+msgstr "冻结失败。请稍后再试"
+
 #: src/app/admin/users/[id]/page.tsx
 #: src/components/admin/UserTable.tsx
 msgid "凍結中"
@@ -2352,6 +2356,10 @@ msgstr "解冻"
 #: src/components/admin/UserFreezeButton.tsx
 msgid "解凍すると再びログインできるようになります。データは保持されます。"
 msgstr "解冻后该用户可重新登录。数据将保留。"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍に失敗しました。時間をおいて再度お試しください"
+msgstr "解冻失败。请稍后再试"
 
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -47,10 +47,22 @@ msgstr "{0}"
 msgid "{0} {1}"
 msgstr "{0} {1}"
 
+#. placeholder {0}: result.items.length
+#. placeholder {1}: result.total
+#: src/components/admin/UserDataTabs.tsx
+#: src/components/admin/UserDataTabs.tsx
+msgid "{0} / {1}件表示"
+msgstr "已显示 {0} / {1}"
+
 #. placeholder {0}: i18n._(DOLL_SIZE_LABEL[dollBodySize])
 #: src/components/doll/CompatibleGarmentList.tsx
 msgid "{0} サイズ対応の服を登録すると、ここに表示されます"
 msgstr "登记兼容{0}尺寸的衣服后，将在此处显示"
+
+#. placeholder {0}: c.garmentIds.length
+#: src/components/admin/UserDataTabs.tsx
+msgid "{0}件の服"
+msgstr "{0} 件衣服"
 
 #. placeholder {0}: result.failed
 #. placeholder {0}: status.failed
@@ -628,6 +640,7 @@ msgid "ケース詳細"
 msgstr "收纳箱详情"
 
 #: src/app/coordinates/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 #: src/lib/nav-items.ts
 msgid "コーデ"
 msgstr "搭配"
@@ -649,6 +662,10 @@ msgstr "删除搭配"
 msgid "コーデ名"
 msgstr "搭配名称"
 
+#: src/app/admin/page.tsx
+msgid "コーデ数"
+msgstr "搭配数"
+
 #: src/app/coordinates/[id]/page.tsx
 msgid "コーデ詳細"
 msgstr "搭配详情"
@@ -664,6 +681,30 @@ msgstr "此设备不支持NFC写入。请使用Android Chrome。"
 #: src/app/locations/[caseId]/page.tsx
 msgid "このボックスには服がありません"
 msgstr "这个盒子里没有衣服"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーのコーデはまだ登録されていません"
+msgstr "该用户尚未登记任何搭配"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーの収納場所はまだ登録されていません"
+msgstr "该用户尚未登记任何收纳位置"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "このユーザーの服はまだ登録されていません"
+msgstr "该用户尚未登记任何衣服"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "このユーザーは見つかりません"
+msgstr "未找到该用户"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "このユーザーを凍結しますか？"
+msgstr "要冻结该用户吗？"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "このユーザーを解凍しますか？"
+msgstr "要解冻该用户吗？"
 
 #: src/components/location/StorageGrid.tsx
 msgid "この場所には服がありません"
@@ -785,6 +826,7 @@ msgstr "查看全部"
 msgid "ズレを直す"
 msgstr "修正偏差"
 
+#: src/components/admin/AdminGuard.tsx
 #: src/components/auth/RequireAuth.tsx
 msgid "セッションを確認できませんでした"
 msgstr "无法验证会话"
@@ -1137,6 +1179,10 @@ msgstr "迷你木质衣架上排列的娃娃服装，中央有一个空衣架"
 msgid "メーカー"
 msgstr "厂商"
 
+#: src/components/admin/UserTable.tsx
+msgid "メール"
+msgstr "邮箱"
+
 #: src/app/settings/account/page.tsx
 #: src/components/auth/EmailPasswordForm.tsx
 #: src/components/auth/SignUpForm.tsx
@@ -1155,6 +1201,10 @@ msgstr "修改邮箱失败"
 msgid "メールアドレスまたはパスワードが正しくありません"
 msgstr "邮箱或密码不正确"
 
+#: src/app/admin/users/page.tsx
+msgid "メールアドレスや名前で検索..."
+msgstr "按邮箱或姓名搜索..."
+
 #: src/components/settings/account/DeleteAccountSection.tsx
 msgid "メールアドレスを再入力"
 msgstr "重新输入邮箱地址"
@@ -1166,6 +1216,22 @@ msgstr "修改邮箱"
 #: src/components/settings/account/EmailChangeForm.tsx
 msgid "メールアドレスを変更しました"
 msgstr "邮箱已修改"
+
+#: src/components/admin/AuditLogTable.tsx
+msgid "メタデータ"
+msgstr "元数据"
+
+#: src/components/admin/AdminSideNav.tsx
+msgid "メトリクス"
+msgstr "指标"
+
+#: src/app/admin/page.tsx
+msgid "メトリクスサマリ"
+msgstr "指标摘要"
+
+#: src/app/admin/page.tsx
+msgid "メトリクスの読み込みに失敗しました"
+msgstr "加载指标失败"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/components/coordinate/CoordinateBuilder.tsx
@@ -1180,6 +1246,40 @@ msgstr "备注"
 msgid "もう1枚書き込む"
 msgstr "再写入一张"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/AdminSideNav.tsx
+msgid "ユーザー"
+msgstr "用户"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザーID"
+msgstr "用户 ID"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserDataTabs.tsx
+msgid "ユーザーデータ閲覧"
+msgstr "用户数据查看"
+
+#: src/app/admin/users/page.tsx
+msgid "ユーザー一覧の読み込みに失敗しました"
+msgstr "加载用户列表失败"
+
+#: src/app/admin/users/page.tsx
+msgid "ユーザー管理"
+msgstr "用户管理"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザー詳細"
+msgstr "用户详情"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "ユーザー詳細の読み込みに失敗しました"
+msgstr "加载用户详情失败"
+
+#: src/components/admin/UserTable.tsx
+msgid "ユーザー詳細を開く"
+msgstr "打开用户详情"
+
 #: src/lib/i18n-labels.ts
 msgid "よく着る服 (14日)"
 msgstr "常穿衣服 (14天)"
@@ -1192,6 +1292,10 @@ msgstr "从相册选择"
 #: src/components/location/StorageLocationEditForm.tsx
 msgid "ラベル: {0}"
 msgstr "标签: {0}"
+
+#: src/app/admin/page.tsx
+msgid "リアルタイムの集計値です。サンプル数の少ない指標は今後のスナップショットで補完します。"
+msgstr "这些是实时聚合值。样本量较少的指标将通过后续快照补充。"
 
 #: src/components/ui/ViewToggle.tsx
 msgid "リスト表示"
@@ -1265,6 +1369,15 @@ msgstr "没有找到匹配的娃娃"
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "一致する服が見つかりません"
 msgstr "未找到匹配的衣服"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "一般"
+msgstr "普通"
+
+#: src/app/admin/users/page.tsx
+msgid "一般のみ"
+msgstr "仅普通"
 
 #: src/app/coordinates/[id]/page.tsx
 #: src/app/dolls/[id]/edit/page.tsx
@@ -1402,6 +1515,14 @@ msgstr "请先创建收纳位置"
 msgid "全ドール"
 msgstr "所有娃娃"
 
+#: src/app/admin/users/page.tsx
+msgid "全権限"
+msgstr "全部权限"
+
+#: src/app/admin/users/page.tsx
+msgid "全状態"
+msgstr "全部状态"
+
 #: src/components/scan/CheckoutConfirmSheet.tsx
 #: src/components/scan/OpportunisticReviewDialog.tsx
 msgid "全部ある"
@@ -1427,6 +1548,10 @@ msgstr "来登记你的第一件娃衣吧"
 msgid "最終使用日時"
 msgstr "最后使用时间"
 
+#: src/app/admin/users/[id]/page.tsx
+msgid "最終更新"
+msgstr "最近更新"
+
 #: src/components/dashboard/RecentItems.tsx
 msgid "最近のアイテム"
 msgstr "最近的物品"
@@ -1438,6 +1563,32 @@ msgstr "提醒你最近没确认过的衣服"
 #: src/components/garment/ImageUpload.tsx
 msgid "写真を追加"
 msgstr "添加照片"
+
+#: src/app/admin/audits/page.tsx
+msgid "凍結・解凍などの書き込み操作を行うとここに表示されます"
+msgstr "执行冻结、解冻等写入操作后将显示在此处"
+
+#: src/components/admin/UserFreezeButton.tsx
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結する"
+msgstr "冻结"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "凍結すると現在のセッションは即時失効し、再ログインも拒否されます。データは保持されます。"
+msgstr "冻结后当前会话立即失效，且会拒绝再次登录。数据将保留。"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "凍結中"
+msgstr "已冻结"
+
+#: src/app/admin/users/page.tsx
+msgid "凍結中のみ"
+msgstr "仅已冻结"
+
+#: src/app/admin/page.tsx
+msgid "凍結中ユーザー"
+msgstr "已冻结用户"
 
 #: src/components/marketing/StepsSection.tsx
 msgid "出し入れの度に場所の QR を読むだけで、居場所が常に最新の状態に保たれます。"
@@ -1483,6 +1634,7 @@ msgstr "打印"
 msgid "印刷する QR コードが選択されていません"
 msgstr "未选择要打印的QR码"
 
+#: src/components/admin/UserDataTabs.tsx
 #: src/lib/nav-items.ts
 msgid "収納"
 msgstr "收纳"
@@ -1524,6 +1676,10 @@ msgstr "没有收纳位置"
 msgid "収納場所を選択"
 msgstr "选择收纳位置"
 
+#: src/app/admin/page.tsx
+msgid "収納場所数"
+msgstr "收纳位置数"
+
 #: src/components/marketing/FeatureGrid.tsx
 msgid "取り出したまま忘れている服を検知"
 msgstr "检测拿出后被遗忘的衣服"
@@ -1554,6 +1710,7 @@ msgstr "最旧优先"
 msgid "合計"
 msgstr "合计"
 
+#: src/components/admin/UserTable.tsx
 #: src/components/doll/DollForm.tsx
 #: src/components/garment/bulk/BulkMetadataFormFields.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
@@ -1648,6 +1805,14 @@ msgstr "永久删除"
 msgid "定期的な更新を推奨します。"
 msgstr "建议定期更新。"
 
+#: src/components/admin/AuditLogTable.tsx
+msgid "実行者"
+msgstr "执行者"
+
+#: src/components/admin/AuditLogTable.tsx
+msgid "対象"
+msgstr "对象"
+
 #: src/lib/i18n-labels.ts
 msgid "帽子/ヘッドドレス"
 msgstr "帽子/头饰"
@@ -1697,6 +1862,11 @@ msgstr "手动"
 #: src/components/marketing/StepsSection.tsx
 msgid "撮影台に並べたドール服とスマホの俯瞰写真"
 msgstr "拍摄台上摆放的娃娃服装和手机的俯视图"
+
+#: src/components/admin/AuditLogTable.tsx
+#: src/components/admin/UserTable.tsx
+msgid "操作"
+msgstr "操作"
 
 #: src/components/marketing/StepsSection.tsx
 msgid "整然と整理された 12 コンパートメントの引き出し"
@@ -1766,6 +1936,10 @@ msgstr "写入失败"
 msgid "書き込み対象"
 msgstr "写入对象"
 
+#: src/app/admin/audits/page.tsx
+msgid "書き込み操作 (凍結 / 解凍 等) のみが記録されます。閲覧操作は記録されません。"
+msgstr "仅记录写入操作（冻结 / 解冻 等）。查看操作不会被记录。"
+
 #: src/app/nfc-write/page.tsx
 msgid "書き込む"
 msgstr "写入"
@@ -1782,7 +1956,17 @@ msgstr "请选择要写入的对象"
 msgid "書き込む服を選択"
 msgstr "选择要写入的衣服"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "有効"
+msgstr "有效"
+
+#: src/app/admin/users/page.tsx
+msgid "有効のみ"
+msgstr "仅有效"
+
 #: src/app/nfc-write/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 msgid "服"
 msgstr "衣服"
 
@@ -1850,6 +2034,19 @@ msgstr "取消分配"
 msgid "本当に削除しますか？"
 msgstr "确定要删除吗？"
 
+#: src/app/admin/users/page.tsx
+msgid "検索条件を変更してもう一度お試しください"
+msgstr "请修改搜索条件后重试"
+
+#: src/app/admin/users/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "権限"
+msgstr "权限"
+
+#: src/components/admin/AdminGuard.tsx
+msgid "権限のあるアカウントで再ログインしてください"
+msgstr "请使用具有权限的账户重新登录"
+
 #: src/components/digest/DigestCard.tsx
 msgid "次に引き出しを開けたときに自動で確認されます"
 msgstr "下次打开抽屉时将自动确认"
@@ -1887,6 +2084,8 @@ msgstr "免费开始"
 msgid "片付けの度に場所が変わり、アプリの記録と現実の居場所がすぐに合わなくなる。"
 msgstr "每次整理位置都会变,应用的记录很快与现实脱节。"
 
+#: src/app/admin/users/page.tsx
+#: src/components/admin/UserTable.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "状態"
 msgstr "状态"
@@ -1909,9 +2108,17 @@ msgstr "原始密钥仅在签发后显示一次。请妥善保管。"
 msgid "画像をアップロードしています ({0}/{1})"
 msgstr "正在上传图片 ({0}/{1})"
 
+#: src/components/admin/AuditLogTable.tsx
+msgid "発生日時"
+msgstr "发生时间"
+
 #: src/components/settings/api-key/ApiKeyCreateSheet.tsx
 msgid "発行"
 msgstr "签发"
+
+#: src/app/admin/page.tsx
+msgid "登録された服"
+msgstr "已登记衣服"
 
 #: src/components/coordinate/CoordinateBuilder.tsx
 msgid "登録された服がありません"
@@ -1942,6 +2149,11 @@ msgstr "注册中…"
 msgid "登録完了"
 msgstr "登记完成"
 
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "登録日"
+msgstr "注册日期"
+
 #: src/components/garment/bulk/BulkMetadataForm.tsx
 msgid "登録開始"
 msgstr "开始登记"
@@ -1949,6 +2161,23 @@ msgstr "开始登记"
 #: src/lib/i18n-labels.ts
 msgid "白"
 msgstr "白色"
+
+#: src/app/admin/audits/page.tsx
+#: src/components/admin/AdminSideNav.tsx
+msgid "監査ログ"
+msgstr "审计日志"
+
+#: src/app/admin/audits/page.tsx
+msgid "監査ログの読み込みに失敗しました"
+msgstr "加载审计日志失败"
+
+#: src/app/admin/audits/page.tsx
+msgid "監査ログはまだありません"
+msgstr "尚无审计日志"
+
+#: src/app/admin/page.tsx
+msgid "直近7日のサインアップ"
+msgstr "近 7 天注册"
 
 #: src/components/confidence/ConfidenceStats.tsx
 #~ msgid "着"
@@ -1977,9 +2206,39 @@ msgstr "确认"
 #~ msgid "確認"
 #~ msgstr "确认"
 
+#: src/components/admin/AdminSideNav.tsx
+#: src/lib/nav-items.ts
+msgid "管理"
+msgstr "管理"
+
 #: src/components/digest/DigestCard.tsx
 #~ msgid "管理中の服: {0}着"
 #~ msgstr "管理中的衣服：{0}件"
+
+#: src/app/admin/layout.tsx
+msgid "管理画面"
+msgstr "管理控制台"
+
+#: src/components/admin/AdminSideNav.tsx
+msgid "管理画面ナビゲーション"
+msgstr "管理控制台导航"
+
+#: src/app/admin/users/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
+msgid "管理者"
+msgstr "管理员"
+
+#: src/app/admin/users/page.tsx
+msgid "管理者のみ"
+msgstr "仅管理员"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "管理者の凍結は MVP では未対応です"
+msgstr "MVP 暂不支持冻结管理员"
+
+#: src/components/admin/AdminGuard.tsx
+msgid "管理者権限が必要です"
+msgstr "需要管理员权限"
 
 #: src/components/dashboard/CheckedOutSection.tsx
 #: src/lib/i18n-labels.ts
@@ -2006,6 +2265,10 @@ msgstr "继续导入"
 msgid "続けて撮影する"
 msgstr "继续拍摄"
 
+#: src/app/admin/page.tsx
+msgid "総ユーザー数"
+msgstr "用户总数"
+
 #: src/lib/i18n-labels.ts
 msgid "緑"
 msgstr "绿色"
@@ -2017,6 +2280,10 @@ msgstr "绿色"
 #: src/components/location/StorageGrid.tsx
 msgid "編集"
 msgstr "编辑"
+
+#: src/app/admin/users/[id]/page.tsx
+msgid "自分自身は凍結できません"
+msgstr "不能冻结自己"
 
 #: src/components/doll/DollForm.tsx
 msgid "自由にメモを入力..."
@@ -2077,6 +2344,15 @@ msgstr "待确认"
 msgid "要確認のアイテム（{0}件）"
 msgstr "待确认的物品（{0}件）"
 
+#: src/components/admin/UserFreezeButton.tsx
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍する"
+msgstr "解冻"
+
+#: src/components/admin/UserFreezeButton.tsx
+msgid "解凍すると再びログインできるようになります。データは保持されます。"
+msgstr "解冻后该用户可重新登录。数据将保留。"
+
 #: src/components/settings/LocaleSelector.tsx
 msgid "言語"
 msgstr "语言"
@@ -2091,8 +2367,13 @@ msgstr "设置"
 msgid "該当するドールがありません"
 msgstr "没有匹配的娃娃"
 
+#: src/app/admin/users/page.tsx
+msgid "該当するユーザーがいません"
+msgstr "没有符合条件的用户"
+
 #: src/app/dolls/[id]/page.tsx
 #: src/app/garments/[id]/page.tsx
+#: src/components/admin/UserTable.tsx
 #: src/components/garment/csv/CsvPreviewTable.tsx
 msgid "詳細"
 msgstr "详情"
@@ -2121,6 +2402,7 @@ msgstr "说明"
 #: src/app/garments/page.tsx
 #: src/app/locations/[caseId]/page.tsx
 #: src/app/locations/page.tsx
+#: src/components/admin/UserDataTabs.tsx
 msgid "読み込みに失敗しました"
 msgstr "加载失败"
 
@@ -2128,6 +2410,7 @@ msgstr "加载失败"
 msgid "赤"
 msgstr "红色"
 
+#: src/components/admin/AdminGuard.tsx
 #: src/components/auth/RequireAuth.tsx
 msgid "通信状況を確認してから再読み込みしてください"
 msgstr "请检查网络连接后重新加载页面"
@@ -2173,6 +2456,10 @@ msgstr "在打开的抽屉上方握住手机进行扫描的场景"
 #: src/app/coordinates/[id]/page.tsx
 msgid "関連する服がありません（削除された可能性があります）"
 msgstr "没有关联的衣服（可能已被删除）。"
+
+#: src/components/admin/UserDataTabs.tsx
+msgid "閲覧専用"
+msgstr "仅查看"
 
 #: src/lib/i18n-labels.ts
 msgid "青"

--- a/src/stores/adminAtoms.ssr.test.ts
+++ b/src/stores/adminAtoms.ssr.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment node
+ */
+
+// SSR (Node 環境) で `typeof window === "undefined"` 経路を確認するテスト。
+// happy-dom 配下の他テストでは window が常に定義されるため、別 file で node
+// 環境を指定して fallback 分岐 (adminAtoms.ts の各 atom 冒頭の if) を
+// 明示的にカバーする。
+//
+// このファイルは src/test/setup.ts (vitest config の setupFiles) が読み込む
+// fake-indexeddb / @testing-library/jest-dom などの jsdom 依存を持つため、
+// global setup の代わりに必要な module のみ単独で import する。
+
+import { describe, it, expect } from "vitest";
+import { createStore } from "jotai";
+import {
+  adminAuditsAtom,
+  adminMetricsAtom,
+  adminUserCoordinatesAtomFamily,
+  adminUserDetailAtomFamily,
+  adminUserGarmentsAtomFamily,
+  adminUserLocationsAtomFamily,
+  adminUsersAtom,
+} from "./adminAtoms";
+
+describe("adminAtoms SSR fallback (node 環境)", () => {
+  it("adminMetricsAtom は EMPTY_METRICS を返す", async () => {
+    const store = createStore();
+    const value = await store.get(adminMetricsAtom);
+    expect(value).toEqual({
+      totalUsers: 0,
+      frozenUsers: 0,
+      totalGarments: 0,
+      totalCoordinates: 0,
+      totalLocations: 0,
+      signupsLast7d: 0,
+    });
+  });
+
+  it("adminUsersAtom は空の検索結果を返す", async () => {
+    const store = createStore();
+    const value = await store.get(adminUsersAtom);
+    expect(value).toEqual({ items: [], total: 0 });
+  });
+
+  it("adminUserDetailAtomFamily は undefined を返す", async () => {
+    const store = createStore();
+    const value = await store.get(adminUserDetailAtomFamily("u-1"));
+    expect(value).toBeUndefined();
+  });
+
+  it("adminAuditsAtom は空の監査ログを返す", async () => {
+    const store = createStore();
+    const value = await store.get(adminAuditsAtom);
+    expect(value).toEqual({ items: [], total: 0 });
+  });
+
+  it("adminUserGarmentsAtomFamily は空配列を返す", async () => {
+    const store = createStore();
+    const value = await store.get(adminUserGarmentsAtomFamily("u-1", 0));
+    expect(value).toEqual({ items: [], total: 0 });
+  });
+
+  it("adminUserCoordinatesAtomFamily は空配列を返す", async () => {
+    const store = createStore();
+    const value = await store.get(adminUserCoordinatesAtomFamily("u-1", 0));
+    expect(value).toEqual({ items: [], total: 0 });
+  });
+
+  it("adminUserLocationsAtomFamily は空配列を返す", async () => {
+    const store = createStore();
+    const value = await store.get(adminUserLocationsAtomFamily("u-1"));
+    expect(value).toEqual([]);
+  });
+});

--- a/src/stores/adminAtoms.ts
+++ b/src/stores/adminAtoms.ts
@@ -2,6 +2,8 @@
 
 import { atom } from "jotai";
 import { trpcClient } from "@/lib/trpc";
+import { DEFAULT_PAGE_SIZE } from "@/lib/constants";
+import type { PageSize } from "@/lib/constants";
 
 const adminRefreshTriggerAtom = atom(0);
 
@@ -69,11 +71,34 @@ export type AdminUsersResult = {
 };
 
 const DEFAULT_USERS_QUERY: AdminUsersQuery = {
-  limit: 50,
+  limit: DEFAULT_PAGE_SIZE,
   offset: 0,
 };
 
 export const adminUsersQueryAtom = atom<AdminUsersQuery>(DEFAULT_USERS_QUERY);
+
+// Pagination ボタン用の write-only atom。limit を固定して offset のみ更新する。
+// `(page - 1) * limit` で offset を導出するため、ページ 1 = offset 0。
+export const setAdminUsersPageAtom = atom(
+  undefined,
+  (get, set, page: number) => {
+    const current = get(adminUsersQueryAtom);
+    const safePage = Math.max(1, page);
+    set(adminUsersQueryAtom, {
+      ...current,
+      offset: (safePage - 1) * current.limit,
+    });
+  },
+);
+
+// pageSize 切り替え用。limit を更新して offset を 0 にリセット (現在ページ位置を失わせる)。
+export const setAdminUsersPageSizeAtom = atom(
+  undefined,
+  (get, set, size: PageSize) => {
+    const current = get(adminUsersQueryAtom);
+    set(adminUsersQueryAtom, { ...current, limit: size, offset: 0 });
+  },
+);
 
 export const adminUsersAtom = atom(async (get): Promise<AdminUsersResult> => {
   if (typeof window === "undefined") {
@@ -118,12 +143,32 @@ export type AdminAuditsResult = {
 };
 
 const DEFAULT_AUDITS_QUERY: AdminAuditsQuery = {
-  limit: 50,
+  limit: DEFAULT_PAGE_SIZE,
   offset: 0,
 };
 
 export const adminAuditsQueryAtom =
   atom<AdminAuditsQuery>(DEFAULT_AUDITS_QUERY);
+
+export const setAdminAuditsPageAtom = atom(
+  undefined,
+  (get, set, page: number) => {
+    const current = get(adminAuditsQueryAtom);
+    const safePage = Math.max(1, page);
+    set(adminAuditsQueryAtom, {
+      ...current,
+      offset: (safePage - 1) * current.limit,
+    });
+  },
+);
+
+export const setAdminAuditsPageSizeAtom = atom(
+  undefined,
+  (get, set, size: PageSize) => {
+    const current = get(adminAuditsQueryAtom);
+    set(adminAuditsQueryAtom, { ...current, limit: size, offset: 0 });
+  },
+);
 
 export const adminAuditsAtom = atom(async (get): Promise<AdminAuditsResult> => {
   if (typeof window === "undefined") {

--- a/src/stores/adminAtoms.ts
+++ b/src/stores/adminAtoms.ts
@@ -1,0 +1,199 @@
+"use client";
+
+import { atom } from "jotai";
+import { trpcClient } from "@/lib/trpc";
+
+const adminRefreshTriggerAtom = atom(0);
+
+export const refreshAdminAtom = atom(undefined, (_get, set) => {
+  set(adminRefreshTriggerAtom, (prev) => prev + 1);
+});
+
+// 戻り値の shape は workers 側 (admin-repository / admin-service) と一致させる。
+// AppRouter からの inferRouterOutputs 経由だと jotai の writable atom 制約で
+// 型が解決できなかったため、ここで shape を duplicate して固定する。
+
+export type AdminUserRole = "admin" | "user";
+
+export type AdminMetricsSummary = {
+  readonly totalUsers: number;
+  readonly frozenUsers: number;
+  readonly totalGarments: number;
+  readonly totalCoordinates: number;
+  readonly totalLocations: number;
+  readonly signupsLast7d: number;
+};
+
+const EMPTY_METRICS: AdminMetricsSummary = {
+  totalUsers: 0,
+  frozenUsers: 0,
+  totalGarments: 0,
+  totalCoordinates: 0,
+  totalLocations: 0,
+  signupsLast7d: 0,
+};
+
+export const adminMetricsAtom = atom(
+  async (get): Promise<AdminMetricsSummary> => {
+    if (typeof window === "undefined") {
+      return EMPTY_METRICS;
+    }
+    get(adminRefreshTriggerAtom);
+    return await trpcClient.admin.metrics.summary.query();
+  },
+);
+
+export type AdminUser = {
+  readonly id: string;
+  readonly name: string;
+  readonly email: string;
+  readonly emailVerified: boolean;
+  readonly image?: string;
+  readonly role: AdminUserRole;
+  readonly frozen: boolean;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+};
+
+export type AdminUsersQuery = {
+  readonly search?: string;
+  readonly role?: AdminUserRole;
+  readonly frozen?: boolean;
+  readonly limit: number;
+  readonly offset: number;
+};
+
+export type AdminUsersResult = {
+  readonly items: readonly AdminUser[];
+  readonly total: number;
+};
+
+const DEFAULT_USERS_QUERY: AdminUsersQuery = {
+  limit: 50,
+  offset: 0,
+};
+
+export const adminUsersQueryAtom = atom<AdminUsersQuery>(DEFAULT_USERS_QUERY);
+
+export const adminUsersAtom = atom(async (get): Promise<AdminUsersResult> => {
+  if (typeof window === "undefined") {
+    return { items: [], total: 0 };
+  }
+  get(adminRefreshTriggerAtom);
+  const query = get(adminUsersQueryAtom);
+  return await trpcClient.admin.users.list.query(query);
+});
+
+export const adminUserDetailAtomFamily = (id: string) =>
+  atom(async (get): Promise<AdminUser | undefined> => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+    get(adminRefreshTriggerAtom);
+    return await trpcClient.admin.users.detail
+      .query({ id })
+      .catch((): undefined => undefined);
+  });
+
+export type AdminAuditLog = {
+  readonly id: string;
+  readonly actorUserId: string;
+  readonly action: string;
+  readonly targetUserId?: string;
+  readonly metadata?: string;
+  readonly createdAt: number;
+};
+
+export type AdminAuditsQuery = {
+  readonly action?: string;
+  readonly actorUserId?: string;
+  readonly targetUserId?: string;
+  readonly limit: number;
+  readonly offset: number;
+};
+
+export type AdminAuditsResult = {
+  readonly items: readonly AdminAuditLog[];
+  readonly total: number;
+};
+
+const DEFAULT_AUDITS_QUERY: AdminAuditsQuery = {
+  limit: 50,
+  offset: 0,
+};
+
+export const adminAuditsQueryAtom =
+  atom<AdminAuditsQuery>(DEFAULT_AUDITS_QUERY);
+
+export const adminAuditsAtom = atom(async (get): Promise<AdminAuditsResult> => {
+  if (typeof window === "undefined") {
+    return { items: [], total: 0 };
+  }
+  get(adminRefreshTriggerAtom);
+  const query = get(adminAuditsQueryAtom);
+  return await trpcClient.admin.audits.list.query(query);
+});
+
+const ADMIN_USER_DATA_LIMIT = 50;
+
+export const adminUserGarmentsAtomFamily = (userId: string, offset: number) =>
+  atom(async (get) => {
+    if (typeof window === "undefined") {
+      return { items: [], total: 0 };
+    }
+    get(adminRefreshTriggerAtom);
+    return await trpcClient.admin.userDataView.garments.query({
+      userId,
+      limit: ADMIN_USER_DATA_LIMIT,
+      offset,
+    });
+  });
+
+export const adminUserCoordinatesAtomFamily = (
+  userId: string,
+  offset: number,
+) =>
+  atom(async (get) => {
+    if (typeof window === "undefined") {
+      return { items: [], total: 0 };
+    }
+    get(adminRefreshTriggerAtom);
+    return await trpcClient.admin.userDataView.coordinates.query({
+      userId,
+      limit: ADMIN_USER_DATA_LIMIT,
+      offset,
+    });
+  });
+
+export const adminUserLocationsAtomFamily = (userId: string) =>
+  atom(async (get) => {
+    if (typeof window === "undefined") {
+      return [];
+    }
+    get(adminRefreshTriggerAtom);
+    return await trpcClient.admin.userDataView.locations.query({ userId });
+  });
+
+export const freezeUserAtom = atom(
+  undefined,
+  async (
+    _get,
+    set,
+    input: { readonly targetUserId: string; readonly reason?: string },
+  ) => {
+    await trpcClient.admin.users.freeze.mutate(input);
+    set(adminRefreshTriggerAtom, (prev) => prev + 1);
+  },
+);
+
+export const unfreezeUserAtom = atom(
+  undefined,
+  async (
+    _get,
+    set,
+    input: { readonly targetUserId: string; readonly reason?: string },
+  ) => {
+    await trpcClient.admin.users.unfreeze.mutate(input);
+    set(adminRefreshTriggerAtom, (prev) => prev + 1);
+  },
+);

--- a/src/stores/adminAtoms.ts
+++ b/src/stores/adminAtoms.ts
@@ -1,9 +1,33 @@
 "use client";
 
 import { atom } from "jotai";
+import { TRPCClientError } from "@trpc/client";
 import { trpcClient } from "@/lib/trpc";
 import { DEFAULT_PAGE_SIZE } from "@/lib/constants";
 import type { PageSize } from "@/lib/constants";
+import { isRecord } from "@/lib/typeGuards";
+
+// admin.users.detail が NOT_FOUND を返したケースだけ undefined にダウングレードし、
+// transient / network / 500 などは ErrorBoundary に流すための判定。
+// TRPCClientError の data?.code は workers 側 ServiceErrorCode と一致する。
+const isNotFoundError = (error: unknown): boolean => {
+  if (!(error instanceof TRPCClientError)) return false;
+  const { data } = error;
+  if (!isRecord(data)) return false;
+  return data.code === "NOT_FOUND";
+};
+
+// catch を「該当エラーなら値に変換、それ以外は再 throw」させるためのヘルパー。
+// CLAUDE.md「try/catch 禁止」を守るため .catch のみで分岐する。
+// throw は ErrorBoundary に到達させるための副作用 — 既存 lint exception と同じ
+// 形 (toastAtoms.ts などで使われている) を踏襲する。
+const rethrowUnless =
+  <T>(predicate: (error: unknown) => boolean, fallback: T) =>
+  (error: unknown): T => {
+    if (predicate(error)) return fallback;
+    // eslint-disable-next-line functional/no-throw-statements, @typescript-eslint/only-throw-error -- 上流 ErrorBoundary に到達させる
+    throw error;
+  };
 
 const adminRefreshTriggerAtom = atom(0);
 
@@ -115,9 +139,12 @@ export const adminUserDetailAtomFamily = (id: string) =>
       return undefined;
     }
     get(adminRefreshTriggerAtom);
+    // NOT_FOUND は「ユーザーがいない」UI に流すために undefined にダウングレード。
+    // それ以外 (transient / 500 / network) は ErrorBoundary に流して、
+    // 障害を not-found 状態でマスクしないようにする。
     return await trpcClient.admin.users.detail
       .query({ id })
-      .catch((): undefined => undefined);
+      .catch(rethrowUnless(isNotFoundError, undefined));
   });
 
 export type AdminAuditLog = {

--- a/src/stores/authAtoms.ts
+++ b/src/stores/authAtoms.ts
@@ -3,7 +3,7 @@
 import { atom } from "jotai";
 import { unwrap } from "jotai/utils";
 import { getSession, signOut as authSignOut } from "@/lib/auth";
-import type { SessionResponse } from "@/lib/auth";
+import type { SessionResponse, UserRole } from "@/lib/auth";
 import { getDb } from "@/lib/db/dexie";
 
 type AuthUser = {
@@ -11,6 +11,8 @@ type AuthUser = {
   readonly name: string;
   readonly email: string;
   readonly image: string | undefined;
+  readonly role: UserRole;
+  readonly frozen: boolean;
 };
 
 type AuthState = {
@@ -27,6 +29,8 @@ const extractUser = (
   session: SessionResponse | undefined,
 ): AuthUser | undefined => {
   const user = session?.data?.user;
+  // SessionUser 側 (src/lib/auth.ts) で getSession のレスポンスを必ず
+  // { role, frozen } 込みに正規化しているため、ここでは安全に展開する。
   return user === undefined
     ? undefined
     : {
@@ -34,6 +38,8 @@ const extractUser = (
         name: user.name,
         email: user.email,
         image: user.image ?? undefined,
+        role: user.role,
+        frozen: user.frozen,
       };
 };
 

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -4,22 +4,57 @@ import { trpcDispatcherHandlers } from "./trpc/handlerFactory";
 
 registerDefaultTrpcHandlers();
 
+type SessionUserRole = "admin" | "user";
+
+type MockSessionUser = {
+  readonly id: string;
+  readonly name: string;
+  readonly email: string;
+  readonly image: string | null;
+  readonly emailVerified: boolean;
+  readonly role: SessionUserRole;
+  readonly frozen: boolean;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+};
+
+const DEFAULT_SESSION_USER: MockSessionUser = {
+  id: "user-1",
+  name: "テストユーザー",
+  email: "test@example.com",
+  image: null,
+  emailVerified: false,
+  role: "user",
+  frozen: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
 export const handlers = [
   http.get("*/api/auth/get-session", () =>
-    HttpResponse.json({
-      user: {
-        id: "user-1",
-        name: "テストユーザー",
-        email: "test@example.com",
-        image: null,
-        emailVerified: false,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      },
-    }),
+    HttpResponse.json({ user: DEFAULT_SESSION_USER }),
   ),
   ...trpcDispatcherHandlers,
 ];
+
+export const adminSessionHandler = http.get("*/api/auth/get-session", () =>
+  HttpResponse.json({
+    user: { ...DEFAULT_SESSION_USER, id: "admin-1", role: "admin" },
+  }),
+);
+
+export const frozenSessionHandler = http.get("*/api/auth/get-session", () =>
+  HttpResponse.json({
+    user: { ...DEFAULT_SESSION_USER, frozen: true },
+  }),
+);
+
+type SessionOverrides = Partial<MockSessionUser>;
+
+export const sessionHandler = (overrides: SessionOverrides) =>
+  http.get("*/api/auth/get-session", () =>
+    HttpResponse.json({ user: { ...DEFAULT_SESSION_USER, ...overrides } }),
+  );
 
 export const unauthenticatedHandler = http.get("*/api/auth/get-session", () =>
   HttpResponse.json(null),

--- a/src/test/mocks/trpc/defaults.ts
+++ b/src/test/mocks/trpc/defaults.ts
@@ -45,4 +45,46 @@ export const registerDefaultTrpcHandlers = (): void => {
     success: true as const,
     processedCount: 0,
   }));
+
+  // admin 系: テストでは空の安全なデフォルトを返し、必要な検証は trpcQuery /
+  // trpcMutation の override で個別に上書きする。
+  registerDefaultQuery("admin.users.list", () => ({ items: [], total: 0 }));
+  registerDefaultQuery("admin.users.detail", () => ({
+    id: "user-default",
+    name: "デフォルトユーザー",
+    email: "default@example.com",
+    emailVerified: false,
+    image: undefined,
+    role: "user" as const,
+    frozen: false,
+    createdAt: 0,
+    updatedAt: 0,
+  }));
+  registerDefaultQuery("admin.metrics.summary", () => ({
+    totalUsers: 0,
+    frozenUsers: 0,
+    totalGarments: 0,
+    totalCoordinates: 0,
+    totalLocations: 0,
+    signupsLast7d: 0,
+  }));
+  registerDefaultQuery("admin.audits.list", () => ({ items: [], total: 0 }));
+  registerDefaultQuery("admin.userDataView.garments", () => ({
+    items: [],
+    total: 0,
+  }));
+  registerDefaultQuery("admin.userDataView.locations", () => []);
+  registerDefaultQuery("admin.userDataView.coordinates", () => ({
+    items: [],
+    total: 0,
+  }));
+
+  registerDefaultMutation("admin.users.freeze", () => ({
+    ok: true as const,
+    noop: false,
+  }));
+  registerDefaultMutation("admin.users.unfreeze", () => ({
+    ok: true as const,
+    noop: false,
+  }));
 };

--- a/src/test/mocks/trpc/handlerFactory.ts
+++ b/src/test/mocks/trpc/handlerFactory.ts
@@ -6,30 +6,32 @@ import type { AppRouter } from "../../../../workers/src/trpc/router";
 type RouterInputsRaw = inferRouterInputs<AppRouter>;
 type RouterOutputsRaw = inferRouterOutputs<AppRouter>;
 
-export type ProcedurePath = {
-  [R in keyof RouterInputsRaw]: {
-    [P in keyof RouterInputsRaw[R]]: `${R & string}.${P & string}`;
-  }[keyof RouterInputsRaw[R]];
-}[keyof RouterInputsRaw];
+// 入力/出力が plain object なら procedure leaf、それ以外 (ネストされた router の object) は再帰。
+// tRPC の inferRouterInputs では procedure の input は record か void/undefined になる。
+// 厳密な leaf 判定は難しいので、`object` を再帰し、`void`/`undefined`/primitives を leaf とみなす。
+// admin.users.list のように 3 階層まで対応。
+type FlattenPath<T, Prefix extends string = ""> = {
+  [K in keyof T & string]: T[K] extends Record<string, unknown>
+    ? `${Prefix}${K}` | FlattenPath<T[K], `${Prefix}${K}.`>
+    : `${Prefix}${K}`;
+}[keyof T & string];
+
+export type ProcedurePath = FlattenPath<RouterInputsRaw>;
+
+type GetByPath<T, P extends string> = P extends `${infer Head}.${infer Tail}`
+  ? Head extends keyof T
+    ? GetByPath<T[Head], Tail>
+    : never
+  : P extends keyof T
+    ? T[P]
+    : never;
 
 export type RouterInputs = {
-  [P in ProcedurePath]: P extends `${infer R}.${infer K}`
-    ? R extends keyof RouterInputsRaw
-      ? K extends keyof RouterInputsRaw[R]
-        ? RouterInputsRaw[R][K]
-        : never
-      : never
-    : never;
+  [P in ProcedurePath]: GetByPath<RouterInputsRaw, P>;
 };
 
 export type RouterOutputs = {
-  [P in ProcedurePath]: P extends `${infer R}.${infer K}`
-    ? R extends keyof RouterOutputsRaw
-      ? K extends keyof RouterOutputsRaw[R]
-        ? RouterOutputsRaw[R][K]
-        : never
-      : never
-    : never;
+  [P in ProcedurePath]: GetByPath<RouterOutputsRaw, P>;
 };
 
 export type Resolver<P extends ProcedurePath> = (args: {

--- a/src/test/mocks/trpc/handlerFactory.ts
+++ b/src/test/mocks/trpc/handlerFactory.ts
@@ -77,13 +77,48 @@ const resolveByPath = (
 ): WideResolver | undefined =>
   overrideRegistry[kind].get(path) ?? defaultRegistry[kind].get(path);
 
-const errorEntry = (message: string) => ({
+// resolver が trpcError(...) を throw すると `data.code` を保持して errorEntry に
+// 反映する。CLAUDE.md「class 禁止」を守るため、Error インスタンスに追加プロパティを
+// 持たせるタグオブジェクト方式で識別する。
+const MOCK_TRPC_ERROR_TAG = Symbol.for("mock-trpc-error");
+
+type MockTRPCErrorTagged = Error & {
+  readonly [MOCK_TRPC_ERROR_TAG]: true;
+  readonly trpcCode: string;
+  readonly httpStatus: number;
+};
+
+const isMockTRPCError = (error: unknown): error is MockTRPCErrorTagged =>
+  error instanceof Error && MOCK_TRPC_ERROR_TAG in error;
+
+const DEFAULT_HTTP_STATUS = 500;
+
+export const mockTRPCError = (
+  code: string,
+  message: string,
+  httpStatus = DEFAULT_HTTP_STATUS,
+): MockTRPCErrorTagged =>
+  // Object.assign の戻り値型は intersection なので、Error にタグ + 追加プロパティを
+  // 載せた型として推論される。明示的な type assertion を使わずに済む。
+  Object.assign(new Error(message), {
+    [MOCK_TRPC_ERROR_TAG]: true as const,
+    trpcCode: code,
+    httpStatus,
+  });
+
+const TRPC_ERROR_CODE_INTERNAL = -32603;
+
+const errorEntry = (
+  message: string,
+  code = "INTERNAL_SERVER_ERROR",
+  httpStatus = DEFAULT_HTTP_STATUS,
+) => ({
   error: {
     message,
-    code: -32603,
+    code: TRPC_ERROR_CODE_INTERNAL,
     data: {
-      code: "INTERNAL_SERVER_ERROR",
-      httpStatus: 500,
+      code,
+      httpStatus,
     },
   },
 });
@@ -113,7 +148,12 @@ const parsePostInputs = async (
 
 type ResolverOutcome =
   | { readonly kind: "ok"; readonly value: unknown }
-  | { readonly kind: "error"; readonly message: string };
+  | {
+      readonly kind: "error";
+      readonly message: string;
+      readonly code: string;
+      readonly httpStatus: number;
+    };
 
 const runResolver = async (
   resolver: WideResolver,
@@ -128,9 +168,19 @@ const runResolver = async (
   }));
   if (typeof value === "object" && value !== null && errorSentinel in value) {
     const error: unknown = Reflect.get(value, errorSentinel);
+    if (isMockTRPCError(error)) {
+      return {
+        kind: "error",
+        message: error.message,
+        code: error.trpcCode,
+        httpStatus: error.httpStatus,
+      };
+    }
     return {
       kind: "error",
       message: error instanceof Error ? error.message : String(error),
+      code: "INTERNAL_SERVER_ERROR",
+      httpStatus: DEFAULT_HTTP_STATUS,
     };
   }
   return { kind: "ok", value };
@@ -151,7 +201,7 @@ const dispatch = async (
       const { [String(i)]: input } = inputs;
       const outcome = await runResolver(resolver, input, request);
       if (outcome.kind === "error") {
-        return errorEntry(outcome.message);
+        return errorEntry(outcome.message, outcome.code, outcome.httpStatus);
       }
       return successEntry(outcome.value);
     }),


### PR DESCRIPTION
## Summary

issue #236 の Step 5-6 (フロント `/admin` ガード + 各ページ実装) を提供する。

✅ **frontend + qa + i18n-design の追加 commit 完了** — codex 再レビュー + 人間マージ待ち。

### 実装範囲

#### 認証・ガード
- `src/components/admin/AdminGuard.tsx` (+ test) — `role!="admin"` or `frozen=true` で `/dashboard` リダイレクト
- `src/stores/authAtoms.ts` — `AuthUser` に `role` / `frozen` を伝播
- `src/test/mocks/handlers.ts` — `adminSessionHandler` / `sessionHandler` ヘルパー追加

#### レイアウト・ナビ
- `src/components/admin/AdminSideNav.tsx`
- `src/app/admin/layout.tsx`
- `src/lib/nav-items.ts` を `getNavItems(role)` 関数化し、admin 入口は `role=admin` のみ表示
- `src/components/layout/{TopBar,BottomNav}.tsx` を `getNavItems` に切替

#### Jotai atom (`src/stores/adminAtoms.ts`)
- `adminMetricsAtom`, `adminUsersAtom`, `adminUserDetailAtomFamily`
- `adminAuditsAtom`, `adminUser{Garments,Coordinates,Locations}AtomFamily`
- `freezeUserAtom` / `unfreezeUserAtom` (refresh trigger 連携)

#### ページ
- `src/app/admin/page.tsx` + test — KPI カード 6 枚 (`totalUsers` / `frozenUsers` / `signupsLast7d` / `totalGarments` / `totalCoordinates` / `totalLocations`)
- `src/app/admin/users/page.tsx` + test — 検索 + role/frozen フィルタ + ページネーション
- `src/app/admin/users/[id]/page.tsx` + test — 詳細 + 凍結/解凍 ConfirmSheet + データ閲覧タブ
- `src/app/admin/audits/page.tsx` + test — 監査ログ一覧 + ページネーション

#### UI コンポーネント
- `src/components/admin/{UserTable,UserFreezeButton,MetricsCard,AuditLogTable,UserDataTabs}.tsx`
- 既存 `src/components/ui/` (Card / Badge / Button / SearchInput / ChipGroup / EmptyState / Pagination / ConfirmSheet / BottomSheet / PageHeader / Skeleton) を最大限再利用、独自 UI は最小限

#### tRPC モック基盤
- `src/test/mocks/trpc/handlerFactory.ts` の `ProcedurePath` をネスト router (例: `admin.users.list`) 対応に拡張
- `src/test/mocks/trpc/defaults.ts` に `admin.*` の安全なデフォルト resolver を登録

#### qa による追加 (commit `5950947`)
- UserDataTabs / adminAtoms / 各 UI コンポーネントのカバレッジ補強
- +51 tests (1542 → 1593)
- branches: 89.04% → **90.02%**

#### i18n-design による追加 (commit `cae6e41`)
- `pnpm i18n:extract` → en / ko / zh の admin 関連 65 新規エントリすべてに翻訳記入
- `pnpm i18n:compile` → コンパイル済みカタログ再生成
- 既存翻訳は未変更
- UI トーン / a11y 最終確認 (read-only バッジ `<Eye />` + 「閲覧専用」、freeze/unfreeze ConfirmSheet で語混同なし、aria-label 完備)

### 設計判断

- **真の防御は Workers 側の `adminProcedure`** (PR2 で実装済み)。`AdminGuard` は UX 目的のみで、bypass されてもバックエンドが拒否する。
- **freezeUser のガード**: 自己凍結・admin→admin 凍結はフロント側で disabled (理由を表示)、Workers 側でも `BAD_REQUEST` / `FORBIDDEN` を返す二重防御。
- **データ閲覧 read-only**: タブに `<Eye />` + 「閲覧専用」バッジを明示。
- **Suspense + ErrorBoundary + Jotai atom** パターンを既存 `src/app/garments/page.tsx` に揃える。
- **全 UI テキストを Lingui マクロ** (`<Trans>` / `t` / `msg`) で囲み、ja/en/ko/zh の 4 言語完訳済み。

### CLAUDE.md 準拠

- バレルファイル禁止 / 型アサーション禁止 / `any` 禁止 / `let` 禁止 / `null` (DOM 以外) 禁止 / `try/catch` 禁止 を遵守
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors, 既存 warnings のみ)
- `pnpm format:check` ✅
- `pnpm i18n:check` ✅ (en / ko / zh 全エントリ翻訳済み)
- `pnpm test` ✅ (**1593 passed**)
- `pnpm test:coverage` ✅ (branches **90.02%** / 80% 閾値クリア)
- `pnpm precheck:full` ✅

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check` / `pnpm i18n:check` / `pnpm test` 全 pass (`pnpm precheck:full`)
- [x] `pnpm test:coverage` branches 90.02% (>= 80%)
- [x] AdminGuard: admin / role=user / 未認証 / frozen admin / frozen user / transient error の 6 ケース
- [x] /admin/users 詳細: 一般 / admin (disabled) / 自己 (disabled) / freeze mutation / unfreeze mutation / not found / 各 data tab の 9 ケース
- [x] BottomNav: 一般ユーザー non-admin entry / admin ユーザー admin entry の 2 追加ケース
- [x] qa: UserDataTabs / adminAtoms / 各 UI コンポーネント のエッジケース補強 (+51 tests)
- [x] i18n-design: en / ko / zh PO 65 エントリ翻訳記入、UI トーン / a11y 最終確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)