### PR TITLE
feat(observability): Workers Sentry 統合 + Cloudflare runbook (#234)

### DIFF
--- a/.github/actions/sentry-sourcemap-upload/action.yml
+++ b/.github/actions/sentry-sourcemap-upload/action.yml
@@ -34,14 +34,16 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.local/bin/sentry-cli
-        key: sentry-cli-${{ runner.os }}-latest
+        key: sentry-cli-${{ runner.os }}-2.40.0
 
     - name: Install sentry-cli (if cache miss)
       shell: bash
+      env:
+        SENTRY_CLI_VERSION: "2.40.0"
       run: |
         if [ ! -x "$HOME/.local/bin/sentry-cli" ]; then
           mkdir -p "$HOME/.local/bin"
-          curl -sL https://sentry.io/get-cli/ | INSTALL_DIR="$HOME/.local/bin" bash
+          curl -sL https://sentry.io/get-cli/ | INSTALL_DIR="$HOME/.local/bin" SENTRY_CLI_VERSION="$SENTRY_CLI_VERSION" bash
         fi
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
@@ -71,6 +73,7 @@ runs:
         sentry-cli sourcemaps upload \
           --release="${{ inputs.release }}" \
           --url-prefix="${{ inputs.url_prefix }}" \
+          --strict \
           "${{ inputs.sourcemap_path }}"
 
     - name: Finalize release and attach deploy

--- a/.github/actions/sentry-sourcemap-upload/action.yml
+++ b/.github/actions/sentry-sourcemap-upload/action.yml
@@ -14,7 +14,12 @@ inputs:
     description: Sentry project slug (e.g. dollrobe-api, dollrobe-web)
     required: true
   release:
-    description: Release identifier (commonly the git SHA)
+    description: >-
+      Base release identifier (commonly the git SHA). The action namespaces it
+      per project as "<project>@<release>" so Web / API uploads sharing the same
+      SHA never collide on a single org-level Sentry release. The runtime
+      SENTRY_RELEASE must be set to this same "<project>@<release>" value so
+      events match the uploaded artifacts.
     required: true
   sourcemap_path:
     description: Directory containing the .js / .js.map files to upload
@@ -47,13 +52,21 @@ runs:
         fi
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+    - name: Compute project-scoped release
+      id: release
+      shell: bash
+      env:
+        PROJECT: ${{ inputs.project }}
+        RELEASE: ${{ inputs.release }}
+      run: echo "name=${PROJECT}@${RELEASE}" >> "$GITHUB_OUTPUT"
+
     - name: Create Sentry release
       shell: bash
       env:
         SENTRY_AUTH_TOKEN: ${{ inputs.auth_token }}
         SENTRY_ORG: ${{ inputs.org }}
         SENTRY_PROJECT: ${{ inputs.project }}
-      run: sentry-cli releases new "${{ inputs.release }}"
+      run: sentry-cli releases new "${{ steps.release.outputs.name }}"
 
     - name: Inject release identifier into bundles
       shell: bash
@@ -71,7 +84,7 @@ runs:
         SENTRY_PROJECT: ${{ inputs.project }}
       run: |
         sentry-cli sourcemaps upload \
-          --release="${{ inputs.release }}" \
+          --release="${{ steps.release.outputs.name }}" \
           --url-prefix="${{ inputs.url_prefix }}" \
           --strict \
           "${{ inputs.sourcemap_path }}"
@@ -83,6 +96,6 @@ runs:
         SENTRY_ORG: ${{ inputs.org }}
         SENTRY_PROJECT: ${{ inputs.project }}
       run: |
-        sentry-cli releases finalize "${{ inputs.release }}"
-        sentry-cli releases deploys "${{ inputs.release }}" new \
+        sentry-cli releases finalize "${{ steps.release.outputs.name }}"
+        sentry-cli releases deploys "${{ steps.release.outputs.name }}" new \
           --env "${{ inputs.environment }}"

--- a/.github/actions/sentry-sourcemap-upload/action.yml
+++ b/.github/actions/sentry-sourcemap-upload/action.yml
@@ -1,0 +1,85 @@
+name: Sentry sourcemap upload
+description: >-
+  Upload source maps to Sentry as part of a release. Designed to be called from
+  the Web / API deploy jobs once they exist (see issue #232).
+
+inputs:
+  auth_token:
+    description: Sentry auth token (typically from secrets.SENTRY_AUTH_TOKEN)
+    required: true
+  org:
+    description: Sentry organization slug
+    required: true
+  project:
+    description: Sentry project slug (e.g. dollrobe-api, dollrobe-web)
+    required: true
+  release:
+    description: Release identifier (commonly the git SHA)
+    required: true
+  sourcemap_path:
+    description: Directory containing the .js / .js.map files to upload
+    required: true
+  url_prefix:
+    description: URL prefix Sentry should use when matching frames (e.g. "~/_next" for Next.js, "~/" for Workers)
+    required: false
+    default: "~/"
+  environment:
+    description: Deployment environment (staging / production)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Cache sentry-cli
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/bin/sentry-cli
+        key: sentry-cli-${{ runner.os }}-latest
+
+    - name: Install sentry-cli (if cache miss)
+      shell: bash
+      run: |
+        if [ ! -x "$HOME/.local/bin/sentry-cli" ]; then
+          mkdir -p "$HOME/.local/bin"
+          curl -sL https://sentry.io/get-cli/ | INSTALL_DIR="$HOME/.local/bin" bash
+        fi
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: Create Sentry release
+      shell: bash
+      env:
+        SENTRY_AUTH_TOKEN: ${{ inputs.auth_token }}
+        SENTRY_ORG: ${{ inputs.org }}
+        SENTRY_PROJECT: ${{ inputs.project }}
+      run: sentry-cli releases new "${{ inputs.release }}"
+
+    - name: Inject release identifier into bundles
+      shell: bash
+      env:
+        SENTRY_AUTH_TOKEN: ${{ inputs.auth_token }}
+        SENTRY_ORG: ${{ inputs.org }}
+        SENTRY_PROJECT: ${{ inputs.project }}
+      run: sentry-cli sourcemaps inject "${{ inputs.sourcemap_path }}"
+
+    - name: Upload source maps
+      shell: bash
+      env:
+        SENTRY_AUTH_TOKEN: ${{ inputs.auth_token }}
+        SENTRY_ORG: ${{ inputs.org }}
+        SENTRY_PROJECT: ${{ inputs.project }}
+      run: |
+        sentry-cli sourcemaps upload \
+          --release="${{ inputs.release }}" \
+          --url-prefix="${{ inputs.url_prefix }}" \
+          "${{ inputs.sourcemap_path }}"
+
+    - name: Finalize release and attach deploy
+      shell: bash
+      env:
+        SENTRY_AUTH_TOKEN: ${{ inputs.auth_token }}
+        SENTRY_ORG: ${{ inputs.org }}
+        SENTRY_PROJECT: ${{ inputs.project }}
+      run: |
+        sentry-cli releases finalize "${{ inputs.release }}"
+        sentry-cli releases deploys "${{ inputs.release }}" new \
+          --env "${{ inputs.environment }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,11 @@
 
 - `gh` コマンドを使用して issue や PR にアクセスすること
 
+## Cloudflare Operations
+
+- 障害対応・ロールバック・gradual deployments の運用ルールは [`docs/cloudflare-runbook.md`](docs/cloudflare-runbook.md) を参照
+- Sentry へのエラー転送は `workers/src/lib/sentry.ts` 経由で `Sentry.withSentry` でラップ済み
+
 ---
 
 ## プロジェクト概要

--- a/docs/cloudflare-runbook.md
+++ b/docs/cloudflare-runbook.md
@@ -156,10 +156,10 @@ wrangler versions deploy <new-id>@100% --name doll-wardrobe-api
 
 ### 5.1 release タグでエラーを絞り込み
 
-deploy 時に CI が `SENTRY_RELEASE` (git SHA) を注入します。Sentry の Issues 画面で:
+deploy 時に CI が `SENTRY_RELEASE` を注入します。release 名は Web / API でアーティファクトが混ざらないよう `<project>@<git-sha>` 形式で namespace されます (例: `dollrobe-api@<git-sha>`)。Sentry の Issues 画面で:
 
 ```
-release:<git-sha>
+release:dollrobe-api@<git-sha>
 ```
 
 で検索すると、その deploy 由来のエラーだけが表示されます。
@@ -168,11 +168,11 @@ release:<git-sha>
 
 source map は CI の `.github/actions/sentry-sourcemap-upload` composite action 経由でアップロードされます (子 Issue #232 の deploy.yml 完成後に有効化)。Sentry の Issue 詳細ページで minify されたフレームの右側に「View source map」のアイコンが出ます。
 
-> **トラブルシューティング**: スタックトレースが minified のままなら、`SENTRY_RELEASE` と CI で upload したときの `--release` が一致しているか確認。
+> **トラブルシューティング**: スタックトレースが minified のままなら、ランタイムの `SENTRY_RELEASE` と CI で upload したときの `--release` (どちらも `<project>@<git-sha>` 形式) が一致しているか確認。
 
 ### 5.3 環境タグ
 
-`environment:production` / `environment:staging` で絞り込めます。`SENTRY_ENVIRONMENT` env var (wrangler の `[vars]` または `[env.production.vars]`) で設定。
+`environment:production` / `environment:staging` で絞り込めます。`SENTRY_ENVIRONMENT` env var は `wrangler.jsonc` の各 `env.staging.vars` / `env.production.vars` で設定 (top-level `vars` には置かない。未設定の環境が local 扱いになるのを防ぐため)。
 
 ---
 

--- a/docs/cloudflare-runbook.md
+++ b/docs/cloudflare-runbook.md
@@ -1,0 +1,195 @@
+# Cloudflare Operations Runbook
+
+このドキュメントは Dollrobe の Cloudflare デプロイに対する障害対応・ロールバック手順をまとめたものです。インシデント発生時に最初に読むエントリポイントです。
+
+## 前提
+
+- **Worker 名**: `doll-wardrobe-api` (API), `doll-wardrobe-web` (Web、子 Issue #231 で追加予定)
+- **deployment 履歴**: Cloudflare Workers は **直近 100 deployment** を保持します。`wrangler rollback` で任意の過去 deployment に戻せます。
+- **Durable Objects 制約**: Dollrobe は Durable Objects を使用していないため、`wrangler rollback` の DO 関連制約は該当しません。
+- **Sentry**: API Worker は `@sentry/cloudflare` で計装済み。`SENTRY_DSN` が secret 設定されていればハンドラ内例外と tRPC の 5xx エラーが自動キャプチャされます。
+
+---
+
+## 1. デプロイ一覧の確認
+
+最新の deployment と直近の履歴を確認するには:
+
+```bash
+wrangler deployments list --name doll-wardrobe-api
+```
+
+出力例:
+
+```
+Created:     2026-05-20 10:23:45
+Author:      ci@cloudflare
+Source:      Upload
+Tag:         (no tag)
+Message:     (no message)
+Version ID:  9b1c4a3f-...
+```
+
+- **Version ID**: rollback 先を指定するキー。
+- **Created**: deployment 時刻。インシデント発生時刻と突き合わせて疑わしい deployment を特定します。
+- **Source**: `Upload` (CI 経由) / `Dash` (手動操作) など。
+
+特定 version の詳細を見るには:
+
+```bash
+wrangler deployments view <version-id>
+```
+
+---
+
+## 2. ロールバック手順
+
+### 2.1 直近の deployment を 1 つ前に戻す
+
+```bash
+# 対話モードで一覧から選択
+wrangler rollback --name doll-wardrobe-api
+
+# 一発で直前版に戻す
+wrangler rollback --name doll-wardrobe-api --message "incident: 500 spike"
+```
+
+### 2.2 特定の version-id に戻す
+
+```bash
+wrangler rollback <version-id> --name doll-wardrobe-api \
+  --message "incident #XXXX: rolling back to known-good"
+```
+
+### 2.3 staging / production を両方戻すケース
+
+両環境に同じ不具合があるなら **production を先に** 戻して影響を止めてから staging を戻す。
+
+```bash
+# 1. production を即座に戻す（ユーザー影響の停止が最優先）
+wrangler rollback <version-id> --name doll-wardrobe-api --env production
+
+# 2. staging を戻して再現確認できる状態に戻す
+wrangler rollback <version-id> --name doll-wardrobe-api --env staging
+```
+
+> **注記**: `--env` フラグは子 Issue #230 で `wrangler.jsonc` に staging / production の env が定義された後に有効化されます。それまでは単一環境のみ。
+
+### 2.4 secret / D1 / R2 / KV の扱い
+
+- **secret**: rollback で消えません。`wrangler secret put` で投入した値はそのまま維持されます。
+- **D1 マイグレーション**: コードを rollback しても DB schema は **戻りません**。schema 破壊的変更（カラム DROP など）を含む deploy を rollback する場合、事前に手動で down migration が必要です（expand & contract 運用は子 Issue #233 を参照）。
+- **R2 / KV**: 状態は変わりません。
+
+---
+
+## 3. インシデント判断フロー
+
+```
+エラー率急増 / アラート発火
+       │
+       ▼
+  Sentry でエラー範囲を特定
+       │
+       ├── 直近 deploy 後にエラーが立ち上がっている？
+       │        │
+       │        ├── YES → ロールバック (§2)
+       │        │         + 修正を別ブランチで作業
+       │        │
+       │        └── NO  → ホットフィックス
+       │                  + 短い PR で main → deploy
+       │
+       └── データ起因（特定ユーザーのみ等）
+                 │
+                 └── ホットフィックス + 該当データの調査
+```
+
+### 判断のしきい値
+
+- **ロールバックを選ぶ目安**: 影響範囲が広い / 修正に 30 分以上かかる / 原因が直近 deploy 由来であることが明確
+- **ホットフィックスを選ぶ目安**: 影響範囲が限定的 / 修正が 1〜2 行で済む / 原因が直近 deploy 以外（データ / 外部 API / cron 等）
+
+迷ったら **ロールバックが先**。ホットフィックスは時間を消費します。
+
+---
+
+## 4. Gradual Deployments 運用ルール
+
+重大変更（破壊的変更 / 大規模リファクタ / 認証周りの変更）は手動で段階展開します。**自動化はしません** — オペレーターが Sentry とメトリクスを目視確認することが前提です。
+
+### 段階展開コマンド
+
+```bash
+# 1. 新バージョンをアップロード（まだ traffic は流さない）
+wrangler versions upload --name doll-wardrobe-api
+
+# 2. 10% で開始
+wrangler versions deploy <new-id>@10% <prev-id>@90% --name doll-wardrobe-api
+
+# (Sentry / メトリクスで 10 分以上観測。エラー増加なし & p99 latency 退行なし を確認)
+
+# 3. 50% に拡大
+wrangler versions deploy <new-id>@50% <prev-id>@50% --name doll-wardrobe-api
+
+# (さらに 10 分以上観測)
+
+# 4. 100% に切替
+wrangler versions deploy <new-id>@100% --name doll-wardrobe-api
+```
+
+### 段階展開の対象判断
+
+| 変更内容                          | 段階展開                            |
+| --------------------------------- | ----------------------------------- |
+| typo 修正・コメント追加           | 不要 (直接 100%)                    |
+| UI 文言変更                       | 不要                                |
+| 通常の機能追加                    | 不要                                |
+| API スキーマ変更 (互換)           | 不要                                |
+| API スキーマ変更 (破壊)           | **必須**                            |
+| 認証ロジック変更                  | **必須**                            |
+| パフォーマンス系大規模変更        | **必須**                            |
+| DB マイグレーションを伴うリリース | **必須** (expand & contract 順序で) |
+
+---
+
+## 5. Sentry での確認手順
+
+### 5.1 release タグでエラーを絞り込み
+
+deploy 時に CI が `SENTRY_RELEASE` (git SHA) を注入します。Sentry の Issues 画面で:
+
+```
+release:<git-sha>
+```
+
+で検索すると、その deploy 由来のエラーだけが表示されます。
+
+### 5.2 source map によるスタックトレース解読
+
+source map は CI の `.github/actions/sentry-sourcemap-upload` composite action 経由でアップロードされます (子 Issue #232 の deploy.yml 完成後に有効化)。Sentry の Issue 詳細ページで minify されたフレームの右側に「View source map」のアイコンが出ます。
+
+> **トラブルシューティング**: スタックトレースが minified のままなら、`SENTRY_RELEASE` と CI で upload したときの `--release` が一致しているか確認。
+
+### 5.3 環境タグ
+
+`environment:production` / `environment:staging` で絞り込めます。`SENTRY_ENVIRONMENT` env var (wrangler の `[vars]` または `[env.production.vars]`) で設定。
+
+---
+
+## 6. 緊急時の連絡フロー
+
+1. インシデント検知（Sentry alert / メトリクス / ユーザー報告）
+2. `#incident` チャンネルへ起票（チャンネル未整備の場合は GitHub Issue に `incident` ラベルで起票）
+3. ロールバック判断（§3 のフロー）
+4. ロールバック実施 (§2) / ホットフィックス deploy
+5. ポストモーテム（同日中に Issue にまとめる）
+
+---
+
+## 関連リソース
+
+- 親 Issue: [#229](https://github.com/butaosuinu/Dollrobe/issues/229) — Cloudflare デプロイ基盤整備
+- Sentry composite action: `.github/actions/sentry-sourcemap-upload/action.yml`
+- Workers Sentry 計装: `workers/src/lib/sentry.ts`, `workers/src/index.ts`
+- Cloudflare Workers rollback 公式 doc: <https://developers.cloudflare.com/workers/configuration/versions-and-deployments/rollbacks/>
+- Cloudflare Workers gradual deployments: <https://developers.cloudflare.com/workers/configuration/versions-and-deployments/gradual-deployments/>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@lingui/react": "^5.9.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@paralleldrive/cuid2": "^2.2.2",
+    "@sentry/cloudflare": "^10.53.1",
     "@sentry/nextjs": "^10.43.0",
     "@serwist/turbopack": "^9.5.6",
     "@techstark/opencv-js": "4.12.0-release.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.3.1
+      '@sentry/cloudflare':
+        specifier: ^10.53.1
+        version: 10.53.1(@cloudflare/workers-types@4.20260312.1)
       '@sentry/nextjs':
         specifier: ^10.43.0
         version: 10.43.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4(esbuild@0.27.4))
@@ -1952,6 +1955,10 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/context-async-hooks@2.6.0':
     resolution: {integrity: sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2655,8 +2662,21 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@sentry/cloudflare@10.53.1':
+    resolution: {integrity: sha512-iSohVibGRAKg7zLUflfA2ePG69Uw6bqm6iCQLM18hoG2gT4DGigaKcjJmZLTfAtW1DInMCb0DYc/mltCznxMrQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.x
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   '@sentry/core@10.43.0':
     resolution: {integrity: sha512-l0SszQAPiQGWl/ferw8GP3ALyHXiGiRKJaOvNmhGO+PrTQyZTZ6OYyPnGijAFRg58dE1V3RCH/zw5d2xSUIiNg==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.53.1':
+    resolution: {integrity: sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==}
     engines: {node: '>=18'}
 
   '@sentry/nextjs@10.43.0':
@@ -8591,6 +8611,8 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -9171,7 +9193,16 @@ snapshots:
       - encoding
       - supports-color
 
+  '@sentry/cloudflare@10.53.1(@cloudflare/workers-types@4.20260312.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@sentry/core': 10.53.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260312.1
+
   '@sentry/core@10.43.0': {}
+
+  '@sentry/core@10.53.1': {}
 
   '@sentry/nextjs@10.43.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4(esbuild@0.27.4))':
     dependencies:

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -5,6 +5,7 @@ import { requestId } from "hono/request-id";
 import { timing } from "hono/timing";
 import { trpcServer } from "@hono/trpc-server";
 import { APIError } from "better-auth/api";
+import * as Sentry from "@sentry/cloudflare";
 import { appRouter } from "./trpc/router";
 import type { TRPCContext } from "./trpc/index";
 import type { Env } from "./types";
@@ -13,6 +14,7 @@ import type { Auth } from "./auth";
 import { createLogger, DEFAULT_LOG_LEVEL } from "./lib/logger";
 import type { Logger, LogLevel } from "./lib/logger";
 import { isUserFrozen } from "./lib/user-status";
+import { buildSentryOptions, captureTrpcError } from "./lib/sentry";
 import { imageRoutes } from "./routes/image";
 import * as imageService from "./services/image-service";
 import { handleDigestCron } from "./scheduled/digest-cron";
@@ -242,13 +244,14 @@ app.use(
           errorMessage: error.message,
         });
       }
+      captureTrpcError({ error, path });
     },
   }),
 );
 
 app.get("/health", (c) => c.json({ status: "ok" }));
 
-export default {
+const handler = {
   async fetch(
     request: Request,
     env: Env,
@@ -279,3 +282,8 @@ export default {
     await handleDigestQueue({ batch, env, logger: queueLogger });
   },
 } satisfies ExportedHandler<Env>;
+
+export default Sentry.withSentry(
+  (env: Env) => buildSentryOptions(env),
+  handler,
+);

--- a/workers/src/lib/sentry.test.ts
+++ b/workers/src/lib/sentry.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TRPCError } from "@trpc/server";
+import {
+  buildSentryOptions,
+  captureTrpcError,
+  shouldCaptureTrpcError,
+} from "./sentry";
+
+const { captureExceptionMock, honoIntegrationMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(
+    (_error: unknown, _options?: unknown): undefined => undefined,
+  ),
+  honoIntegrationMock: vi.fn((_options?: unknown) => ({
+    name: "Hono",
+    setupOnce: () => undefined,
+  })),
+}));
+
+vi.mock("@sentry/cloudflare", () => ({
+  captureException: (error: unknown, options?: unknown) => {
+    captureExceptionMock(error, options);
+  },
+  honoIntegration: (options?: unknown) => honoIntegrationMock(options),
+}));
+
+afterEach(() => {
+  captureExceptionMock.mockClear();
+  honoIntegrationMock.mockClear();
+});
+
+describe("buildSentryOptions", () => {
+  it("DSN が undefined のまま options に乗る (SDK 側で no-op になる前提)", () => {
+    const options = buildSentryOptions({});
+
+    expect(options.dsn).toBeUndefined();
+    expect(options.environment).toBe("local");
+    expect(options.release).toBeUndefined();
+    expect(options.tracesSampleRate).toBe(0.05);
+    expect(options.integrations).toHaveLength(1);
+  });
+
+  it("DSN / environment / release を env から拾う", () => {
+    const options = buildSentryOptions({
+      SENTRY_DSN: "https://public@example.ingest.sentry.io/1",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_RELEASE: "abc1234",
+    });
+
+    expect(options.dsn).toBe("https://public@example.ingest.sentry.io/1");
+    expect(options.environment).toBe("production");
+    expect(options.release).toBe("abc1234");
+  });
+});
+
+describe("shouldCaptureTrpcError", () => {
+  it.each([
+    ["BAD_REQUEST", false],
+    ["UNAUTHORIZED", false],
+    ["FORBIDDEN", false],
+    ["NOT_FOUND", false],
+    ["TOO_MANY_REQUESTS", false],
+    ["INTERNAL_SERVER_ERROR", true],
+    ["NOT_IMPLEMENTED", true],
+    ["BAD_GATEWAY", true],
+    ["SERVICE_UNAVAILABLE", true],
+    ["GATEWAY_TIMEOUT", true],
+  ] as const)("%s -> %s", (code, expected) => {
+    expect(shouldCaptureTrpcError(code)).toBe(expected);
+  });
+});
+
+describe("captureTrpcError", () => {
+  it("4xx 系は Sentry へ送らない", () => {
+    captureTrpcError({
+      error: new TRPCError({ code: "BAD_REQUEST", message: "bad input" }),
+      path: "garment.create",
+    });
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("5xx 系は Sentry へ送る (cause があれば cause を優先)", () => {
+    const cause = new Error("DB down");
+    captureTrpcError({
+      error: new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "boom",
+        cause,
+      }),
+      path: "garment.list",
+    });
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledWith(cause, {
+      tags: {
+        trpc_procedure: "garment.list",
+        trpc_code: "INTERNAL_SERVER_ERROR",
+      },
+    });
+  });
+
+  it("cause が無いときは TRPCError 自体を送る", () => {
+    captureTrpcError({
+      error: new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "boom" }),
+      path: undefined,
+    });
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const [capturedError, captureOptions] =
+      captureExceptionMock.mock.calls[0] ?? [];
+    expect(capturedError).toBeInstanceOf(TRPCError);
+    expect(captureOptions).toEqual({
+      tags: {
+        trpc_procedure: "<unknown>",
+        trpc_code: "INTERNAL_SERVER_ERROR",
+      },
+    });
+  });
+});

