### PR TITLE
docs(admin): admin 付与手順 + 最終 precheck (Step 7 of #236)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ pnpm dev
 pnpm dev:workers
 ```
 
+## 管理者（admin）の付与
+
+`/admin` 配下の管理画面（ユーザー一覧・凍結・メトリクス・監査ログ）は `role = "admin"` を持つユーザーのみアクセスできる。初期 admin は D1 を直接更新して付与する。
+
+### ローカル環境
+
+```bash
+pnpm wrangler d1 execute doll-wardrobe-db --local \
+  --command "UPDATE \"user\" SET role='admin' WHERE email = 'you@example.com';"
+```
+
+### 本番環境
+
+```bash
+pnpm wrangler d1 execute doll-wardrobe-db --remote \
+  --command "UPDATE \"user\" SET role='admin' WHERE email = 'you@example.com';"
+```
+
+`role` を `'user'` に戻すと admin 権限を剥奪できる。`frozen = 1` を立てるとログイン拒否＋既存セッション失効になる（運用は `/admin` の凍結 UI から行う）。
+
+> better-auth が管理する `user` テーブルの `role` / `frozen` カラムを直接更新する運用。スクリプト化は MVP 段階では行わない。
+
 ## スクリプト一覧
 
 | コマンド                | 説明                             |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,26 @@ pnpm wrangler d1 execute doll-wardrobe-db --remote \
   --command "UPDATE \"user\" SET role='admin' WHERE email = 'you@example.com';"
 ```
 
-`role` を `'user'` に戻すと admin 権限を剥奪できる。`frozen = 1` を立てるとログイン拒否＋既存セッション失効になる（運用は `/admin` の凍結 UI から行う）。
+`role` を `'user'` に戻すと admin 権限を剥奪できる。
+
+### ユーザー凍結（frozen）の運用
+
+**凍結は必ず `/admin/users/[id]` の凍結 UI から行う**。UI 経由なら以下が batch でアトミックに実行される:
+
+1. `user.frozen = 1` 更新
+2. 該当ユーザーの既存 better-auth session を `DELETE FROM "session" WHERE "userId" = ?` で全消去
+3. `admin_audit_logs` に `user.freeze` を記録
+
+SQL で `frozen = 1` を直接立てるだけでは **既存セッションが残ったまま** になり、認証経路（better-auth ネイティブの `/api/auth/*` 等）によっては凍結後もリクエストが通る可能性がある（tRPC / REST の主経路は `resolveAuthenticatedUserId` の frozen チェックで弾けるが、全パスは保証しない）。
+
+緊急時に CLI から凍結する必要がある場合は session 削除も併せて実行する:
+
+```bash
+pnpm wrangler d1 execute doll-wardrobe-db --local --command "
+UPDATE \"user\" SET frozen=1 WHERE email='target@example.com';
+DELETE FROM \"session\" WHERE userId IN (SELECT id FROM \"user\" WHERE email='target@example.com');
+"
+```
 
 > better-auth が管理する `user` テーブルの `role` / `frozen` カラムを直接更新する運用。スクリプト化は MVP 段階では行わない。
 


### PR DESCRIPTION
Refs #236 — admin MVP の最終仕上げ (Step 7)。

## Summary

- README に admin (role) 付与手順を追記
  - ローカル: `pnpm wrangler d1 execute doll-wardrobe-db --local --command "UPDATE \"user\" SET role='admin' WHERE email = '...';"`
  - 本番: `--remote` 版
  - `role` を `'user'` に戻す手順、`frozen` カラムの運用注意も明記
- i18n 翻訳（en/ko/zh）は PR #239 内で完了済み、本 PR では `precheck:full` pass を確認するのみ

## Test plan

- [x] `pnpm precheck:full` pass (typecheck / lint / format:check / i18n:check / test 全部)
- [ ] ローカル D1 にマイグレーション適用: `pnpm db:migrate:local`
- [ ] 自分のアカウントを admin に昇格 → `/admin` にアクセスしてメトリクスが見える
- [ ] `/admin/users` で別ユーザーを検索 → 詳細 → 凍結
- [ ] 別タブで凍結ユーザーで再ログイン → 拒否確認
- [ ] `/admin/audits` で `user.freeze` 行確認
- [ ] 解凍 → 再ログイン可能確認
- [ ] role=user のアカウントで `/admin` → `/` リダイレクト確認

## 関連 PR

- #237 PR1: DB スキーマ + better-auth role/frozen
- #238 PR2: adminProcedure + admin API
- #239 PR3: /admin ガード + 各ページ実装