--- a/workers/src/lib/sentry.test.ts
+++ b/workers/src/lib/sentry.test.ts
@@ -33,10 +33,15 @@ describe("buildSentryOptions", () => {
     const options = buildSentryOptions({});
 
     expect(options.dsn).toBeUndefined();
-    expect(options.environment).toBe("local");
-    expect(options.release).toBeUndefined();
     expect(options.tracesSampleRate).toBe(0.05);
     expect(options.integrations).toHaveLength(1);
+  });
+
+  it("SENTRY_ENVIRONMENT / SENTRY_RELEASE が未設定ならキーごと生やさない (SDK の自動解決に委ねる)", () => {
+    const options = buildSentryOptions({});
+
+    expect("environment" in options).toBe(false);
+    expect("release" in options).toBe(false);
   });
 
   it("DSN / environment / release を env から拾う", () => {

--- a/workers/src/lib/sentry.ts
+++ b/workers/src/lib/sentry.ts
@@ -1,0 +1,63 @@
+import * as Sentry from "@sentry/cloudflare";
+import type { CloudflareOptions } from "@sentry/cloudflare";
+import type { TRPCError } from "@trpc/server";
+import type { Env } from "../types";
+
+type SentryEnv = Pick<
+  Env,
+  "SENTRY_DSN" | "SENTRY_ENVIRONMENT" | "SENTRY_RELEASE"
+>;
+
+// 100 ユーザー規模で Sentry の Developer plan (10K transactions/month) を
+// 圧迫しない値。production で観測量が足りなければ環境別に上げる。
+const DEFAULT_TRACES_SAMPLE_RATE = 0.05;
+const DEFAULT_ENVIRONMENT = "local";
+const UNKNOWN_PROCEDURE = "<unknown>";
+
+// 4xx 相当の tRPC エラーは利用者起因なので Sentry に送らない。
+// BAD_REQUEST 系のバリデーションエラーは構造化ログ側で十分追跡できる。
+const NON_CAPTURED_TRPC_CODES: ReadonlySet<TRPCError["code"]> = new Set([
+  "PARSE_ERROR",
+  "BAD_REQUEST",
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "NOT_FOUND",
+  "METHOD_NOT_SUPPORTED",
+  "TIMEOUT",
+  "CONFLICT",
+  "PRECONDITION_FAILED",
+  "PAYLOAD_TOO_LARGE",
+  "UNSUPPORTED_MEDIA_TYPE",
+  "UNPROCESSABLE_CONTENT",
+  "TOO_MANY_REQUESTS",
+  "CLIENT_CLOSED_REQUEST",
+]);
+
+// fetch hot path で毎リクエスト再生成しないため module レベルで保持する。
+const INTEGRATIONS = [Sentry.honoIntegration()];
+
+export const buildSentryOptions = (env: SentryEnv): CloudflareOptions => ({
+  dsn: env.SENTRY_DSN,
+  environment: env.SENTRY_ENVIRONMENT ?? DEFAULT_ENVIRONMENT,
+  release: env.SENTRY_RELEASE,
+  tracesSampleRate: DEFAULT_TRACES_SAMPLE_RATE,
+  integrations: INTEGRATIONS,
+});
+
+export const shouldCaptureTrpcError = (code: TRPCError["code"]): boolean =>
+  !NON_CAPTURED_TRPC_CODES.has(code);
+
+export const captureTrpcError = ({
+  error,
+  path,
+}: {
+  readonly error: TRPCError;
+  readonly path: string | undefined;
+}): void => {
+  if (!shouldCaptureTrpcError(error.code)) {
+    return;
+  }
+  Sentry.captureException(error.cause ?? error, {
+    tags: { trpc_procedure: path ?? UNKNOWN_PROCEDURE, trpc_code: error.code },
+  });
+};

--- a/workers/src/lib/sentry.ts
+++ b/workers/src/lib/sentry.ts
@@ -11,7 +11,6 @@ type SentryEnv = Pick<
 // 100 ユーザー規模で Sentry の Developer plan (10K transactions/month) を
 // 圧迫しない値。production で観測量が足りなければ環境別に上げる。
 const DEFAULT_TRACES_SAMPLE_RATE = 0.05;
-const DEFAULT_ENVIRONMENT = "local";
 const UNKNOWN_PROCEDURE = "<unknown>";
 
 // 4xx 相当の tRPC エラーは利用者起因なので Sentry に送らない。
@@ -36,10 +35,17 @@ const NON_CAPTURED_TRPC_CODES: ReadonlySet<TRPCError["code"]> = new Set([
 // fetch hot path で毎リクエスト再生成しないため module レベルで保持する。
 const INTEGRATIONS = [Sentry.honoIntegration()];
 
+// environment / release は env が未設定なら option キー自体を生やさない。
+// @sentry/cloudflare はユーザー指定の release が undefined でも user 値として
+// 優先してしまい CF_VERSION_METADATA.id への自動 fallback が効かなくなるため。
+// environment も "local" を固定 default にすると prod/staging で env 変数を
+// 入れ忘れたときに本番イベントが local 扱いになりアラートが機能しなくなる。
 export const buildSentryOptions = (env: SentryEnv): CloudflareOptions => ({
   dsn: env.SENTRY_DSN,
-  environment: env.SENTRY_ENVIRONMENT ?? DEFAULT_ENVIRONMENT,
-  release: env.SENTRY_RELEASE,
+  ...(env.SENTRY_ENVIRONMENT !== undefined && {
+    environment: env.SENTRY_ENVIRONMENT,
+  }),
+  ...(env.SENTRY_RELEASE !== undefined && { release: env.SENTRY_RELEASE }),
   tracesSampleRate: DEFAULT_TRACES_SAMPLE_RATE,
   integrations: INTEGRATIONS,
 });

--- a/workers/src/types.ts
+++ b/workers/src/types.ts
@@ -20,4 +20,7 @@ export type Env = {
   readonly TRUSTED_ORIGINS: string;
   readonly ALLOWED_ORIGINS: string;
   readonly LOG_LEVEL?: string;
+  readonly SENTRY_DSN?: string;
+  readonly SENTRY_ENVIRONMENT?: string;
+  readonly SENTRY_RELEASE?: string;
 };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -54,6 +54,7 @@
         "TRUSTED_ORIGINS": "https://staging.dollrobe.example",
         "ALLOWED_ORIGINS": "https://staging.dollrobe.example",
         "LOG_LEVEL": "debug",
+        "SENTRY_ENVIRONMENT": "staging",
       },
     },
     "production": {
@@ -86,6 +87,7 @@
         "TRUSTED_ORIGINS": "https://dollrobe.example",
         "ALLOWED_ORIGINS": "https://dollrobe.example",
         "LOG_LEVEL": "info",
+        "SENTRY_ENVIRONMENT": "production",
       },
     },
   },


### PR DESCRIPTION
## Summary

Closes #234 (親 #229)

- API Worker (Hono) を `@sentry/cloudflare` の `Sentry.withSentry` でラップし、fetch / scheduled / queue 各ハンドラの未捕捉例外を自動キャプチャ
- tRPC `onError` で 5xx 系のみ Sentry に送る (`captureTrpcError`)。4xx は構造化ログ側のみで追跡してノイズを抑制
- composite action `.github/actions/sentry-sourcemap-upload` を新規追加。`#232` で `deploy.yml` が作成されたら Web / API 両ジョブから `uses:` で呼び出してもらう想定
- `docs/cloudflare-runbook.md` 新規。ロールバック・gradual deployments・インシデント判断フロー・Sentry 確認手順を網羅。`CLAUDE.md` からリンク

## Acceptance criteria 対応

| 項目 | 状態 |
|---|---|
| API Worker でハンドラ内 throw が Sentry に届く (staging 実証) | 本 PR ではローカル単体テストで挙動検証。staging 実証は #230/#231/#232 完了後にフォローアップ |
| Web / API の deploy ジョブで source map upload | composite action を新規追加。**#232 の deploy.yml が完成したら `uses:` で組み込んでもらう** (本 PR の scope 外) |
| `docs/cloudflare-runbook.md` がロールバック手順を含む | ✅ |
| runbook が CLAUDE.md からリンクされている | ✅ |

## 設計メモ

- `tracesSampleRate: 0.05` に設定 (100 ユーザー規模で Sentry Developer plan 10K transactions/月の余裕を確保)
- `buildSentryOptions` は `Pick<Env, "SENTRY_DSN" | "SENTRY_ENVIRONMENT" | "SENTRY_RELEASE">` のサブセット型を引数に取る。`integrations` 配列は module レベルに hoist して fetch hot path で再生成しない
- `SENTRY_DSN` 未設定でも `withSentry` がそのまま動作し SDK 側で no-op になるため、ローカル / 既存環境を壊さない (init はしない / `captureException` は no-op)
- `wrangler.toml` の `upload_source_maps = true` は子 #230 の `wrangler.jsonc` 移行時にそのまま引き継がれる

## 未着手の兄弟タスクとの関係 (scope 外)

- #230: `wrangler.jsonc` 移行 — 本 PR の `wrangler.toml` 設定はそのまま .jsonc へ引き継いでもらう
- #231: `wrangler.web.jsonc` 新規 — Web Worker 側の `upload_source_maps: true` 設定をお願いします
- #232: `deploy.yml` 新規 — composite action `./.github/actions/sentry-sourcemap-upload` を `uses:` で呼び出してください

## Test plan

- [x] `pnpm precheck` 通過
- [x] `pnpm test:workers` 通過 (1617 tests)
- [x] `pnpm test:coverage` 通過 (`workers/src/lib/sentry.ts` 100%)
- [ ] (フォローアップ) staging 環境で意図的に 500 を発生させ Sentry に届くことを実証
- [ ] (フォローアップ) #232 で source map upload を deploy.yml に組み込んだ後、release タグでスタックトレースが unminify されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)